### PR TITLE
Reverse months order

### DIFF
--- a/generateNavigation.js
+++ b/generateNavigation.js
@@ -32,8 +32,8 @@ const navigation = { navbar: [
     categories: []
   },
   {
-    documentation: 'News',
-    slugPrefix: 'updates/announcements',
+    documentation: 'Announcements',
+    slugPrefix: 'announcements',
     categories: []
   },
 ] };
@@ -184,6 +184,8 @@ function getNews() {
 
     newsCategories.push(newsCategory);
   }
+
+  newsCategories.forEach((cat) => cat.children.reverse());
 
   return newsCategories;
 }


### PR DESCRIPTION
Reverse order of months on generateNavigation.js/navigation.json, to display them from most recent to less recent in the Announcements sidebar.