### PR TITLE
Index docs: run on merged PRs or manual dispatch; add local act helper

### DIFF
--- a/.github/workflows/index-docs-on-change.yml
+++ b/.github/workflows/index-docs-on-change.yml
@@ -1,11 +1,8 @@
 name: Index changed docs to Algolia
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'docs/**/*.md'
   pull_request:
+    types: [closed]
     paths:
       - 'docs/**/*.md'
   workflow_dispatch:
@@ -17,6 +14,8 @@ on:
 
 jobs:
   index-docs:
+    # Run only for merged PRs or manual dispatch
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) }}
     name: Index changed markdown files
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -47,25 +46,49 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: algolia-index-analyzer/package-lock.json
+      - name: Set analyzer directory (supports act bind-mount)
+        run: |
+          if [ "${ACT:-}" = "true" ]; then
+            echo "ANALYZER_DIR=/home/runner/algolia-index-analyzer" >> "$GITHUB_ENV"
+          else
+            echo "ANALYZER_DIR=algolia-index-analyzer" >> "$GITHUB_ENV"
+          fi
 
-      - name: Checkout analyzer repo (design/cli-indexer-proposal)
+
+      - name: Checkout analyzer repo (default token)
+        if: ${{ env.ACT != 'true' && (secrets.ANALYZER_REPO_TOKEN == '' || secrets.ANALYZER_REPO_TOKEN == null) }}
         uses: actions/checkout@v4
         with:
           repository: ${{ env.ANALYZER_REPO_SLUG }}
           ref: ${{ env.ANALYZER_REF }}
-          path: algolia-index-analyzer
-          # If the analyzer repo is private, provide a PAT via secrets.ANALYZER_REPO_TOKEN
+          path: ${{ env.ANALYZER_DIR }}
+
+      - name: Checkout analyzer repo (PAT)
+        if: ${{ env.ACT != 'true' && secrets.ANALYZER_REPO_TOKEN != '' }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.ANALYZER_REPO_SLUG }}
+          ref: ${{ env.ANALYZER_REF }}
+          path: ${{ env.ANALYZER_DIR }}
           token: ${{ secrets.ANALYZER_REPO_TOKEN }}
