### PR TITLE
test: fix image html in faq

### DIFF
--- a/docs/en/faq/Marketing & Merchandising/why-is-the-product-not-visible-on-the-website.md
+++ b/docs/en/faq/Marketing & Merchandising/why-is-the-product-not-visible-on-the-website.md
@@ -76,9 +76,9 @@ To check the product settings, you must follow the steps below.
     * If the product contains specifications, check the **Specifications** tab to see if they are filled in.
 3. After each change, click `Save`.
 
-<img class="db center mv9 shadow-4 pointer" src="https://images.ctfassets.net/alneenqid6w5/nGAGYNdVtTFdAPjW1mi5f/080a8fbd5815fe8059b449a23c01b944/02-campos-produto-en.png" alt="02-campos-produto-en" style="margin-bottom: 20px;"> <figcaption align = "center"><em>Fields you must check on the product information page.</em></figcaption></figure>
+<img class="db center mv9 shadow-4 pointer" src="https://images.ctfassets.net/alneenqid6w5/nGAGYNdVtTFdAPjW1mi5f/080a8fbd5815fe8059b449a23c01b944/02-campos-produto-en.png" alt="02-campos-produto-en" style="margin-bottom: 20px;"> <figcaption align = "center"><em>Fields you must check on the product information page.</em></figcaption></img>
 
-<img class="db center mv9 shadow-4 pointer" src="https://images.ctfassets.net/alneenqid6w5/6UXDapFf9bvtnCSoHQBwZC/4870d3860fc73faed98f2237aa85cca9/03-aba-especificacoes-en.png" alt="03-aba-especificacoes-en" style="margin-bottom: 20px;"> <figcaption align = "center"><em><strong>Specifications</strong> tab</em></figcaption></figure>
+<img class="db center mv9 shadow-4 pointer" src="https://images.ctfassets.net/alneenqid6w5/6UXDapFf9bvtnCSoHQBwZC/4870d3860fc73faed98f2237aa85cca9/03-aba-especificacoes-en.png" alt="03-aba-especificacoes-en" style="margin-bottom: 20px;"> <figcaption align = "center"><em><strong>Specifications</strong> tab</em></figcaption></img>
 
 ### SKUs
 
@@ -112,7 +112,7 @@ On the SKUs page, in **Products > Catalog > Products and SKUs**, follow the inst
 8. Check if the SKU contains at least one image. If it does not, the SKU will not be activated — follow the next step to correct this problem.
 9. Click `Insert` to upload a new image. If you prefer, click `Associate existing images`  to include an image already used for another SKU.
 
