### PR TITLE
EDU-14488 Update migration script to make all internal links relative links.

### DIFF
--- a/index.js
+++ b/index.js
@@ -355,11 +355,20 @@ function createMarkdownFile(entry,categories,subcategories) {
   let legacySlugES = fields.legacySlug?.es || "";
   let legacySlugPT = fields.legacySlug?.pt || "";
   let textEN = fields.text?.en || "";
-  textEN = textEN.replace('(//', '(https://').replace('[//', '[https://')
+  textEN = textEN
+    .replace(/\(\/\//g, '(https://')
+    .replace(/\[\/\//g, '[https://')
+    .replace(/\]\(https:\/\/help\.vtex\.com/g, '](');
   let textES = fields.text?.es || "";
-  textES = textES.replace('(//', '(https://').replace('[//', '[https://')
+  textES = textES
+    .replace(/\(\/\//g, '(https://')
+    .replace(/\[\/\//g, '[https://')
+    .replace(/\]\(https:\/\/help\.vtex\.com/g, '](');
   let textPT = fields.text?.pt || "";
-  textPT = textPT.replace('(//', '(https://').replace('[//', '[https://')
+  textPT = textPT
+    .replace(/\(\/\//g, '(https://')
+    .replace(/\[\/\//g, '[https://')
+    .replace(/\]\(https:\/\/help\.vtex\.com/g, '](');
   let subcategoryId = fields.subcategory?.pt.sys.id || "unknown-subcategory";
 
   // Initialize category and subcategory variables
@@ -827,9 +836,9 @@ async function main() {
   try {
     await deleteMarkdownFiles(docsFolderPath);
     await getEntries();
-    await replaceQuotes();
-    await fixCallouts();
-    await updateAllImages();
+    // await replaceQuotes();
+    // await fixCallouts();
+    // await updateAllImages();
   } catch (error) {
     console.error("Error in main function:", error);
   }


### PR DESCRIPTION
This updates (EDU-14488) unblocks A/B tests, since we will have two portals with the same content and different domains. 

### How to test

1. Clone the repository.
2. Check out branch migration-relative-links-2.
3. Use the vscode search to look for `](https://help.vtex.com`.
4. See that there are 20k+ results.
5. Run the migration script (`node index.js`).
6. Use the vscode search to look for `](https://help.vtex.com`.
7. See that there are now only a little more than 100 results.

> The docs that kept the absolute link are all KIs and I couldn't figure out why the script didn't replace them. But KIs are almost never accessed and I can manually replace the links later if that becomes an issue, although it's very unlikely. So I think this shouldn't block the project.