+
+      - name: Setup Node.js (act)
+        if: ${{ env.ACT == 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup Node.js (CI)
+        if: ${{ env.ACT != 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: ${{ env.ANALYZER_DIR }}/package-lock.json
 
       - name: Install analyzer dependencies
         run: npm ci --no-audit --no-fund
-        working-directory: algolia-index-analyzer
+        working-directory: ${{ env.ANALYZER_DIR }}
 
 
       - name: Ensure jq is installed
@@ -91,18 +114,28 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_REF="${{ github.event.pull_request.base.ref }}"
-            git fetch --no-tags --prune origin "$BASE_REF" --depth=1
-            BASE="origin/$BASE_REF"
-            HEAD="HEAD"
-          else
-            BASE="${{ github.event.before }}"
-            HEAD="HEAD"
-            if [ -z "$BASE" ]; then
-              BASE_REF="main"
-              git fetch --no-tags --prune origin "$BASE_REF" --depth=1
-              BASE="origin/$BASE_REF"
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            MERGE_SHA="${{ github.event.pull_request.merge_commit_sha }}"
+            # Fetch specific commits (fallback to base ref)
+            git fetch --no-tags --prune origin "$BASE_SHA" || git fetch --no-tags --prune origin "${{ github.event.pull_request.base.ref }}" --depth=100
+            if [ -n "$MERGE_SHA" ]; then
+              git fetch --no-tags --prune origin "$MERGE_SHA" || git fetch --no-tags --prune origin "${{ github.event.pull_request.base.ref }}" --depth=100
+              BASE="$BASE_SHA"
+              HEAD="$MERGE_SHA"
+            else
+              # Fallback: diff base SHA vs latest base ref
+              git fetch --no-tags --prune origin "${{ github.event.pull_request.base.ref }}" --depth=1
+              BASE="$BASE_SHA"
+              HEAD="origin/${{ github.event.pull_request.base.ref }}"
             fi
+          else
+            # Manual run without specific file input: diff last commit against origin/main
+            BASE="$(git rev-parse HEAD~1 2>/dev/null || echo '')"
+            if [ -z "$BASE" ]; then
+              git fetch --no-tags --prune origin main --depth=2
+              BASE="$(git rev-parse origin/main)"
+            fi
+            HEAD="$(git rev-parse HEAD)"
           fi
           CHANGED=$(git --no-pager diff --name-status "$BASE" "$HEAD" -- 'docs/**/*.md' | awk '$1 != "D" {print $NF}' | jq -R -s -c 'split("\n")|map(select(length>0))')
           echo "files=$CHANGED" >> "$GITHUB_OUTPUT"
@@ -137,4 +170,4 @@ jobs:
               --repo "${REPO}" \
               --json
           done
-        working-directory: algolia-index-analyzer
+        working-directory: ${{ env.ANALYZER_DIR }}

--- a/.github/workflows/index-docs-on-change.yml
+++ b/.github/workflows/index-docs-on-change.yml
@@ -31,6 +31,8 @@ jobs:
 
       # GitHub API token to increase rate limits for content fetches
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Optional PAT for analyzer checkout if private; exposed as env so we can use in 'if' conditions
+      ANALYZER_REPO_TOKEN: ${{ secrets.ANALYZER_REPO_TOKEN }}
 
       # Repository context that the analyzer API uses to fetch markdown files
       OWNER: ${{ github.repository_owner }}
@@ -56,7 +58,7 @@ jobs:
 
 
       - name: Checkout analyzer repo (default token)
-        if: ${{ env.ACT != 'true' && (secrets.ANALYZER_REPO_TOKEN == '' || secrets.ANALYZER_REPO_TOKEN == null) }}
+        if: ${{ env.ACT != 'true' && (env.ANALYZER_REPO_TOKEN == '' || env.ANALYZER_REPO_TOKEN == null) }}
         uses: actions/checkout@v4
         with:
           repository: ${{ env.ANALYZER_REPO_SLUG }}
@@ -64,13 +66,13 @@ jobs:
           path: ${{ env.ANALYZER_DIR }}
 
       - name: Checkout analyzer repo (PAT)
-        if: ${{ env.ACT != 'true' && secrets.ANALYZER_REPO_TOKEN != '' }}
+        if: ${{ env.ACT != 'true' && env.ANALYZER_REPO_TOKEN != '' }}
         uses: actions/checkout@v4
         with:
           repository: ${{ env.ANALYZER_REPO_SLUG }}
           ref: ${{ env.ANALYZER_REF }}
           path: ${{ env.ANALYZER_DIR }}
-          token: ${{ secrets.ANALYZER_REPO_TOKEN }}
+          token: ${{ env.ANALYZER_REPO_TOKEN }}
 
       - name: Setup Node.js (act)
         if: ${{ env.ACT == 'true' }}

--- a/.github/workflows/index-docs-on-change.yml
+++ b/.github/workflows/index-docs-on-change.yml
@@ -1,0 +1,140 @@
+name: Index changed docs to Algolia
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'docs/**/*.md'
+  pull_request:
+    paths:
+      - 'docs/**/*.md'
+  workflow_dispatch:
+    inputs:
+      file:
+        description: 'Optional markdown file path to index (e.g., docs/en/path/to/file.md)'
+        required: false
+        type: string
+
+jobs:
+  index-docs:
+    name: Index changed markdown files
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      # Algolia configuration (set these in repository Secrets)
+      NEXT_PUBLIC_ALGOLIA_APPLICATION_ID: ${{ secrets.ALGOLIA_APPLICATION_ID }}
+      ALGOLIA_ADMIN_API_KEY: ${{ secrets.ALGOLIA_ADMIN_API_KEY }}
+      ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
+      # Help Center hostname used to construct record URLs (optional override via repo Variables)
+      HELP_CENTER_HOSTNAME: ${{ vars.HELP_CENTER_HOSTNAME || 'newhelp.vtex.com' }}
+
+      # GitHub API token to increase rate limits for content fetches
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Repository context that the analyzer API uses to fetch markdown files
+      OWNER: ${{ github.repository_owner }}
+      REPO: ${{ github.event.repository.name }}
+
+      # Analyzer repository location and branch
+      ANALYZER_REPO_SLUG: vtexdocs/algolia-index-analyzer
+      ANALYZER_REF: design/cli-indexer-proposal
+
+    steps:
+      - name: Checkout content repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: algolia-index-analyzer/package-lock.json
+
+      - name: Checkout analyzer repo (design/cli-indexer-proposal)
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.ANALYZER_REPO_SLUG }}
+          ref: ${{ env.ANALYZER_REF }}
+          path: algolia-index-analyzer
+          # If the analyzer repo is private, provide a PAT via secrets.ANALYZER_REPO_TOKEN
+          token: ${{ secrets.ANALYZER_REPO_TOKEN }}
+
+      - name: Install analyzer dependencies
+        run: npm ci --no-audit --no-fund
+        working-directory: algolia-index-analyzer
+
+
+      - name: Ensure jq is installed
+        run: |
+          set -euo pipefail
+          if command -v jq >/dev/null 2>&1; then
+            echo "jq already installed"
+          else
+            if command -v apt-get >/dev/null 2>&1; then
+              sudo apt-get update || apt-get update
+              sudo apt-get install -y jq || apt-get install -y jq
+            elif command -v apk >/dev/null 2>&1; then
+              sudo apk add --no-cache jq || apk add --no-cache jq
+            else
+              echo "Package manager not found; please ensure jq is available" >&2
+              exit 1
+            fi
+          fi
+
+      - name: Compute changed files (docs/**/*.md)
+        id: changed
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.file == '' }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="${{ github.event.pull_request.base.ref }}"
+            git fetch --no-tags --prune origin "$BASE_REF" --depth=1
+            BASE="origin/$BASE_REF"
+            HEAD="HEAD"
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="HEAD"
+            if [ -z "$BASE" ]; then
+              BASE_REF="main"
+              git fetch --no-tags --prune origin "$BASE_REF" --depth=1
+              BASE="origin/$BASE_REF"
+            fi
+          fi
+          CHANGED=$(git --no-pager diff --name-status "$BASE" "$HEAD" -- 'docs/**/*.md' | awk '$1 != "D" {print $NF}' | jq -R -s -c 'split("\n")|map(select(length>0))')
+          echo "files=$CHANGED" >> "$GITHUB_OUTPUT"
+
+      - name: No docs changed
+        if: ${{ github.event_name != 'workflow_dispatch' && steps.changed.outputs.files == '[]' }}
+        run: echo "No markdown files changed under docs/, skipping."
+
+      - name: Build file matrix from manual input
+        id: manual
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.file != '' }}
+        run: |
+          echo "files=[\"${{ inputs.file }}\"]" >> "$GITHUB_OUTPUT"
+
+      - name: Index changed docs
+        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.file != '') || steps.changed.outputs.files != '[]' }}
+        run: |
+          set -euo pipefail
+          FILES_JSON='${{ steps.manual.outputs.files || steps.changed.outputs.files }}'
+          echo "Indexing files: $FILES_JSON"
+          echo "$FILES_JSON" | jq -r '.[]' | while read -r file; do
+            [ -z "$file" ] && continue
+            lang="$(echo "$file" | awk -F/ '{print $2}')"
+            echo "Indexing $file (language=$lang)"
+            # Direct mode: run without starting Next.js server
+            node scripts/cli-index.js \
+              --direct \
+              --file "$file" \
+              --language "$lang" \
+              --index-name "${ALGOLIA_INDEX_NAME}" \
+              --owner "${OWNER}" \
+              --repo "${REPO}" \
+              --json
+          done
+        working-directory: algolia-index-analyzer

