### PR TITLE
EDU-15196: Add condition to return only published articles from Contentful

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,8 +184,9 @@ async function getEntries() {
 
       for (let j = 0; j < entries.items.length ; j++) {
         let entry = entries.items[j];
-//      console.log(entry.fields)
-        createMarkdownFile(entry, categories, subcategories);
+        if (isPublished(entry)) {
+          createMarkdownFile(entry, categories, subcategories);
+        }
       }
       skip += limit;
     } while (skip < totalCount);


### PR DESCRIPTION
This PR adds a condition to the Contentful migration script to only return `.md` files with status `PUBLISHED`.

#### Steps to test:

1. Clone the repository to your local machine.
2. Open the cloned repository in your code editor.
3. Add the necessary secrets/security files.
4. Run `yarn` in the terminal to install all project dependencies.
5. In the terminal, run the following command to count how many `.md` files currently exist in the docs folder:

```bash
find ./docs/ -type f -name "*.md" | wc -l  
```

6. Write down the total number displayed (e.g., 13331) for future reference.
7. Switch from the `main` branch to the `EDU-15196` branch.
8. In the `index.js` file, comment out lines `830` to 832`. This will disable the following functions: `replaceQuotes`, `fixCallouts` and `updateAllImages`.

> With this change, the script will only delete existing markdown files and pull new `.md` files from Contentful.

9. Execute the script with the command:

```bash
node index.js
```

10. After running the script, check if any files with `DRAFT`, `CHANGED`, or `ARCHIVED` status remain in the repository. In VS Code, search for:

- `status: DRAFT`
- `status: CHANGED`
- `status: ARCHIVED`

If the script ran correctly, no files should contain these statuses.

11. To confirm the new count of .md files, run the command again:

```bash
find ./docs/ -type f -name "*.md" | wc -l  
```

12. The displayed number should now be lower than the initial count (e.g., 10469), confirming the script worked as expected.
