### PR TITLE
Restore lost feature: relative links conversion

### DIFF
--- a/contentful-fetcher/package.json
+++ b/contentful-fetcher/package.json
@@ -11,7 +11,10 @@
         "release": "standard-version",
         "release:minor": "standard-version --release-as minor",
         "release:patch": "standard-version --release-as patch",
-        "release:major": "standard-version --release-as major"
+        "release:major": "standard-version --release-as major",
+        "convert-links": "node index.js --convertLinksOnly",
+        "convert-links:dry-run": "node index.js --convertLinksOnly --dry-run",
+        "convert-links:backup": "node index.js --convertLinksOnly --backup --verbose"
     },
     "devDependencies": {
         "@commitlint/cli": "^19.8.0",

--- a/contentful-fetcher/utils/linkConverter.js
+++ b/contentful-fetcher/utils/linkConverter.js
@@ -1,0 +1,248 @@
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * Converts absolute portal links to relative links in markdown content
+ * @param {string} content - The markdown content to process
+ * @returns {string} - The processed content with converted links
+ */
+function convertPortalLinks(content) {
+  if (!content || typeof content !== "string") {
+    return content;
+  }
+
+  let processedContent = content;
+
+  // Pattern 1: Markdown inline links [text](https://help.vtex.com/path)
+  const markdownLinkPattern = /\[([^\]]+)\]\(https:\/\/help\.vtex\.com\/([^)]+)\)/g;
+  processedContent = processedContent.replace(
+    markdownLinkPattern,
+    "[$1](/$2)"
+  );
+
+  // Pattern 2: HTML <a> tags <a href="https://help.vtex.com/path">text</a>
+  const htmlLinkPattern = /<a\s+href="https:\/\/help\.vtex\.com\/([^"]+)"([^>]*)>([^<]+)<\/a>/g;
+  processedContent = processedContent.replace(
+    htmlLinkPattern,
+    '<a href="/$1"$2>$3</a>'
+  );
+
+  return processedContent;
+}
+
+/**
+ * Processes a single markdown file
+ * @param {string} filePath - Path to the markdown file
+ * @param {Object} options - Processing options
+ * @param {boolean} options.dryRun - If true, don't modify files
+ * @param {boolean} options.backup - If true, create backup files
+ * @param {boolean} options.verbose - If true, show detailed logging
+ * @returns {Object} - Result object with success status and changes made
+ */
+async function processMarkdownFile(filePath, options = {}) {
+  const { dryRun = false, backup = false, verbose = false } = options;
+
+  try {
+    // Read the file content
+    const originalContent = fs.readFileSync(filePath, "utf8");
+    
+    // Convert the links
+    const convertedContent = convertPortalLinks(originalContent);
+    
+    // Check if any changes were made
+    const hasChanges = originalContent !== convertedContent;
+    
+    if (!hasChanges) {
+      if (verbose) {
+        console.log(`📄 No changes needed: ${filePath}`);
+      }
+      return { success: true, changed: false, filePath };
+    }
+
+    if (verbose) {
+      console.log(`🔄 Processing: ${filePath}`);
+    }
+
+    if (dryRun) {
+      if (verbose) {
+        console.log(`🔍 [DRY RUN] Would convert links in: ${filePath}`);
+      }
+      return { success: true, changed: true, filePath, dryRun: true };
+    }
+
+    // Create backup if requested
+    if (backup) {
+      const backupPath = `${filePath}.bak`;
+      fs.writeFileSync(backupPath, originalContent);
+      if (verbose) {
+        console.log(`💾 Created backup: ${backupPath}`);
+      }
+    }
+
+    // Write the converted content
+    fs.writeFileSync(filePath, convertedContent);
+    
+    if (verbose) {
+      console.log(`✅ Converted links in: ${filePath}`);
+    }
+
+    return { success: true, changed: true, filePath };
+
+  } catch (error) {
+    console.error(`❌ Error processing ${filePath}:`, error.message);
+    return { success: false, error: error.message, filePath };
+  }
+}
+
+/**
+ * Recursively processes all .md files in a directory
+ * @param {string} directoryPath - Path to the directory to process
+ * @param {Object} options - Processing options
+ * @param {string[]} options.locales - Array of locale codes to process (e.g., ['en', 'pt', 'es'])
+ * @param {boolean} options.dryRun - If true, don't modify files
+ * @param {boolean} options.backup - If true, create backup files
+ * @param {boolean} options.verbose - If true, show detailed logging
+ * @returns {Object} - Result object with processing statistics
+ */
+async function processDirectory(directoryPath, options = {}) {
+  const { locales = [], dryRun = false, backup = false, verbose = false } = options;
+
+  if (!fs.existsSync(directoryPath)) {
+    throw new Error(`Directory does not exist: ${directoryPath}`);
+  }
+
+  const results = {
+    total: 0,
+    processed: 0,
+    changed: 0,
+    errors: 0,
+    files: []
+  };
+
+  try {
+    // Get all markdown files recursively
+    const markdownFiles = getAllMarkdownFiles(directoryPath, locales);
+    results.total = markdownFiles.length;
+
+    if (verbose) {
+      console.log(`📁 Found ${markdownFiles.length} markdown files to process`);
+    }
+
+    // Process each file
+    for (const filePath of markdownFiles) {
+      const result = await processMarkdownFile(filePath, options);
+      results.files.push(result);
+      
+      if (result.success) {
+        results.processed++;
+        if (result.changed) {
+          results.changed++;
+        }
+      } else {
+        results.errors++;
+      }
+    }
+
+    return results;
+
+  } catch (error) {
+    console.error(`❌ Error processing directory ${directoryPath}:`, error.message);
+    throw error;
+  }
+}
+
+/**
+ * Recursively finds all .md files in a directory, optionally filtered by locale
+ * @param {string} directoryPath - Path to search
+ * @param {string[]} locales - Array of locale codes to include
+ * @returns {string[]} - Array of file paths
+ */
+function getAllMarkdownFiles(directoryPath, locales = []) {
+  const markdownFiles = [];
+
+  function scanDirectory(dir, isTopLevel = true) {
+    const items = fs.readdirSync(dir);
+    
+    for (const item of items) {
+      const fullPath = path.join(dir, item);
+      const stat = fs.statSync(fullPath);
+      
+      if (stat.isDirectory()) {
+        // Only apply locale filtering at the top level
+        if (isTopLevel && locales.length > 0 && !locales.includes(item)) {
+          continue;
+        }
+        scanDirectory(fullPath, false);
+      } else if (stat.isFile() && item.endsWith('.md')) {
+        markdownFiles.push(fullPath);
+      }
+    }
+  }
+
+  scanDirectory(directoryPath, true);
+  return markdownFiles;
+}
+
+/**
+ * Main function to run link conversion
+ * @param {Object} options - Processing options
+ * @param {string} options.docsPath - Path to the docs directory
+ * @param {string[]} options.locales - Array of locale codes to process
+ * @param {boolean} options.dryRun - If true, don't modify files
+ * @param {boolean} options.backup - If true, create backup files
+ * @param {boolean} options.verbose - If true, show detailed logging
+ * @returns {Object} - Processing results
+ */
+async function runLinkConversion(options = {}) {
+  const {
+    docsPath = path.join(__dirname, "..", "..", "docs"),
+    locales = [],
+    dryRun = false,
+    backup = false,
+    verbose = false
+  } = options;
+
+  console.log("🔗 Starting link conversion process...");
+  
+  if (dryRun) {
+    console.log("🔍 Running in DRY RUN mode - no files will be modified");
+  }
+  
+  if (backup) {
+    console.log("💾 Backup files will be created");
+  }
+
+  try {
+    const results = await processDirectory(docsPath, {
+      locales,
+      dryRun,
+      backup,
+      verbose
+    });
+
+    // Print summary
+    console.log("\n📊 Link Conversion Summary:");
+    console.log(`   Total files found: ${results.total}`);
+    console.log(`   Files processed: ${results.processed}`);
+    console.log(`   Files changed: ${results.changed}`);
+    console.log(`   Errors: ${results.errors}`);
+
+    if (dryRun && results.changed > 0) {
+      console.log(`\n🔍 ${results.changed} files would be modified in a real run`);
+    }
+
+    return results;
+
+  } catch (error) {
+    console.error("❌ Link conversion failed:", error.message);
+    throw error;
+  }
+}
+
+module.exports = {
+  convertPortalLinks,
+  processMarkdownFile,
+  processDirectory,
+  runLinkConversion,
+  getAllMarkdownFiles
+};

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -45627,6 +45627,21 @@
             },
             {
               "name": {
+                "en": "Regionalization or trade policies aren't considered while filtering or sorting items by price or discount",
+                "es": "La regionalización o las políticas comerciales no se tienen en cuenta al filtrar u ordenar los artículos por precio o descuento.",
+                "pt": "A regionalização ou as políticas comerciais não são consideradas ao filtrar ou classificar itens por preço ou desconto"
+              },
+              "slug": {
+                "en": "regionalization-or-trade-policies-arent-considered-while-filtering-or-sorting-items-by-price-or-discount",
+                "es": "la-regionalizacion-o-las-politicas-comerciales-no-se-tienen-en-cuenta-al-filtrar-u-ordenar-los-articulos-por-precio-o-descuento",
+                "pt": "a-regionalizacao-ou-as-politicas-comerciais-nao-sao-consideradas-ao-filtrar-ou-classificar-itens-por-preco-ou-desconto"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
                 "en": "Save button disabled when modifying imported search synonyms",
                 "es": "Botón de guardar desactivado al modificar los sinónimos de búsqueda importados",
                 "pt": "Botão Salvar desativado ao modificar sinônimos de pesquisa importados"
@@ -55420,21 +55435,6 @@
             },
             {
               "name": {
-                "en": "Free shipping promotion fails to apply due to minimum or maximum amount being based on unit price instead of total item value",
-                "es": "La promoción de envío gratuito no se aplica debido a que el importe mínimo o máximo se basa en el precio unitario en lugar del valor total del artículo.",
-                "pt": "A promoção de frete grátis não se aplica devido ao fato de o valor mínimo ou máximo ser baseado no preço unitário em vez do valor total do item"
-              },
-              "slug": {
-                "en": "free-shipping-promotion-fails-to-apply-due-to-minimum-or-maximum-amount-being-based-on-unit-price-instead-of-total-item-value",
-                "es": "la-promocion-de-envio-gratuito-no-se-aplica-debido-a-que-el-importe-minimo-o-maximo-se-basa-en-el-precio-unitario-en-lugar-del-valor-total-del-arti",
-                "pt": "a-promocao-de-frete-gratis-nao-se-aplica-devido-ao-fato-de-o-valor-minimo-ou-maximo-ser-baseado-no-preco-unitario-em-vez-do-valor-total-do-item"
-              },
-              "origin": "",
-              "type": "markdown",
-              "children": []
-            },
-            {
-              "name": {
                 "en": "GET Coupon Usage API doesn't list multiple orders for the same coupon",
                 "es": "La API de uso de cupones GET no muestra varios pedidos del mismo cupón.",
                 "pt": "A API GET Coupon Usage não lista vários pedidos para o mesmo cupom"
@@ -55503,6 +55503,21 @@
                 "en": "incorrect-price-update-when-a-promotion-doesnt-apply-the-discount-to-all-the-same-items-in-a-cart",
                 "es": "actualizacion-incorrecta-del-precio-cuando-una-promocion-no-aplica-el-descuento-a-todos-los-mismos-articulos-de-un-carrito",
                 "pt": "atualizacao-incorreta-do-preco-quando-uma-promocao-nao-aplica-o-desconto-a-todos-os-mesmos-itens-em-um-carrinho"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
+                "es": "La promoción de envío gratuito no se aplica debido a que el importe mínimo o máximo se basa en el precio unitario en lugar del valor total del artículo.",
+                "en": "La promoción de envío gratuito no se aplica debido a que el importe mínimo o máximo se basa en el precio unitario en lugar del valor total del artículo.",
+                "pt": "La promoción de envío gratuito no se aplica debido a que el importe mínimo o máximo se basa en el precio unitario en lugar del valor total del artículo."
+              },
+              "slug": {
+                "es": "la-promocion-de-envio-gratuito-no-se-aplica-debido-a-que-el-importe-minimo-o-maximo-se-basa-en-el-precio-unitario-en-lugar-del-valor-total-del-arti",
+                "en": "",
+                "pt": ""
               },
               "origin": "",
               "type": "markdown",
@@ -55758,6 +55773,21 @@
                 "en": "promotion-usage-counter-not-working-as-expected",
                 "es": "el-contador-de-uso-de-promociones-no-funciona-como-se-esperaba",
                 "pt": "o-contador-de-uso-da-promocao-nao-esta-funcionando-como-esperado"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
+                "en": "Promotion validation uses unit price instead of total item price",
+                "es": "La validación de la promoción utiliza el precio unitario en lugar del precio total del artículo",
+                "pt": "A validação da promoção usa o preço unitário em vez do preço total do item"
+              },
+              "slug": {
+                "en": "promotion-validation-uses-unit-price-instead-of-total-item-price",
+                "es": "la-validacion-de-la-promocion-utiliza-el-precio-unitario-en-lugar-del-precio-total-del-articulo",
+                "pt": "a-validacao-da-promocao-usa-o-preco-unitario-em-vez-do-preco-total-do-item"
               },
               "origin": "",
               "type": "markdown",


### PR DESCRIPTION
During traffic tests it is important that internal links don't take users to the old portal. The automatic GTM redirect experience is not the best and it might not work for some edge cases. So relative links are best.

This PR adds this feature to the content migration tool box.