--- a/docs/en/announcements/2024/may/2024-05-29-web-page-performance-deprecation.md
+++ b/docs/en/announcements/2024/may/2024-05-29-web-page-performance-deprecation.md
@@ -22,3 +22,5 @@ From now on, merchants will be able to [monitor and optimize these metrics](http
 ## What needs to be done?
 
 In this discontinuation, the merchants do not need to take any action. In the VTEX Admin, the [Store Overview](/en/tutorial/vista-general-de-la-tienda--P8ahguoRs0U3PzmXg2wuQ) and [Sales Performance](/en/tutorial/desempeno-de-ventas--3DMube0sEsK9vPcRYGas72) modules will continue to be available.
+
+<!-- mock change for indexing action PR test -->

--- a/scripts/local-act-pr-test.sh
+++ b/scripts/local-act-pr-test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Run the index-docs-on-change workflow locally for a mock pull_request using act.
+# Usage:
+#   scripts/local-act-pr-test.sh [HEAD_BRANCH] [BASE_BRANCH]
+# Examples:
+#   scripts/local-act-pr-test.sh                 # uses current branch as head, base=main
+#   scripts/local-act-pr-test.sh ci/mock-pr-index main
+# Notes:
+# - Loads secrets from ../algolia-index-analyzer/scripts/.env.local (not printed)
+# - Requires: Docker running, act installed (brew install act)
+# - Override runner image: ACT_IMAGE=ghcr.io/catthehacker/ubuntu:act-22.04 scripts/local-act-pr-test.sh
+
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# Default runner image mapping for act
+ACT_IMAGE_DEFAULT="ghcr.io/catthehacker/ubuntu:act-22.04"
+ACT_IMAGE="${ACT_IMAGE:-$ACT_IMAGE_DEFAULT}"
+
+if ! command -v act >/dev/null 2>&1; then
+  echo "act is not installed. Install with: brew install act" >&2
+  exit 1
+fi
+
+ANALYZER_ENV="$ROOT_DIR/../algolia-index-analyzer/.env.local"
+if [ ! -f "$ANALYZER_ENV" ]; then
+  echo "Missing $ANALYZER_ENV" >&2
+  exit 1
+fi
+
+# Load environment (do not print)
+set -a
+. "$ANALYZER_ENV"
+set +a
+
+SECRETS_FILE="$(mktemp -t act-secrets.XXXXXX)"
+EVENT_FILE="$(mktemp -t act-event.XXXXXX.json)"
+cleanup() { rm -f "$SECRETS_FILE" "$EVENT_FILE"; }
+trap cleanup EXIT
+chmod 600 "$SECRETS_FILE"
+
+# Append secrets if present (never echo values)
+write_secret() {
+  local key="$1"
+  local val="${!key:-}"
+  if [ -n "$val" ]; then
+    printf '%s=%s\n' "$key" "$val" >> "$SECRETS_FILE"
+  fi
+}
+write_secret ALGOLIA_APPLICATION_ID
+write_secret ALGOLIA_ADMIN_API_KEY
+write_secret ALGOLIA_INDEX_NAME
+write_secret GITHUB_TOKEN
+write_secret ANALYZER_REPO_TOKEN
+printf 'ACTIONS_STEP_DEBUG=true\n' >> "$SECRETS_FILE"
+
+HEAD_BRANCH="${1:-$(git rev-parse --abbrev-ref HEAD)}"
+BASE_BRANCH="${2:-main}"
+
+# Minimal PR event payload
+cat > "$EVENT_FILE" <<JSON
+{
+  "pull_request": {
+    "base": { "ref": "$BASE_BRANCH" },
+    "head": { "ref": "$HEAD_BRANCH" }
+  },
+  "repository": {
+    "name": "help-center-content",
+    "full_name": "vtexdocs/help-center-content",
+    "owner": { "login": "vtexdocs" }
+  }
+}
+JSON
+
+# Resolve local analyzer absolute path and mount into container at /home/runner/algolia-index-analyzer
+ANALYZER_SRC="$(cd "$ROOT_DIR/../algolia-index-analyzer" && pwd)"
+ANALYZER_DST="/home/runner/algolia-index-analyzer"
+
+# Run act against the single workflow/job with bind mounts
+act pull_request \
+  -b \
+  -W .github/workflows/index-docs-on-change.yml \
+  -j index-docs \
+  --secret-file "$SECRETS_FILE" \
+  -e "$EVENT_FILE" \
+  -P ubuntu-latest="$ACT_IMAGE" \
+  --container-options "-v ${ANALYZER_SRC}:${ANALYZER_DST}" \
+  "${@:3}"


### PR DESCRIPTION
This PR:
- Indexes docs on merged PRs only (pull_request.closed + merged == true)
- Keeps workflow_dispatch for manual testing (with file input)
- Uses direct mode CLI, no Next server
- Adds GITHUB_TOKEN for GitHub API rate limits
- Installs jq when needed
- Supports act bind-mount; skips analyzer checkout when ACT=true
- Adds scripts/local-act-pr-test.sh to run the PR workflow locally with act

Tested locally with act using bind mounts (see helper script).