-<img class="db center mv9 shadow-4 pointer" src="https://images.ctfassets.net/alneenqid6w5/3StXGBCMW8ZExshcEhfF9m/ebc572e69e7dc83a5de491a83c4233ac/08-aba-imagens-en.png" alt="08-aba-imagens-es" style="margin-bottom: 20px;"> <figcaption align = "center"><em><strong>Images</strong> tab</em></figcaption></figure>
+<img class="db center mv9 shadow-4 pointer" src="https://images.ctfassets.net/alneenqid6w5/3StXGBCMW8ZExshcEhfF9m/ebc572e69e7dc83a5de491a83c4233ac/08-aba-imagens-en.png" alt="08-aba-imagens-es" style="margin-bottom: 20px;"> <figcaption align = "center"><em><strong>Images</strong> tab</em></figcaption></img>
 
 ![09-sku-imagens-en](https://images.ctfassets.net/alneenqid6w5/1JJflflW0ACgVn05sRv29x/f58814d66052faf18d3bc44e68eb83cc/09-sku-imagens-en.PNG)
 

--- a/docs/es/faq/Marketing & Merchandising/por-que-el-producto-no-aparece-en-el-sitio-web.md
+++ b/docs/es/faq/Marketing & Merchandising/por-que-el-producto-no-aparece-en-el-sitio-web.md
@@ -76,9 +76,9 @@ Para verificar la configuración del producto, es importante que sigas los pasos
     * En caso de que el producto tenga especificaciones, navega hasta la pestaña **Especificaciones** y verifica que se hayan rellenado los campos correspondientes.
 3. Luego de cualquier modificación, haz clic en `Guardar`.
 
-<img class="db center mv9 shadow-4 pointer" src="https://images.ctfassets.net/alneenqid6w5/nGAGYNdVtTFdAPjW1mi5f/ad8fd616f6245872af18ad98d1c9f4a6/02-campos-produto-es.png" alt="02-campos-produto-pt" style="margin-bottom: 20px;"> <figcaption align = "center"><em>Campos que se deben verificar en la página de información del producto</em></figcaption></figure>
+<img class="db center mv9 shadow-4 pointer" src="https://images.ctfassets.net/alneenqid6w5/nGAGYNdVtTFdAPjW1mi5f/ad8fd616f6245872af18ad98d1c9f4a6/02-campos-produto-es.png" alt="02-campos-produto-pt" style="margin-bottom: 20px;"> <figcaption align = "center"><em>Campos que se deben verificar en la página de información del producto</em></figcaption></img>
 
-<img class="db center mv9 shadow-4 pointer" src="https://images.ctfassets.net/alneenqid6w5/6UXDapFf9bvtnCSoHQBwZC/1933479b0f82ec9229bdf1687859a714/03-aba-especificacoes-es.png" alt="03-aba-especificacoes-pt" style="margin-bottom: 20px;"> <figcaption align = "center"><em>Pestaña <strong>Especificaciones</strong></em></figcaption></figure>
+<img class="db center mv9 shadow-4 pointer" src="https://images.ctfassets.net/alneenqid6w5/6UXDapFf9bvtnCSoHQBwZC/1933479b0f82ec9229bdf1687859a714/03-aba-especificacoes-es.png" alt="03-aba-especificacoes-pt" style="margin-bottom: 20px;"> <figcaption align = "center"><em>Pestaña <strong>Especificaciones</strong></em></figcaption></img>
 
 ### SKU
 
@@ -112,7 +112,7 @@ En la página de SKU, en **Productos > Catálogo > Gestión de productos y SKU**
 8. Verifica si el SKU incluye al menos una imagen. Si no la tiene, el SKU no se activará. Realiza el paso a continuación para corregir este problema.
 9. Haz clic en `Insertar` para subir una imagen nueva. Si lo prefieres, haz clic en `Asociar a las imágenes existentes` para incluir una imagen que ya se utilice en otro SKU.
 
-<img class="db center mv9 shadow-4 pointer" src="https://images.ctfassets.net/alneenqid6w5/3StXGBCMW8ZExshcEhfF9m/1be699da86b880750f7884f9aabaa8a3/08-aba-imagens-es.png" alt="08-aba-imagens-pt" style="margin-bottom: 20px;"> <figcaption align = "center"><em>Pestaña  <strong>Imágenes</strong></em></figcaption></figure>
+<img class="db center mv9 shadow-4 pointer" src="https://images.ctfassets.net/alneenqid6w5/3StXGBCMW8ZExshcEhfF9m/1be699da86b880750f7884f9aabaa8a3/08-aba-imagens-es.png" alt="08-aba-imagens-pt" style="margin-bottom: 20px;"> <figcaption align = "center"><em>Pestaña  <strong>Imágenes</strong></em></figcaption></img>
 
 ![09-sku-imagens-es](https://images.ctfassets.net/alneenqid6w5/1JJflflW0ACgVn05sRv29x/06bad0f8081c24488cee7ec6d0853853/09-sku-imagens-es.PNG)
 

--- a/docs/pt/faq/Marketing & Merchandising/por-que-o-produto-nao-aparece-no-site.md
+++ b/docs/pt/faq/Marketing & Merchandising/por-que-o-produto-nao-aparece-no-site.md
@@ -76,9 +76,9 @@ Para verificar as configurações do produto, é importante seguir os passos aba
    * Caso o produto contenha especificações, navegue até a aba **Especificações** e verifique se elas estão preenchidas.
 3. Após qualquer alteração, clique em `Salvar`.
 
-<img class="db center mv9 shadow-4 pointer" src="https://images.ctfassets.net/alneenqid6w5/nGAGYNdVtTFdAPjW1mi5f/0651c6f05455a3318423364b9129b8b4/02-campos-produto-pt.png" alt="02-campos-produto-pt" style="margin-bottom: 20px;"> <figcaption align = "center"><em>Campos que devem ser verificados na página de informações do produto</em></figcaption></figure>
+<img class="db center mv9 shadow-4 pointer" src="https://images.ctfassets.net/alneenqid6w5/nGAGYNdVtTFdAPjW1mi5f/0651c6f05455a3318423364b9129b8b4/02-campos-produto-pt.png" alt="02-campos-produto-pt" style="margin-bottom: 20px;"> <figcaption align = "center"><em>Campos que devem ser verificados na página de informações do produto</em></figcaption></img>
 
-<img class="db center mv9 shadow-4 pointer" src="https://images.ctfassets.net/alneenqid6w5/6UXDapFf9bvtnCSoHQBwZC/d8a3043e74dfea536e1f47c02a634359/03-aba-especificacoes-pt.png" alt="03-aba-especificacoes-pt" style="margin-bottom: 20px;"> <figcaption align = "center"><em>Aba <strong>Especificações</strong></em></figcaption></figure>
+<img class="db center mv9 shadow-4 pointer" src="https://images.ctfassets.net/alneenqid6w5/6UXDapFf9bvtnCSoHQBwZC/d8a3043e74dfea536e1f47c02a634359/03-aba-especificacoes-pt.png" alt="03-aba-especificacoes-pt" style="margin-bottom: 20px;"> <figcaption align = "center"><em>Aba <strong>Especificações</strong></em></figcaption></img>
 
 ### SKUs
 
@@ -112,7 +112,7 @@ Na página de SKUs, em **Produtos > Catálogo > Produtos e SKUs**, siga as instr
 8. Verifique se o SKU contém pelo menos uma imagem. Se não tiver, o SKU não será ativado – siga o próximo passo para corrigir esse problema.
 9. Clique em `Inserir` para fazer upload de uma nova imagem. Se preferir, clique em `Associar a imagens existentes` para incluir uma imagem já utilizada em outro SKU.
 
-<img class="db center mv9 shadow-4 pointer" src="https://images.ctfassets.net/alneenqid6w5/3StXGBCMW8ZExshcEhfF9m/71839095433fdf925be4cbe97710fb7c/08-aba-imagens-pt.png" alt="08-aba-imagens-pt" style="margin-bottom: 20px;"> <figcaption align = "center"><em>Aba <strong>Imagens</strong></em></figcaption></figure>
+<img class="db center mv9 shadow-4 pointer" src="https://images.ctfassets.net/alneenqid6w5/3StXGBCMW8ZExshcEhfF9m/71839095433fdf925be4cbe97710fb7c/08-aba-imagens-pt.png" alt="08-aba-imagens-pt" style="margin-bottom: 20px;"> <figcaption align = "center"><em>Aba <strong>Imagens</strong></em></figcaption></img>
 
 ![09-sku-imagens-pt](https://images.ctfassets.net/alneenqid6w5/1JJflflW0ACgVn05sRv29x/ef6a125c561d518d683a942b15b3bf58/09-sku-imagens-pt.png)
 


### PR DESCRIPTION
fix image html in faq to test if the page renders correctly (it's a card in the home page), solving this error:

<img width="389" height="214" alt="image" src="https://github.com/user-attachments/assets/b7410470-b586-46df-b53e-a05fe0043a5b" />

(already fixed in contentful)

part of [EDU-15434](https://vtex-dev.atlassian.net/browse/EDU-15434)