### PR TITLE
EDU-14951: Contentful script - Special chars and quotes in titles issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -851,9 +851,9 @@ async function main() {
   try {
     await deleteMarkdownFiles(docsFolderPath);
     await getEntries();
-    await replaceQuotes();
-    await fixCallouts();
-    await updateAllImages();
+    //await replaceQuotes();
+    //await fixCallouts();
+    //await updateAllImages();
   } catch (error) {
     console.error("Error in main function:", error);
   }

--- a/index.js
+++ b/index.js
@@ -836,9 +836,9 @@ async function main() {
   try {
     await deleteMarkdownFiles(docsFolderPath);
     await getEntries();
-    // await replaceQuotes();
-    // await fixCallouts();
-    // await updateAllImages();
+    await replaceQuotes();
+    await fixCallouts();
+    await updateAllImages();
   } catch (error) {
     console.error("Error in main function:", error);
   }

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const { fixCallouts } = require('./docs-utils/fix-callouts'); // Import the fix-
 
 const { updateAllImages } = require('./docs-utils/update-all-images'); // Import the update-all-images function
 
-// Inline title quote fixer
+// Fix title quotes function
 function fixTitleQuotes(title) {
   // Remove leading/trailing whitespace and quotes
   title = title.trim().replace(/^['"]+|['"]+$/g, '');
@@ -292,6 +292,30 @@ function getSubcategoryInfo(entry) {
   }
 }
 
+function normalizeFileName(str) {
+  if (!str) return '';
+  return str
+    .normalize('NFD')
+    // Replace common accented and special characters
+    .replace(/[ñÑ]/g, 'n')
+    .replace(/[óòöôõÓÒÖÔÕ]/g, 'o')
+    .replace(/[áàäâãÁÀÄÂÃ]/g, 'a')
+    .replace(/[éèëêÉÈËÊ]/g, 'e')
+    .replace(/[íìïîÍÌÏÎ]/g, 'i')
+    .replace(/[úùüûÚÙÜÛ]/g, 'u')
+    .replace(/[çÇ]/g, 'c')
+    .replace(/[¿¡]/g, '')
+    .replace(/[’'`]/g, '')
+    // Remove any remaining diacritics
+    .replace(/\p{Diacritic}/gu, '')
+    // Replace any other non-alphanumeric character (except dash, underscore, dot) with dash
+    .replace(/[^a-zA-Z0-9-_.]/g, '-')
+    // Collapse multiple dashes
+    .replace(/-+/g, '-')
+    // Trim dashes from start/end
+    .replace(/^-+|-+$/g, '');
+}
+
 function createMarkdownFile(entry,categories,subcategories) {
   // extract information from each entry
 
@@ -431,13 +455,9 @@ function createMarkdownFile(entry,categories,subcategories) {
 
   // create .md files in locale folders for each item
 
-  let fileNameEN = slugEN.substring(0, 147).replace(/-$/, "") + ".md";
-  fileNameEN = fileNameEN.replace(/\?/g, ""); // remove all "?" characters and trim if necessary to avoid "filename too long" git error
-  let fileNameES = slugES.substring(0, 147).replace(/-$/, "") + ".md";
-  fileNameES = fileNameES.replace(/\?/g, "");
-  let fileNamePT = slugPT.substring(0, 147).replace(/-$/, "") + ".md";
-  fileNamePT = fileNamePT.replace(/\?/g, "");
-
+  let fileNameEN = normalizeFileName(slugEN.substring(0, 147).replace(/-$/, "")) + ".md";
+  let fileNameES = normalizeFileName(slugES.substring(0, 147).replace(/-$/, "")) + ".md";
+  let fileNamePT = normalizeFileName(slugPT.substring(0, 147).replace(/-$/, "")) + ".md";
   let fileContentEN = "";
   let fileContentES = "";
   let fileContentPT = "";

--- a/index.js
+++ b/index.js
@@ -377,15 +377,18 @@ function createMarkdownFile(entry,categories,subcategories) {
   let textEN = fields.text?.en || "";
   textEN = textEN
     .replace(/\(\/\//g, '(https://')
-    .replace(/\[\/\//g, '[https://');
+    .replace(/\[\/\//g, '[https://')
+    .replace(/\]\(https:\/\/help\.vtex\.com/g, '](');
   let textES = fields.text?.es || "";
   textES = textES
     .replace(/\(\/\//g, '(https://')
-    .replace(/\[\/\//g, '[https://');
+    .replace(/\[\/\//g, '[https://')
+    .replace(/\]\(https:\/\/help\.vtex\.com/g, '](');
   let textPT = fields.text?.pt || "";
   textPT = textPT
     .replace(/\(\/\//g, '(https://')
-    .replace(/\[\/\//g, '[https://');
+    .replace(/\[\/\//g, '[https://')
+    .replace(/\]\(https:\/\/help\.vtex\.com/g, '](');
   let subcategoryId = fields.subcategory?.pt.sys.id || "unknown-subcategory";
 
   // Initialize category and subcategory variables

--- a/index.js
+++ b/index.js
@@ -273,6 +273,30 @@ function getSubcategoryInfo(entry) {
   }
 }
 
+function normalizeFileName(str) {
+  if (!str) return '';
+  return str
+    .normalize('NFD')
+    // Replace common accented and special characters
+    .replace(/[ñÑ]/g, 'n')
+    .replace(/[óòöôõÓÒÖÔÕ]/g, 'o')
+    .replace(/[áàäâãÁÀÄÂÃ]/g, 'a')
+    .replace(/[éèëêÉÈËÊ]/g, 'e')
+    .replace(/[íìïîÍÌÏÎ]/g, 'i')
+    .replace(/[úùüûÚÙÜÛ]/g, 'u')
+    .replace(/[çÇ]/g, 'c')
+    .replace(/[¿¡]/g, '')
+    .replace(/[’'`]/g, '')
+    // Remove any remaining diacritics
+    .replace(/\p{Diacritic}/gu, '')
+    // Replace any other non-alphanumeric character (except dash, underscore, dot) with dash
+    .replace(/[^a-zA-Z0-9-_.]/g, '-')
+    // Collapse multiple dashes
+    .replace(/-+/g, '-')
+    // Trim dashes from start/end
+    .replace(/^-+|-+$/g, '');
+}
+
 function createMarkdownFile(entry,categories,subcategories) {
   // extract information from each entry
 
@@ -357,18 +381,15 @@ function createMarkdownFile(entry,categories,subcategories) {
   let textEN = fields.text?.en || "";
   textEN = textEN
     .replace(/\(\/\//g, '(https://')
-    .replace(/\[\/\//g, '[https://')
-    .replace(/\]\(https:\/\/help\.vtex\.com/g, '](');
+    .replace(/\[\/\//g, '[https://');
   let textES = fields.text?.es || "";
   textES = textES
     .replace(/\(\/\//g, '(https://')
-    .replace(/\[\/\//g, '[https://')
-    .replace(/\]\(https:\/\/help\.vtex\.com/g, '](');
+    .replace(/\[\/\//g, '[https://');
   let textPT = fields.text?.pt || "";
   textPT = textPT
     .replace(/\(\/\//g, '(https://')
-    .replace(/\[\/\//g, '[https://')
-    .replace(/\]\(https:\/\/help\.vtex\.com/g, '](');
+    .replace(/\[\/\//g, '[https://');
   let subcategoryId = fields.subcategory?.pt.sys.id || "unknown-subcategory";
 
   // Initialize category and subcategory variables
@@ -411,14 +432,9 @@ function createMarkdownFile(entry,categories,subcategories) {
   let announcementSynopsisPT = fields.synopsis?.pt || "";
 
   // create .md files in locale folders for each item
-
-  let fileNameEN = slugEN.substring(0, 147).replace(/-$/, "") + ".md";
-  fileNameEN = fileNameEN.replace(/\?/g, ""); // remove all "?" characters and trim if necessary to avoid "filename too long" git error
-  let fileNameES = slugES.substring(0, 147).replace(/-$/, "") + ".md";
-  fileNameES = fileNameES.replace(/\?/g, "");
-  let fileNamePT = slugPT.substring(0, 147).replace(/-$/, "") + ".md";
-  fileNamePT = fileNamePT.replace(/\?/g, "");
-
+  let fileNameEN = normalizeFileName(slugEN.substring(0, 147).replace(/-$/, "")) + ".md";
+  let fileNameES = normalizeFileName(slugES.substring(0, 147).replace(/-$/, "")) + ".md";
+  let fileNamePT = normalizeFileName(slugPT.substring(0, 147).replace(/-$/, "")) + ".md";
   let fileContentEN = "";
   let fileContentES = "";
   let fileContentPT = "";

--- a/index.js
+++ b/index.js
@@ -277,7 +277,7 @@ function normalizeFileName(str) {
   if (!str) return '';
   return str
     .normalize('NFD')
-    // Replace common accented and special characters
+    // Replace common and special characters
     .replace(/[ñÑ]/g, 'n')
     .replace(/[óòöôõÓÒÖÔÕ]/g, 'o')
     .replace(/[áàäâãÁÀÄÂÃ]/g, 'a')
@@ -287,13 +287,9 @@ function normalizeFileName(str) {
     .replace(/[çÇ]/g, 'c')
     .replace(/[¿¡]/g, '')
     .replace(/[’'`]/g, '')
-    // Remove any remaining diacritics
     .replace(/\p{Diacritic}/gu, '')
-    // Replace any other non-alphanumeric character (except dash, underscore, dot) with dash
     .replace(/[^a-zA-Z0-9-_.]/g, '-')
-    // Collapse multiple dashes
     .replace(/-+/g, '-')
-    // Trim dashes from start/end
     .replace(/^-+|-+$/g, '');
 }
 


### PR DESCRIPTION
### Special chars

This PR adds a function to the Contentful migration script to fix special characters on docs slugs.

#### Steps to test:

1. Clone the repository to your local machine.
2. Open the cloned repository in your code editor.
3. Add the necessary secrets/security files.
4. Run `yarn` in the terminal to install all project dependencies.
5. Switch from the `main` branch to the `EDU-14951` branch.
6. Keep the lines `854` to `856` commented ([here](https://github.com/vtexdocs/help-center-content/blob/EDU-14951/index.js#L878-L879)). Once you run the script locally, it won't do all the processes to fix quotes and callouts. It will only delete the files within the `docs` folder and replace them with the new ones from the migration.
7. Before starting the migration process locally, choose a file to see if its filename will be fixed. For example, the [quick-view-no-funciona-en-páginas-HTTPS.md](https://github.com/vtexdocs/help-center-content/blob/main/docs/es/known-issues/Marketing%20%26%20Merchandising/quick-view-no-funciona-en-p%C3%A1ginas-HTTPS.md) file.
8. In the terminal, run the following command to reproduce the migration process:

```bash
node index.js
```

9. Check if the file you have chosen has its slug fixed. For example, the [quick-view-no-funciona-en-páginas-HTTPS.md](https://github.com/vtexdocs/help-center-content/blob/main/docs/es/known-issues/Marketing%20%26%20Merchandising/quick-view-no-funciona-en-p%C3%A1ginas-HTTPS.md) file should now be `quick-view-no-funciona-en-paginas-HTTPS.md` .

10. You can also use the search files bar to search characters such as `í`, `ñ`, `n'`, `ó`, `¿`, `é`, and `á`. The search should show no results for these characters:

<img width="947" alt="Screenshot_20" src="https://github.com/user-attachments/assets/a519ca5f-128f-4ed4-ab25-d4a3e669f207" />

---

### Title quote bugs

**Update:** This PR also introduces a new function to handle title quotes when creating markdown files during content migration. Task: [Contentful script - quotes in titles bug](https://vtex-dev.atlassian.net/browse/EDU-13262)

To address issues with title quotes, this PR adds the [`fixTitleQuotes`](https://github.com/vtexdocs/help-center-content/pull/131/commits/594b4651752a0d771943eca426c3f342a4910da4) function. This function does the following:

- Removes leading and trailing quotes and whitespace.
- For titles containing both single (') and double (") quotes, it escapes all double quotes with backslash (\") and wraps the entire title in double quotes.
- For titles containing only single quotes ('), it wraps the entire title in double quotes.
- For titles containing only double quotes (") , it wraps the entire title in single quotes.
- For titles with no quotes, it wraps the title in double quotes by default.

This new function is used within the `createMarkdownFile` function, so when markdown files are generated during content migration, it automatically handles those title issues.

With this addition, we no longer need to use the `replaceQuotes` function in the script, as the title issues will be addressed during markdown file creation instead of afterward. That's why the `replaceQuotes` function was removed from `index.js`.

References:

- Testing title issues: https://github.com/vtexdocs/help-center-content/pull/132