### PR TITLE
Fix image compression

### DIFF
--- a/docs-utils/cleanup-old-gifs.js
+++ b/docs-utils/cleanup-old-gifs.js
@@ -1,0 +1,82 @@
+// Required Node.js modules
+const fs = require('fs');    // File system module for file operations
+const path = require('path'); // Path module for handling file paths
+
+/**
+ * Recursively walks through a directory and its subdirectories to find GIF files
+ * marked for deletion (ending with '_TO_BE_DELETED.gif')
+ * 
+ * @param {string} dir - The directory to start searching from
+ * @param {Array} fileList - Accumulator array to store found files (used in recursion)
+ * @returns {Array} - List of absolute paths to files marked for deletion
+ */
+const walkSync = (dir, fileList = []) => {
+    // Read all files and directories in the current directory
+    const files = fs.readdirSync(dir);
+    
+    for (const file of files) {
+        // Create full path for the current file/directory
+        const filePath = path.join(dir, file);
+        // Get file/directory information
+        const stat = fs.statSync(filePath);
+        
+        if (stat.isDirectory()) {
+            // If it's a directory, recursively search inside it
+            walkSync(filePath, fileList);
+        } else if (file.endsWith('_TO_BE_DELETED.gif')) {
+            // If it's a file that ends with '_TO_BE_DELETED.gif', add it to our list
+            fileList.push(filePath);
+        }
+    }
+    
+    return fileList;
+};
+
+/**
+ * Main function that handles the cleanup of old GIF files
+ * Searches through the docs directory and deletes any GIF files
+ * that were marked for deletion
+ */
+const cleanupOldGifs = () => {
+    // Construct path to the docs directory (one level up from current script location)
+    const docsDir = path.join(__dirname, '..', 'docs');
+    console.log('Searching for old GIF files to clean up...');
+    
+    try {
+        // Get list of all files that need to be deleted
+        const filesToDelete = walkSync(docsDir);
+        
+        // If no files found, log message and exit
+        if (filesToDelete.length === 0) {
+            console.log('No old GIF files found to delete.');
+            return;
+        }
+        
+        console.log(`Found ${filesToDelete.length} old GIF file(s) to delete:`);
+        
+        // Attempt to delete each file
+        for (const file of filesToDelete) {
+            try {
+                // Delete the file
+                fs.unlinkSync(file);
+                console.log(`✓ Deleted: ${file}`);
+            } catch (err) {
+                // Log any errors that occur during deletion
+                console.error(`× Error deleting ${file}:`, err.message);
+            }
+        }
+        
+        console.log('Cleanup completed.');
+    } catch (err) {
+        // Log any errors that occur during the overall process
+        console.error('Error during cleanup:', err.message);
+    }
+};
+
+// Check if this file is being run directly (not imported as a module)
+if (require.main === module) {
+    cleanupOldGifs(); // Execute the cleanup function
+}
+
+// Export the cleanup function so it can be used by other scripts
+module.exports = { cleanupOldGifs };

--- a/docs-utils/update-images.js
+++ b/docs-utils/update-images.js
@@ -28,7 +28,7 @@ const checkAndCompressImage = async (filePath) => {
 
       if (fileSizeInMB > 100) { // If file exceeds 100MB
           console.log(`File ${filePath} is over 100MB (${fileSizeInMB.toFixed(2)} MB). Compressing...`);
-          let oldFilePath = filePath.replace(/(\.\w+)$/, '_old$1'); // Add "_old" before the extension
+          let oldFilePath = filePath.replace(/(\.\w+)$/, '_old_TO_BE_DELETED$1'); // Add "_old_TO_BE_DELETED" before the extension
 
           fs.renameSync(filePath, oldFilePath); // Rename original file
           console.log(`File renamed: ${filePath}`);

--- a/docs-utils/update-images.js
+++ b/docs-utils/update-images.js
@@ -28,23 +28,21 @@ const checkAndCompressImage = async (filePath) => {
 
       if (fileSizeInMB > 100) { // If file exceeds 100MB
           console.log(`File ${filePath} is over 100MB (${fileSizeInMB.toFixed(2)} MB). Compressing...`);
-          let compressedFilePath = filePath.replace(/(\.\w+)$/, '_compressed$1'); // Add "_compressed" before the extension
-          await sharp(filePath, {limitInputPixels: 0, animated: true })
+          let oldFilePath = filePath.replace(/(\.\w+)$/, '_old$1'); // Add "_old" before the extension
+
+          fs.renameSync(filePath, oldFilePath); // Rename original file
+          console.log(`File renamed: ${filePath}`);
+  
+          await sharp(oldFilePath, {limitInputPixels: 0, animated: true })
               .resize(800) 
               .gif({ interFrameMaxError: 32 })
-              .toFile(compressedFilePath);
-
-          // Check if original file exists and delete it
-          if (fs.existsSync(filePath)) {
-            fs.unlinkSync(filePath); // Delete the original file
-            console.log(`Original file deleted: ${filePath}`);
-            fs.renameSync(compressedFilePath, filePath);
-            console.log(`File renamed: ${filePath}`);
-          } else {
-              console.log(`Original file not found, skipping deletion: ${filePath}`);
-          }
+              .toFile(filePath);
+          
+          fs.unlinkSync(oldFilePath); // Delete the old file
+          console.log(`Original file deleted: ${oldFilePath}`);
 
           return filePath; // Return compressed file path
+          
       } else {
         console.log(`File ${filePath} is within the size limit (${fileSizeInMB.toFixed(2)} MB).`);
         return filePath; // Return original file path if no compression needed


### PR DESCRIPTION
The image compression part of the image update script had an issue. After compressing the image, it wasn't possible to delete the old file because sharp was still handling it. Even after waiting more than 20s, I couldn't get it to work.

## Solution

* I changed the algorythm to rename the old file first, making the compressed version match the URL in the markdown. So the old file could just be deleted.
* I created another script that goes through `/docs` and its subfolders and deletes all uncompressed large gifs that are left from the compression.