### PR TITLE
add webhook trigger to retrieve docs workflow

### DIFF
--- a/.github/workflows/retrieve-docs.yml
+++ b/.github/workflows/retrieve-docs.yml
@@ -3,6 +3,10 @@ name: Retrieve docs from Contentful
 on:
   workflow_dispatch:
 
+  repository_dispatch:
+    types:
+      - webhook
+
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
More information [here](https://www.notion.so/vtexhandbook/Adicionar-trigger-de-webhook-na-action-de-atualizar-docs-no-help-center-content-da3c74c99a804c348d3d68715194b402)