### PR TITLE
fix(es): normalize slugs in metadata files by removing special characters

### DIFF
--- a/docs/es/tutorials/acerca-de-admin/metadata.json
+++ b/docs/es/tutorials/acerca-de-admin/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "about-the-admin",
   "name": "Acerca de Admin",
-  "slug": "acerca-de-admin-categoría",
+  "slug": "acerca-de-admin-categoria",
   "order": 3
 }

--- a/docs/es/tutorials/acerca-de-admin/visión-general-del-admin/metadata.json
+++ b/docs/es/tutorials/acerca-de-admin/visión-general-del-admin/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "admin-overview",
   "name": "Visión general del Admin",
-  "slug": "visión-general-del-admin-subcategoría",
+  "slug": "vision-general-del-admin-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/apps/aplicación-affiliates-program/metadata.json
+++ b/docs/es/tutorials/apps/aplicación-affiliates-program/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "affiliates-program-app",
   "name": "Aplicación Affiliates Program",
-  "slug": "aplicación-affiliates-program-subcategoría",
+  "slug": "aplicacion-affiliates-program-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/apps/aplicación-amazon-mcf/metadata.json
+++ b/docs/es/tutorials/apps/aplicación-amazon-mcf/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "amazon-mcf-app",
   "name": "Aplicación Amazon MCF",
-  "slug": "aplicación-amazon-mcf-subcategoría",
+  "slug": "aplicacion-amazon-mcf-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/apps/assembly-options/metadata.json
+++ b/docs/es/tutorials/apps/assembly-options/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "assembly-options",
   "name": "Assembly Options",
-  "slug": "assembly-options-subcategoría",
+  "slug": "assembly-options-subcategoria",
   "order": 4
 }

--- a/docs/es/tutorials/apps/customer-credit/metadata.json
+++ b/docs/es/tutorials/apps/customer-credit/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "customer-credit",
   "name": "Customer Credit",
-  "slug": "customer-credit-subcategoría",
+  "slug": "customer-credit-subcategoria",
   "order": 6
 }

--- a/docs/es/tutorials/apps/live-shopping/metadata.json
+++ b/docs/es/tutorials/apps/live-shopping/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "live-shopping",
   "name": "Live Shopping",
-  "slug": "live-shopping-subcategoría",
+  "slug": "live-shopping-subcategoria",
   "order": 8
 }

--- a/docs/es/tutorials/apps/metadata.json
+++ b/docs/es/tutorials/apps/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "apps",
   "name": "Apps",
-  "slug": "apps-categoría",
+  "slug": "apps-categoria",
   "order": 4
 }

--- a/docs/es/tutorials/apps/my-account/metadata.json
+++ b/docs/es/tutorials/apps/my-account/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "my-account",
   "name": "My Account",
-  "slug": "my-account-subcategoría",
+  "slug": "my-account-subcategoria",
   "order": 9
 }

--- a/docs/es/tutorials/apps/personal-shopper/metadata.json
+++ b/docs/es/tutorials/apps/personal-shopper/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "personal-shopper",
   "name": "Personal Shopper",
-  "slug": "personal-shopper-subcategoría",
+  "slug": "personal-shopper-subcategoria",
   "order": 11
 }

--- a/docs/es/tutorials/apps/visión-de-conjunto-de-apps/metadata.json
+++ b/docs/es/tutorials/apps/visión-de-conjunto-de-apps/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "apps-overview",
   "name": "Visión de conjunto de Apps",
-  "slug": "visión-de-conjunto-de-apps-subcategoría",
+  "slug": "vision-de-conjunto-de-apps-subcategoria",
   "order": 13
 }

--- a/docs/es/tutorials/apps/vtex-session/metadata.json
+++ b/docs/es/tutorials/apps/vtex-session/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "vtex-session",
   "name": "VTEX Session",
-  "slug": "vtex-session-subcategoría",
+  "slug": "vtex-session-subcategoria",
   "order": 14
 }

--- a/docs/es/tutorials/autenticación/autenticación-de-dos-factores/metadata.json
+++ b/docs/es/tutorials/autenticación/autenticación-de-dos-factores/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "two-factor-authentication",
   "name": "Autenticación de dos factores",
-  "slug": "autenticación-de-dos-factores-subcategoría",
+  "slug": "autenticacion-de-dos-factores-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/autenticación/conceptos-básicos-de-autenticación/metadata.json
+++ b/docs/es/tutorials/autenticación/conceptos-básicos-de-autenticación/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "authentication-basics",
   "name": "Conceptos básicos de autenticación",
-  "slug": "conceptos-básicos-de-autenticación-subcategoría",
+  "slug": "conceptos-basicos-de-autenticacion-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/autenticación/configuración-de-autenticación/metadata.json
+++ b/docs/es/tutorials/autenticación/configuración-de-autenticación/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "authentication-settings",
   "name": "Configuración de Autenticación",
-  "slug": "configuración-de-autenticación-subcategoría",
+  "slug": "configuracion-de-autenticacion-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/autenticación/metadata.json
+++ b/docs/es/tutorials/autenticación/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "authentication",
   "name": "Autenticación",
-  "slug": "autenticación-categoría",
+  "slug": "autenticacion-categoria",
   "order": 6
 }

--- a/docs/es/tutorials/b2b/b2b-checkout-settings/metadata.json
+++ b/docs/es/tutorials/b2b/b2b-checkout-settings/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "b2b-checkout-settings",
   "name": "B2B Checkout Settings",
-  "slug": "b2b-checkout-settings-subcategoría",
+  "slug": "b2b-checkout-settings-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/b2b/b2b-orders-history/metadata.json
+++ b/docs/es/tutorials/b2b/b2b-orders-history/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "b2b-orders-history",
   "name": "B2B Orders History",
-  "slug": "b2b-orders-history-subcategoría",
+  "slug": "b2b-orders-history-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/b2b/cotizaciones-b2b/metadata.json
+++ b/docs/es/tutorials/b2b/cotizaciones-b2b/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "b2b-quotes",
   "name": "Cotizaciones B2B",
-  "slug": "cotizaciones-b2b-subcategoría",
+  "slug": "cotizaciones-b2b-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/b2b/detalles-de-la-organización/metadata.json
+++ b/docs/es/tutorials/b2b/detalles-de-la-organización/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "organization-details",
   "name": "Detalles de la organización",
-  "slug": "detalles-de-la-organización-subcategoría",
+  "slug": "detalles-de-la-organizacion-subcategoria",
   "order": 4
 }

--- a/docs/es/tutorials/b2b/guías-práticas/metadata.json
+++ b/docs/es/tutorials/b2b/guías-práticas/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "practical-guides",
   "name": "Guías práticas",
-  "slug": "guías-práticas-subcategoría",
+  "slug": "guias-praticas-subcategoria",
   "order": 5
 }

--- a/docs/es/tutorials/b2b/metadata.json
+++ b/docs/es/tutorials/b2b/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "b2b",
   "name": "B2B",
-  "slug": "b2b-categoría",
+  "slug": "b2b-categoria",
   "order": 7
 }

--- a/docs/es/tutorials/b2b/organizaciones-b2b/metadata.json
+++ b/docs/es/tutorials/b2b/organizaciones-b2b/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "b2b-organizations",
   "name": "Organizaciones B2B",
-  "slug": "organizaciones-b2b-subcategoría",
+  "slug": "organizaciones-b2b-subcategoria",
   "order": 6
 }

--- a/docs/es/tutorials/b2b/permisos-del-storefront/metadata.json
+++ b/docs/es/tutorials/b2b/permisos-del-storefront/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "storefront-permissions",
   "name": "Permisos del storefront",
-  "slug": "permisos-del-storefront-subcategoría",
+  "slug": "permisos-del-storefront-subcategoria",
   "order": 7
 }

--- a/docs/es/tutorials/b2b/visión-general/metadata.json
+++ b/docs/es/tutorials/b2b/visión-general/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "overview",
   "name": "Visión general",
-  "slug": "visión-general-subcategoría",
+  "slug": "vision-general-subcategoria",
   "order": 10
 }

--- a/docs/es/tutorials/beta/catálogo-beta/metadata.json
+++ b/docs/es/tutorials/beta/catálogo-beta/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "catalog-beta",
   "name": "Catálogo Beta",
-  "slug": "catálogo-beta-subcategoría",
+  "slug": "catalogo-beta-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/beta/dashboards-beta/metadata.json
+++ b/docs/es/tutorials/beta/dashboards-beta/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "dashboards-beta",
   "name": "Dashboards Beta",
-  "slug": "dashboards-beta-subcategoría",
+  "slug": "dashboards-beta-subcategoria",
   "order": 7
 }

--- a/docs/es/tutorials/beta/data-insights-agent-beta/metadata.json
+++ b/docs/es/tutorials/beta/data-insights-agent-beta/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "data-insights-agent-beta",
   "name": "Data Insights Agent Beta",
-  "slug": "data-insights-agent-beta-subcategoría",
+  "slug": "data-insights-agent-beta-subcategoria",
   "order": 8
 }

--- a/docs/es/tutorials/beta/envío-beta/metadata.json
+++ b/docs/es/tutorials/beta/envío-beta/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "shipping-beta",
   "name": "Envío Beta",
-  "slug": "envío-beta-subcategoría",
+  "slug": "envio-beta-subcategoria",
   "order": 9
 }

--- a/docs/es/tutorials/beta/intelligent-search-beta/metadata.json
+++ b/docs/es/tutorials/beta/intelligent-search-beta/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "intelligent-search-beta",
   "name": "Intelligent Search Beta",
-  "slug": "intelligent-search-beta-subcategoría",
+  "slug": "intelligent-search-beta-subcategoria",
   "order": 11
 }

--- a/docs/es/tutorials/beta/lanzamientos-beta/metadata.json
+++ b/docs/es/tutorials/beta/lanzamientos-beta/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "releases-beta",
   "name": "Lanzamientos (Beta)",
-  "slug": "lanzamientos-beta-subcategoría",
+  "slug": "lanzamientos-beta-subcategoria",
   "order": 13
 }

--- a/docs/es/tutorials/beta/metadata.json
+++ b/docs/es/tutorials/beta/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "beta",
   "name": "Beta",
-  "slug": "beta-categoría",
+  "slug": "beta-categoria",
   "order": 8
 }

--- a/docs/es/tutorials/beta/promociones-beta/metadata.json
+++ b/docs/es/tutorials/beta/promociones-beta/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "promotions-beta",
   "name": "Promociones Beta",
-  "slug": "promociones-beta-subcategoría",
+  "slug": "promociones-beta-subcategoria",
   "order": 18
 }

--- a/docs/es/tutorials/beta/recomendaciones-de-productos-beta/metadata.json
+++ b/docs/es/tutorials/beta/recomendaciones-de-productos-beta/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "product-recommendations-beta",
   "name": "Recomendaciones de productos Beta",
-  "slug": "recomendaciones-de-productos-beta-subcategoría",
+  "slug": "recomendaciones-de-productos-beta-subcategoria",
   "order": 19
 }

--- a/docs/es/tutorials/beta/vtex-data-pipeline-beta/metadata.json
+++ b/docs/es/tutorials/beta/vtex-data-pipeline-beta/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "vtex-data-pipeline-beta",
   "name": "VTEX Data Pipeline Beta",
-  "slug": "vtex-data-pipeline-beta-subcategoría",
+  "slug": "vtex-data-pipeline-beta-subcategoria",
   "order": 23
 }

--- a/docs/es/tutorials/beta/vtex-sales-app-beta/metadata.json
+++ b/docs/es/tutorials/beta/vtex-sales-app-beta/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "vtex-sales-app-beta",
   "name": "VTEX Sales App Beta",
-  "slug": "vtex-sales-app-beta-subcategoría",
+  "slug": "vtex-sales-app-beta-subcategoria",
   "order": 24
 }

--- a/docs/es/tutorials/catalogo/búsqueda/metadata.json
+++ b/docs/es/tutorials/catalogo/búsqueda/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "search",
   "name": "Búsqueda",
-  "slug": "búsqueda-subcategoría",
+  "slug": "busqueda-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/catalogo/campos-personalizados/metadata.json
+++ b/docs/es/tutorials/catalogo/campos-personalizados/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "custom-product-attributes",
   "name": "Campos personalizados",
-  "slug": "campos-personalizados-subcategoría",
+  "slug": "campos-personalizados-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/catalogo/categorías/metadata.json
+++ b/docs/es/tutorials/catalogo/categorías/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "categories",
   "name": "Categorías",
-  "slug": "categorías-subcategoría",
+  "slug": "categorias-subcategoria",
   "order": 5
 }

--- a/docs/es/tutorials/catalogo/catálogo-visión-general/metadata.json
+++ b/docs/es/tutorials/catalogo/catálogo-visión-general/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "catalog-overview",
   "name": "Catálogo: Visión General",
-  "slug": "catálogo-visión-general-subcategoría",
+  "slug": "catalogo-vision-general-subcategoria",
   "order": 4
 }

--- a/docs/es/tutorials/catalogo/colecciones/metadata.json
+++ b/docs/es/tutorials/catalogo/colecciones/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "collection",
   "name": "Colecciones",
-  "slug": "colecciones-subcategoría",
+  "slug": "colecciones-subcategoria",
   "order": 6
 }

--- a/docs/es/tutorials/catalogo/condiciones-comerciales/metadata.json
+++ b/docs/es/tutorials/catalogo/condiciones-comerciales/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "commercial-conditions",
   "name": "Condiciones comerciales",
-  "slug": "condiciones-comerciales-subcategoría",
+  "slug": "condiciones-comerciales-subcategoria",
   "order": 7
 }

--- a/docs/es/tutorials/catalogo/importación-y-exportación/metadata.json
+++ b/docs/es/tutorials/catalogo/importación-y-exportación/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "import-and-export",
   "name": "Importación y exportación",
-  "slug": "importación-y-exportación-subcategoría",
+  "slug": "importacion-y-exportacion-subcategoria",
   "order": 8
 }

--- a/docs/es/tutorials/catalogo/informes/metadata.json
+++ b/docs/es/tutorials/catalogo/informes/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "reports",
   "name": "Informes",
-  "slug": "informes-subcategoría",
+  "slug": "informes-subcategoria",
   "order": 9
 }

--- a/docs/es/tutorials/catalogo/integraciones-xml/metadata.json
+++ b/docs/es/tutorials/catalogo/integraciones-xml/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "xml-integration",
   "name": "Integraciones XML",
-  "slug": "integraciones-xml-subcategoría",
+  "slug": "integraciones-xml-subcategoria",
   "order": 10
 }

--- a/docs/es/tutorials/catalogo/kit/metadata.json
+++ b/docs/es/tutorials/catalogo/kit/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "bundle",
   "name": "Kit",
-  "slug": "kit-subcategoría",
+  "slug": "kit-subcategoria",
   "order": 11
 }

--- a/docs/es/tutorials/catalogo/marcas/metadata.json
+++ b/docs/es/tutorials/catalogo/marcas/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "brands",
   "name": "Marcas",
-  "slug": "marcas-subcategoría",
+  "slug": "marcas-subcategoria",
   "order": 12
 }

--- a/docs/es/tutorials/catalogo/metadata.json
+++ b/docs/es/tutorials/catalogo/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "catalog",
   "name": "Catalogo",
-  "slug": "catalogo-categoría",
+  "slug": "catalogo-categoria",
   "order": 9
 }

--- a/docs/es/tutorials/catalogo/productos-y-skus/metadata.json
+++ b/docs/es/tutorials/catalogo/productos-y-skus/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "products-and-skus",
   "name": "Productos y SKUs",
-  "slug": "productos-y-skus-subcategoría",
+  "slug": "productos-y-skus-subcategoria",
   "order": 13
 }

--- a/docs/es/tutorials/catalogo/tipos-de-lista/metadata.json
+++ b/docs/es/tutorials/catalogo/tipos-de-lista/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "list-types",
   "name": "Tipos de lista",
-  "slug": "tipos-de-lista-subcategoría",
+  "slug": "tipos-de-lista-subcategoria",
   "order": 15
 }

--- a/docs/es/tutorials/centro-de-mensajes/metadata.json
+++ b/docs/es/tutorials/centro-de-mensajes/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "message-center",
   "name": "Centro de mensajes",
-  "slug": "centro-de-mensajes-categoría",
+  "slug": "centro-de-mensajes-categoria",
   "order": 10
 }

--- a/docs/es/tutorials/centro-de-mensajes/plantillas/metadata.json
+++ b/docs/es/tutorials/centro-de-mensajes/plantillas/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "templates",
   "name": "Plantillas",
-  "slug": "plantillas-subcategoría",
+  "slug": "plantillas-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/centro-de-mensajes/remitentes/metadata.json
+++ b/docs/es/tutorials/centro-de-mensajes/remitentes/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "senders",
   "name": "Remitentes",
-  "slug": "remitentes-subcategoría",
+  "slug": "remitentes-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/checkout/configuración-de-checkout/metadata.json
+++ b/docs/es/tutorials/checkout/configuración-de-checkout/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "checkout-settings",
   "name": "Configuración de Checkout",
-  "slug": "configuración-de-checkout-subcategoría",
+  "slug": "configuracion-de-checkout-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/checkout/metadata.json
+++ b/docs/es/tutorials/checkout/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "checkout",
   "name": "Checkout",
-  "slug": "checkout-categoría",
+  "slug": "checkout-categoria",
   "order": 11
 }

--- a/docs/es/tutorials/checkout/recaptcha/metadata.json
+++ b/docs/es/tutorials/checkout/recaptcha/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "recaptcha",
   "name": "reCAPTCHA",
-  "slug": "recaptcha-subcategoría",
+  "slug": "recaptcha-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/checkout/visión-de-conjunto-de-checkout/metadata.json
+++ b/docs/es/tutorials/checkout/visión-de-conjunto-de-checkout/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "checkout-overview",
   "name": "Visión de conjunto de Checkout",
-  "slug": "visión-de-conjunto-de-checkout-subcategoría",
+  "slug": "vision-de-conjunto-de-checkout-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/comercio-unificado/metadata.json
+++ b/docs/es/tutorials/comercio-unificado/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "unified-commerce",
   "name": "Comercio Unificado",
-  "slug": "comercio-unificado-categoría",
+  "slug": "comercio-unificado-categoria",
   "order": 12
 }

--- a/docs/es/tutorials/comercio-unificado/vtex-sales-app/metadata.json
+++ b/docs/es/tutorials/comercio-unificado/vtex-sales-app/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "vtex-sales-app",
   "name": "VTEX Sales App",
-  "slug": "vtex-sales-app-subcategoría",
+  "slug": "vtex-sales-app-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/configuraciones-de-la-tienda/mejores-prácticas-para-el-éxito-de-tu-tienda-vtex/metadata.json
+++ b/docs/es/tutorials/configuraciones-de-la-tienda/mejores-prácticas-para-el-éxito-de-tu-tienda-vtex/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "best-practices-for-the-success-of-your-vtex-store",
   "name": "Mejores prácticas para el éxito de tu tienda VTEX",
-  "slug": "mejores-prácticas-para-el-éxito-de-tu-tienda-vtex-subcategoría",
+  "slug": "mejores-practicas-para-el-exito-de-tu-tienda-vtex-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/configuraciones-de-la-tienda/metadata.json
+++ b/docs/es/tutorials/configuraciones-de-la-tienda/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "store-settings",
   "name": "Configuraciones de la Tienda",
-  "slug": "configuraciones-de-la-tienda-categoría",
+  "slug": "configuraciones-de-la-tienda-categoria",
   "order": 13
 }

--- a/docs/es/tutorials/configuraciones-de-la-tienda/visión-general-de-configuraciones-de-la-tienda/metadata.json
+++ b/docs/es/tutorials/configuraciones-de-la-tienda/visión-general-de-configuraciones-de-la-tienda/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "store-settings-overview",
   "name": "Visión General de Configuraciones de la Tienda",
-  "slug": "visión-general-de-configuraciones-de-la-tienda-subcategoría",
+  "slug": "vision-general-de-configuraciones-de-la-tienda-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/conversational-commerce/metadata.json
+++ b/docs/es/tutorials/conversational-commerce/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "conversational-commerce",
   "name": "Conversational Commerce",
-  "slug": "conversational-commerce-categoría",
+  "slug": "conversational-commerce-categoria",
   "order": 15
 }

--- a/docs/es/tutorials/conversational-commerce/vtex-assisted-sales-suiteshare/metadata.json
+++ b/docs/es/tutorials/conversational-commerce/vtex-assisted-sales-suiteshare/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "vtex-assisted-sales-suiteshare",
   "name": "VTEX Assisted Sales (SuiteShare)",
-  "slug": "vtex-assisted-sales-suiteshare-subcategoría",
+  "slug": "vtex-assisted-sales-suiteshare-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/dashboards/dashboards-en-el-admin-vtex/metadata.json
+++ b/docs/es/tutorials/dashboards/dashboards-en-el-admin-vtex/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "dashboards-in-the-vtex-admin",
   "name": "Dashboards en el Admin VTEX",
-  "slug": "dashboards-en-el-admin-vtex-subcategoría",
+  "slug": "dashboards-en-el-admin-vtex-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/dashboards/metadata.json
+++ b/docs/es/tutorials/dashboards/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "dashboards",
   "name": "Dashboards",
-  "slug": "dashboards-categoría",
+  "slug": "dashboards-categoria",
   "order": 16
 }

--- a/docs/es/tutorials/envío/configuración-de-inventario-y-envío/metadata.json
+++ b/docs/es/tutorials/envío/configuración-de-inventario-y-envío/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "inventory-and-shipping-settings",
   "name": "Configuración de inventario y envío",
-  "slug": "configuración-de-inventario-y-envío-subcategoría",
+  "slug": "configuracion-de-inventario-y-envio-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/envío/envío-por-geolocalización/metadata.json
+++ b/docs/es/tutorials/envío/envío-por-geolocalización/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "geolocation-shipping",
   "name": "Envío por geolocalización",
-  "slug": "envío-por-geolocalización-subcategoría",
+  "slug": "envio-por-geolocalizacion-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/envío/estratégia-de-envío/metadata.json
+++ b/docs/es/tutorials/envío/estratégia-de-envío/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "shipping-strategy",
   "name": "Estratégia de envío",
-  "slug": "estratégia-de-envío-subcategoría",
+  "slug": "estrategia-de-envio-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/envío/festivos/metadata.json
+++ b/docs/es/tutorials/envío/festivos/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "holidays",
   "name": "Festivos",
-  "slug": "festivos-subcategoría",
+  "slug": "festivos-subcategoria",
   "order": 4
 }

--- a/docs/es/tutorials/envío/inventario/metadata.json
+++ b/docs/es/tutorials/envío/inventario/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "inventory",
   "name": "Inventario",
-  "slug": "inventario-subcategoría",
+  "slug": "inventario-subcategoria",
   "order": 5
 }

--- a/docs/es/tutorials/envío/metadata.json
+++ b/docs/es/tutorials/envío/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "shipping",
   "name": "Envío",
-  "slug": "envío-categoría",
+  "slug": "envio-categoria",
   "order": 17
 }

--- a/docs/es/tutorials/envío/puntos-de-recogida/metadata.json
+++ b/docs/es/tutorials/envío/puntos-de-recogida/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "pickup-points",
   "name": "Puntos de recogida",
-  "slug": "puntos-de-recogida-subcategoría",
+  "slug": "puntos-de-recogida-subcategoria",
   "order": 7
 }

--- a/docs/es/tutorials/envío/simulador-de-envío/metadata.json
+++ b/docs/es/tutorials/envío/simulador-de-envío/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "shipping-simulator",
   "name": "Simulador de envío",
-  "slug": "simulador-de-envío-subcategoría",
+  "slug": "simulador-de-envio-subcategoria",
   "order": 8
 }

--- a/docs/es/tutorials/envío/tarifas-de-envío/metadata.json
+++ b/docs/es/tutorials/envío/tarifas-de-envío/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "shipping-rates",
   "name": "Tarifas de envío",
-  "slug": "tarifas-de-envío-subcategoría",
+  "slug": "tarifas-de-envio-subcategoria",
   "order": 9
 }

--- a/docs/es/tutorials/envío/visión-general-de-la-logística/metadata.json
+++ b/docs/es/tutorials/envío/visión-general-de-la-logística/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "logistics-overview",
   "name": "Visión general de la logística",
-  "slug": "visión-general-de-la-logística-subcategoría",
+  "slug": "vision-general-de-la-logistica-subcategoria",
   "order": 11
 }

--- a/docs/es/tutorials/envío/vtex-pick-and-pack/metadata.json
+++ b/docs/es/tutorials/envío/vtex-pick-and-pack/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "vtex-pick-and-pack",
   "name": "VTEX Pick and Pack",
-  "slug": "vtex-pick-and-pack-subcategoría",
+  "slug": "vtex-pick-and-pack-subcategoria",
   "order": 12
 }

--- a/docs/es/tutorials/envío/vtex-shipping-network/metadata.json
+++ b/docs/es/tutorials/envío/vtex-shipping-network/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "vtex-shipping-network",
   "name": "VTEX Shipping Network",
-  "slug": "vtex-shipping-network-subcategoría",
+  "slug": "vtex-shipping-network-subcategoria",
   "order": 13
 }

--- a/docs/es/tutorials/facturas/contratos/metadata.json
+++ b/docs/es/tutorials/facturas/contratos/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "contracts",
   "name": "Contratos",
-  "slug": "contratos-subcategoría",
+  "slug": "contratos-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/facturas/datos-de-registro/metadata.json
+++ b/docs/es/tutorials/facturas/datos-de-registro/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "registration-data",
   "name": "Datos de registro",
-  "slug": "datos-de-registro-subcategoría",
+  "slug": "datos-de-registro-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/facturas/facturación-visión-general/metadata.json
+++ b/docs/es/tutorials/facturas/facturación-visión-general/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "billing-overview",
   "name": "Facturación: visión general",
-  "slug": "facturación-visión-general-subcategoría",
+  "slug": "facturacion-vision-general-subcategoria",
   "order": 4
 }

--- a/docs/es/tutorials/facturas/metadata.json
+++ b/docs/es/tutorials/facturas/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "billing",
   "name": "Facturas",
-  "slug": "facturas-categoría",
+  "slug": "facturas-categoria",
   "order": 18
 }

--- a/docs/es/tutorials/facturas/títulos/metadata.json
+++ b/docs/es/tutorials/facturas/títulos/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "invoices",
   "name": "Títulos",
-  "slug": "títulos-subcategoría",
+  "slug": "titulos-subcategoria",
   "order": 5
 }

--- a/docs/es/tutorials/gestión-de-la-cuenta/claves-de-api/metadata.json
+++ b/docs/es/tutorials/gestión-de-la-cuenta/claves-de-api/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "api-keys",
   "name": "Claves de API",
-  "slug": "claves-de-api-subcategoría",
+  "slug": "claves-de-api-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/gestión-de-la-cuenta/configuraciones-de-la-cuenta/metadata.json
+++ b/docs/es/tutorials/gestión-de-la-cuenta/configuraciones-de-la-cuenta/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "account-settings",
   "name": "Configuraciones de la cuenta",
-  "slug": "configuraciones-de-la-cuenta-subcategoría",
+  "slug": "configuraciones-de-la-cuenta-subcategoria",
   "order": 4
 }

--- a/docs/es/tutorials/gestión-de-la-cuenta/control-de-acceso/metadata.json
+++ b/docs/es/tutorials/gestión-de-la-cuenta/control-de-acceso/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "access-control",
   "name": "Control de acceso",
-  "slug": "control-de-acceso-subcategoría",
+  "slug": "control-de-acceso-subcategoria",
   "order": 5
 }

--- a/docs/es/tutorials/gestión-de-la-cuenta/cuentas/metadata.json
+++ b/docs/es/tutorials/gestión-de-la-cuenta/cuentas/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "accounts",
   "name": "Cuentas",
-  "slug": "cuentas-subcategoría",
+  "slug": "cuentas-subcategoria",
   "order": 6
 }

--- a/docs/es/tutorials/gestión-de-la-cuenta/metadata.json
+++ b/docs/es/tutorials/gestión-de-la-cuenta/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "account-management",
   "name": "Gestión de la cuenta",
-  "slug": "gestión-de-la-cuenta-categoría",
+  "slug": "gestion-de-la-cuenta-categoria",
   "order": 19
 }

--- a/docs/es/tutorials/gestión-de-la-cuenta/usuarios/metadata.json
+++ b/docs/es/tutorials/gestión-de-la-cuenta/usuarios/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "users",
   "name": "Usuarios",
-  "slug": "usuarios-subcategoría",
+  "slug": "usuarios-subcategoria",
   "order": 8
 }

--- a/docs/es/tutorials/indeva-by-vtex/actualización-de-ventas-con-pdv/erp/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/actualización-de-ventas-con-pdv/erp/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "sales-update-with-pdv/erp",
   "name": "Actualización de ventas con PDV/ERP",
-  "slug": "actualización-de-ventas-con-pdv/erp-subcategoría",
+  "slug": "actualizacion-de-ventas-con-pdv/erp-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/indeva-by-vtex/capacitación-de-indeva/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/capacitación-de-indeva/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "indeva-training",
   "name": "Capacitación de Indeva",
-  "slug": "capacitación-de-indeva-subcategoría",
+  "slug": "capacitacion-de-indeva-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/indeva-by-vtex/cuenta-de-usuario/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/cuenta-de-usuario/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "user-account",
   "name": "Cuenta de usuario",
-  "slug": "cuenta-de-usuario-subcategoría",
+  "slug": "cuenta-de-usuario-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/indeva-by-vtex/dispositivos-y-aplicaciones/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/dispositivos-y-aplicaciones/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "devices-and-apps",
   "name": "Dispositivos y aplicaciones",
-  "slug": "dispositivos-y-aplicaciones-subcategoría",
+  "slug": "dispositivos-y-aplicaciones-subcategoria",
   "order": 4
 }

--- a/docs/es/tutorials/indeva-by-vtex/feedback-del-vendedor/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/feedback-del-vendedor/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "seller-feedback",
   "name": "Feedback del vendedor",
-  "slug": "feedback-del-vendedor-subcategoría",
+  "slug": "feedback-del-vendedor-subcategoria",
   "order": 5
 }

--- a/docs/es/tutorials/indeva-by-vtex/finanzas-de-indeva/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/finanzas-de-indeva/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "indeva-finance",
   "name": "Finanzas de Indeva",
-  "slug": "finanzas-de-indeva-subcategoría",
+  "slug": "finanzas-de-indeva-subcategoria",
   "order": 6
 }

--- a/docs/es/tutorials/indeva-by-vtex/formularios-de-indeva/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/formularios-de-indeva/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "indeva-forms",
   "name": "Formularios de Indeva",
-  "slug": "formularios-de-indeva-subcategoría",
+  "slug": "formularios-de-indeva-subcategoria",
   "order": 7
 }

--- a/docs/es/tutorials/indeva-by-vtex/gerentes/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/gerentes/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "managers",
   "name": "Gerentes",
-  "slug": "gerentes-subcategoría",
+  "slug": "gerentes-subcategoria",
   "order": 8
 }

--- a/docs/es/tutorials/indeva-by-vtex/informes/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/informes/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "reports",
   "name": "Informes",
-  "slug": "informes-subcategoría",
+  "slug": "informes-subcategoria",
   "order": 9
 }

--- a/docs/es/tutorials/indeva-by-vtex/lista-de-turno-de-indeva/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/lista-de-turno-de-indeva/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "indeva-queue-list",
   "name": "Lista de Turno de Indeva",
-  "slug": "lista-de-turno-de-indeva-subcategoría",
+  "slug": "lista-de-turno-de-indeva-subcategoria",
   "order": 10
 }

--- a/docs/es/tutorials/indeva-by-vtex/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "indeva-by-vtex",
   "name": "Indeva by VTEX",
-  "slug": "indeva-by-vtex-categoría",
+  "slug": "indeva-by-vtex-categoria",
   "order": 20
 }

--- a/docs/es/tutorials/indeva-by-vtex/metas/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/metas/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "goals",
   "name": "Metas",
-  "slug": "metas-subcategoría",
+  "slug": "metas-subcategoria",
   "order": 11
 }

--- a/docs/es/tutorials/indeva-by-vtex/rankings-y-campañas/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/rankings-y-campañas/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "rankings-and-campaigns",
   "name": "Rankings y campañas",
-  "slug": "rankings-y-campañas-subcategoría",
+  "slug": "rankings-y-campanas-subcategoria",
   "order": 12
 }

--- a/docs/es/tutorials/indeva-by-vtex/registro-de-metas/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/registro-de-metas/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "goals-registration",
   "name": "Registro de metas",
-  "slug": "registro-de-metas-subcategoría",
+  "slug": "registro-de-metas-subcategoria",
   "order": 13
 }

--- a/docs/es/tutorials/indeva-by-vtex/registros-de-empleados/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/registros-de-empleados/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "employee-registrations",
   "name": "Registros de empleados",
-  "slug": "registros-de-empleados-subcategoría",
+  "slug": "registros-de-empleados-subcategoria",
   "order": 14
 }

--- a/docs/es/tutorials/indeva-by-vtex/sellers/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/sellers/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "sellers",
   "name": "Sellers",
-  "slug": "sellers-subcategoría",
+  "slug": "sellers-subcategoria",
   "order": 15
 }

--- a/docs/es/tutorials/indeva-by-vtex/soporte-de-indeva/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/soporte-de-indeva/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "indeva-support",
   "name": "Soporte de Indeva",
-  "slug": "soporte-de-indeva-subcategoría",
+  "slug": "soporte-de-indeva-subcategoria",
   "order": 16
 }

--- a/docs/es/tutorials/indeva-by-vtex/tableta-y-lista-del-turno-actual/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/tableta-y-lista-del-turno-actual/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "tablet-and-current-queue-list",
   "name": "Tableta y lista del turno actual",
-  "slug": "tableta-y-lista-del-turno-actual-subcategoría",
+  "slug": "tableta-y-lista-del-turno-actual-subcategoria",
   "order": 17
 }

--- a/docs/es/tutorials/indeva-by-vtex/tienda-indeva/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/tienda-indeva/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "store-indeva",
   "name": "Tienda indeva",
-  "slug": "tienda-indeva-subcategoría",
+  "slug": "tienda-indeva-subcategoria",
   "order": 18
 }

--- a/docs/es/tutorials/indeva-by-vtex/usabilidad-de-indeva/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/usabilidad-de-indeva/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "indeva-usability",
   "name": "Usabilidad de Indeva",
-  "slug": "usabilidad-de-indeva-subcategoría",
+  "slug": "usabilidad-de-indeva-subcategoria",
   "order": 19
 }

--- a/docs/es/tutorials/indeva-by-vtex/validación-de-ventas/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/validación-de-ventas/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "sales-validation",
   "name": "Validación de ventas",
-  "slug": "validación-de-ventas-subcategoría",
+  "slug": "validacion-de-ventas-subcategoria",
   "order": 20
 }

--- a/docs/es/tutorials/indeva-by-vtex/visión-general-indeva/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/visión-general-indeva/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "overview-indeva",
   "name": "Visión general Indeva",
-  "slug": "visión-general-indeva-subcategoría",
+  "slug": "vision-general-indeva-subcategoria",
   "order": 21
 }

--- a/docs/es/tutorials/indeva-by-vtex/visión-general/metadata.json
+++ b/docs/es/tutorials/indeva-by-vtex/visión-general/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "overview",
   "name": "Visión general",
-  "slug": "visión-general-subcategoría",
+  "slug": "vision-general-subcategoria",
   "order": 5
 }

--- a/docs/es/tutorials/infraestructura/cdn-service/metadata.json
+++ b/docs/es/tutorials/infraestructura/cdn-service/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "cdn-service",
   "name": "CDN Service",
-  "slug": "cdn-service-subcategoría",
+  "slug": "cdn-service-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/infraestructura/metadata.json
+++ b/docs/es/tutorials/infraestructura/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "infrastructure",
   "name": "Infraestructura",
-  "slug": "infraestructura-categoría",
+  "slug": "infraestructura-categoria",
   "order": 21
 }

--- a/docs/es/tutorials/infraestructura/sla-y-status/metadata.json
+++ b/docs/es/tutorials/infraestructura/sla-y-status/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "sla-and-status",
   "name": "SLA & Status",
-  "slug": "sla-y-status-subcategoría",
+  "slug": "sla-y-status-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/integraciones/configuración-de-las-integraciones/metadata.json
+++ b/docs/es/tutorials/integraciones/configuración-de-las-integraciones/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "integration-settings",
   "name": "Configuración de las Integraciones",
-  "slug": "configuración-de-las-integraciones-subcategoría",
+  "slug": "configuracion-de-las-integraciones-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/integraciones/gestión-de-anuncios/metadata.json
+++ b/docs/es/tutorials/integraciones/gestión-de-anuncios/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "offer-management",
   "name": "Gestión de anuncios",
-  "slug": "gestión-de-anuncios-subcategoría",
+  "slug": "gestion-de-anuncios-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/integraciones/metadata.json
+++ b/docs/es/tutorials/integraciones/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "integrations",
   "name": "Integraciones",
-  "slug": "integraciones-categoría",
+  "slug": "integraciones-categoria",
   "order": 22
 }

--- a/docs/es/tutorials/integraciones/pedidos/metadata.json
+++ b/docs/es/tutorials/integraciones/pedidos/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "orders",
   "name": "Pedidos",
-  "slug": "pedidos-subcategoría",
+  "slug": "pedidos-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/integraciones/precio/metadata.json
+++ b/docs/es/tutorials/integraciones/precio/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "price",
   "name": "Precio",
-  "slug": "precio-subcategoría",
+  "slug": "precio-subcategoria",
   "order": 4
 }

--- a/docs/es/tutorials/integraciones/productos/metadata.json
+++ b/docs/es/tutorials/integraciones/productos/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "products",
   "name": "Productos",
-  "slug": "productos-subcategoría",
+  "slug": "productos-subcategoria",
   "order": 5
 }

--- a/docs/es/tutorials/integraciones/valores/metadata.json
+++ b/docs/es/tutorials/integraciones/valores/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "inventory",
   "name": "Valores",
-  "slug": "valores-subcategoría",
+  "slug": "valores-subcategoria",
   "order": 7
 }

--- a/docs/es/tutorials/integraciones/visión-de-conjunto-de-integraciones/metadata.json
+++ b/docs/es/tutorials/integraciones/visión-de-conjunto-de-integraciones/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "integrations-overview",
   "name": "Visión de conjunto de Integraciones",
-  "slug": "visión-de-conjunto-de-integraciones-subcategoría",
+  "slug": "vision-de-conjunto-de-integraciones-subcategoria",
   "order": 8
 }

--- a/docs/es/tutorials/intelligent-search/banners/metadata.json
+++ b/docs/es/tutorials/intelligent-search/banners/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "banners",
   "name": "Banners",
-  "slug": "banners-subcategoría",
+  "slug": "banners-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/intelligent-search/comportamiento-del-intelligent-search/metadata.json
+++ b/docs/es/tutorials/intelligent-search/comportamiento-del-intelligent-search/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "intelligent-search-behavior",
   "name": "Comportamiento del Intelligent Search",
-  "slug": "comportamiento-del-intelligent-search-subcategoría",
+  "slug": "comportamiento-del-intelligent-search-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/intelligent-search/configuración-del-intelligent-search/metadata.json
+++ b/docs/es/tutorials/intelligent-search/configuración-del-intelligent-search/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "intelligent-search-settings",
   "name": "Configuración del Intelligent Search",
-  "slug": "configuración-del-intelligent-search-subcategoría",
+  "slug": "configuracion-del-intelligent-search-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/intelligent-search/intelligent-search---visión-general/metadata.json
+++ b/docs/es/tutorials/intelligent-search/intelligent-search---visión-general/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "intelligent-search-overview",
   "name": "Intelligent Search - Visión general",
-  "slug": "intelligent-search---visión-general-subcategoría",
+  "slug": "intelligent-search---vision-general-subcategoria",
   "order": 6
 }

--- a/docs/es/tutorials/intelligent-search/metadata.json
+++ b/docs/es/tutorials/intelligent-search/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "intelligent-search",
   "name": "Intelligent Search",
-  "slug": "intelligent-search-categoría",
+  "slug": "intelligent-search-categoria",
   "order": 23
 }

--- a/docs/es/tutorials/intelligent-search/redireccionamientos/metadata.json
+++ b/docs/es/tutorials/intelligent-search/redireccionamientos/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "redirects",
   "name": "Redireccionamientos",
-  "slug": "redireccionamientos-subcategoría",
+  "slug": "redireccionamientos-subcategoria",
   "order": 7
 }

--- a/docs/es/tutorials/intelligent-search/relevancia/metadata.json
+++ b/docs/es/tutorials/intelligent-search/relevancia/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "relevance",
   "name": "Relevancia",
-  "slug": "relevancia-subcategoría",
+  "slug": "relevancia-subcategoria",
   "order": 8
 }

--- a/docs/es/tutorials/intelligent-search/sinónimos/metadata.json
+++ b/docs/es/tutorials/intelligent-search/sinónimos/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "synonyms",
   "name": "Sinónimos",
-  "slug": "sinónimos-subcategoría",
+  "slug": "sinonimos-subcategoria",
   "order": 9
 }

--- a/docs/es/tutorials/master-data/aplicaciones-de-master-data-v1/metadata.json
+++ b/docs/es/tutorials/master-data/aplicaciones-de-master-data-v1/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "master-data-v1-applications",
   "name": "Aplicaciones de Master Data v1",
-  "slug": "aplicaciones-de-master-data-v1-subcategoría",
+  "slug": "aplicaciones-de-master-data-v1-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/master-data/conceptos-básicos-de-master-data/metadata.json
+++ b/docs/es/tutorials/master-data/conceptos-básicos-de-master-data/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "master-data-basics",
   "name": "Conceptos básicos de Master Data",
-  "slug": "conceptos-básicos-de-master-data-subcategoría",
+  "slug": "conceptos-basicos-de-master-data-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/master-data/configuración-de-master-data-v1/metadata.json
+++ b/docs/es/tutorials/master-data/configuración-de-master-data-v1/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "master-data-v1-settings",
   "name": "Configuración de Master Data v1",
-  "slug": "configuración-de-master-data-v1-subcategoría",
+  "slug": "configuracion-de-master-data-v1-subcategoria",
   "order": 4
 }

--- a/docs/es/tutorials/master-data/configuración-de-master-data/metadata.json
+++ b/docs/es/tutorials/master-data/configuración-de-master-data/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "master-data-settings",
   "name": "Configuración de Master Data",
-  "slug": "configuración-de-master-data-subcategoría",
+  "slug": "configuracion-de-master-data-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/master-data/gestión-de-clientes/metadata.json
+++ b/docs/es/tutorials/master-data/gestión-de-clientes/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "customer-relations-management",
   "name": "Gestión de clientes",
-  "slug": "gestión-de-clientes-subcategoría",
+  "slug": "gestion-de-clientes-subcategoria",
   "order": 5
 }

--- a/docs/es/tutorials/master-data/metadata.json
+++ b/docs/es/tutorials/master-data/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "master-data",
   "name": "Master Data",
-  "slug": "master-data-categoría",
+  "slug": "master-data-categoria",
   "order": 24
 }

--- a/docs/es/tutorials/master-data/triggers-de-master-data-v1/metadata.json
+++ b/docs/es/tutorials/master-data/triggers-de-master-data-v1/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "master-data-v1-triggers",
   "name": "Triggers de Master Data v1",
-  "slug": "triggers-de-master-data-v1-subcategoría",
+  "slug": "triggers-de-master-data-v1-subcategoria",
   "order": 6
 }

--- a/docs/es/tutorials/omnichannel/configuración-de-omnichannel/metadata.json
+++ b/docs/es/tutorials/omnichannel/configuración-de-omnichannel/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "omnichannel-settings",
   "name": "Configuración de Omnichannel",
-  "slug": "configuración-de-omnichannel-subcategoría",
+  "slug": "configuracion-de-omnichannel-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/omnichannel/metadata.json
+++ b/docs/es/tutorials/omnichannel/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "omnichannel",
   "name": "Omnichannel",
-  "slug": "omnichannel-categoría",
+  "slug": "omnichannel-categoria",
   "order": 25
 }

--- a/docs/es/tutorials/omnichannel/visión-general-de-omnichannel/metadata.json
+++ b/docs/es/tutorials/omnichannel/visión-general-de-omnichannel/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "omnichannel-overview",
   "name": "Visión general de Omnichannel",
-  "slug": "visión-general-de-omnichannel-subcategoría",
+  "slug": "vision-general-de-omnichannel-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/operativo/admin-vtex/metadata.json
+++ b/docs/es/tutorials/operativo/admin-vtex/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "vtex-admin",
   "name": "Admin VTEX",
-  "slug": "admin-vtex-subcategoría",
+  "slug": "admin-vtex-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/operativo/apoyo/metadata.json
+++ b/docs/es/tutorials/operativo/apoyo/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "support",
   "name": "Apoyo",
-  "slug": "apoyo-subcategoría",
+  "slug": "apoyo-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/operativo/financiero/metadata.json
+++ b/docs/es/tutorials/operativo/financiero/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "financial",
   "name": "Financiero",
-  "slug": "financiero-subcategoría",
+  "slug": "financiero-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/operativo/metadata.json
+++ b/docs/es/tutorials/operativo/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "operational",
   "name": "Operativo",
-  "slug": "operativo-categoría",
+  "slug": "operativo-categoria",
   "order": 26
 }

--- a/docs/es/tutorials/otros/foresight-commerce-academy/metadata.json
+++ b/docs/es/tutorials/otros/foresight-commerce-academy/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "foresight-commerce-academy",
   "name": "Foresight Commerce Academy",
-  "slug": "foresight-commerce-academy-subcategoría",
+  "slug": "foresight-commerce-academy-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/otros/metadata.json
+++ b/docs/es/tutorials/otros/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "other",
   "name": "Otros",
-  "slug": "otros-categoría",
+  "slug": "otros-categoria",
   "order": 27
 }

--- a/docs/es/tutorials/otros/no-categorizado/metadata.json
+++ b/docs/es/tutorials/otros/no-categorizado/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "uncategorized",
   "name": "No categorizado",
-  "slug": "no-categorizado-subcategoría",
+  "slug": "no-categorizado-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/otros/programación-de-funcionalidades/metadata.json
+++ b/docs/es/tutorials/otros/programación-de-funcionalidades/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "scheduling-features",
   "name": "Programación de funcionalidades",
-  "slug": "programación-de-funcionalidades-subcategoría",
+  "slug": "programacion-de-funcionalidades-subcategoria",
   "order": 4
 }

--- a/docs/es/tutorials/pagos/conciliaciones-bancarias/metadata.json
+++ b/docs/es/tutorials/pagos/conciliaciones-bancarias/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "bank-conciliation",
   "name": "Conciliaciones bancarias",
-  "slug": "conciliaciones-bancarias-subcategoría",
+  "slug": "conciliaciones-bancarias-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/pagos/configuración-de-pagos/metadata.json
+++ b/docs/es/tutorials/pagos/configuración-de-pagos/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "payment-settings",
   "name": "Configuración de Pagos",
-  "slug": "configuración-de-pagos-subcategoría",
+  "slug": "configuracion-de-pagos-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/pagos/metadata.json
+++ b/docs/es/tutorials/pagos/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "payments",
   "name": "Pagos",
-  "slug": "pagos-categoría",
+  "slug": "pagos-categoria",
   "order": 28
 }

--- a/docs/es/tutorials/pagos/tarjeta-de-regalo/metadata.json
+++ b/docs/es/tutorials/pagos/tarjeta-de-regalo/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "gift-card",
   "name": "Tarjeta de regalo",
-  "slug": "tarjeta-de-regalo-subcategoría",
+  "slug": "tarjeta-de-regalo-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/pagos/transacciones/metadata.json
+++ b/docs/es/tutorials/pagos/transacciones/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "transactions",
   "name": "Transacciones",
-  "slug": "transacciones-subcategoría",
+  "slug": "transacciones-subcategoria",
   "order": 4
 }

--- a/docs/es/tutorials/pagos/visión-de-conjunto-de-pagos/metadata.json
+++ b/docs/es/tutorials/pagos/visión-de-conjunto-de-pagos/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "payments-overview",
   "name": "Visión de conjunto de Pagos",
-  "slug": "visión-de-conjunto-de-pagos-subcategoría",
+  "slug": "vision-de-conjunto-de-pagos-subcategoria",
   "order": 5
 }

--- a/docs/es/tutorials/pedidos/configuración-de-gestión-de-pedidos/metadata.json
+++ b/docs/es/tutorials/pedidos/configuración-de-gestión-de-pedidos/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "orders-management-settings",
   "name": "Configuración de Gestión de Pedidos",
-  "slug": "configuración-de-gestión-de-pedidos-subcategoría",
+  "slug": "configuracion-de-gestion-de-pedidos-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/pedidos/metadata.json
+++ b/docs/es/tutorials/pedidos/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "orders",
   "name": "Pedidos",
-  "slug": "pedidos-categoría",
+  "slug": "pedidos-categoria",
   "order": 29
 }

--- a/docs/es/tutorials/pedidos/pedidos-b2b/metadata.json
+++ b/docs/es/tutorials/pedidos/pedidos-b2b/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "b2b-orders",
   "name": "Pedidos B2B",
-  "slug": "pedidos-b2b-subcategoría",
+  "slug": "pedidos-b2b-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/pedidos/televentas-y-servicio-al-cliente/metadata.json
+++ b/docs/es/tutorials/pedidos/televentas-y-servicio-al-cliente/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "telesales-and-customer-service",
   "name": "Televentas y servicio al cliente",
-  "slug": "televentas-y-servicio-al-cliente-subcategoría",
+  "slug": "televentas-y-servicio-al-cliente-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/pedidos/todos-los-pedidos/metadata.json
+++ b/docs/es/tutorials/pedidos/todos-los-pedidos/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "all-orders",
   "name": "Todos los pedidos",
-  "slug": "todos-los-pedidos-subcategoría",
+  "slug": "todos-los-pedidos-subcategoria",
   "order": 4
 }

--- a/docs/es/tutorials/pedidos/visión-de-conjunto-de-pedidos/metadata.json
+++ b/docs/es/tutorials/pedidos/visión-de-conjunto-de-pedidos/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "orders-overview",
   "name": "Visión de conjunto de Pedidos",
-  "slug": "visión-de-conjunto-de-pedidos-subcategoría",
+  "slug": "vision-de-conjunto-de-pedidos-subcategoria",
   "order": 5
 }

--- a/docs/es/tutorials/políticas-comerciales/configuración-de-políticas-comerciales/metadata.json
+++ b/docs/es/tutorials/políticas-comerciales/configuración-de-políticas-comerciales/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "trade-policies-settings",
   "name": "Configuración de Políticas Comerciales",
-  "slug": "configuración-de-políticas-comerciales-subcategoría",
+  "slug": "configuracion-de-politicas-comerciales-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/políticas-comerciales/metadata.json
+++ b/docs/es/tutorials/políticas-comerciales/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "trade-policies",
   "name": "Políticas comerciales",
-  "slug": "políticas-comerciales-categoría",
+  "slug": "politicas-comerciales-categoria",
   "order": 30
 }

--- a/docs/es/tutorials/políticas-comerciales/visión-de-conjunto-de-políticas-comerciales/metadata.json
+++ b/docs/es/tutorials/políticas-comerciales/visión-de-conjunto-de-políticas-comerciales/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "trade-policies'-overview",
   "name": "Visión de conjunto de Políticas Comerciales",
-  "slug": "visión-de-conjunto-de-políticas-comerciales-subcategoría",
+  "slug": "vision-de-conjunto-de-politicas-comerciales-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/precios/configuración-de-precios/metadata.json
+++ b/docs/es/tutorials/precios/configuración-de-precios/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "price-settings",
   "name": "Configuración de precios",
-  "slug": "configuración-de-precios-subcategoría",
+  "slug": "configuracion-de-precios-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/precios/lista-de-precios/metadata.json
+++ b/docs/es/tutorials/precios/lista-de-precios/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "price-list",
   "name": "Lista de precios",
-  "slug": "lista-de-precios-subcategoría",
+  "slug": "lista-de-precios-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/precios/metadata.json
+++ b/docs/es/tutorials/precios/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "prices",
   "name": "Precios",
-  "slug": "precios-categoría",
+  "slug": "precios-categoria",
   "order": 31
 }

--- a/docs/es/tutorials/precios/redondeo-de-precios/metadata.json
+++ b/docs/es/tutorials/precios/redondeo-de-precios/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "rounding-rules",
   "name": "Redondeo de Precios",
-  "slug": "redondeo-de-precios-subcategoría",
+  "slug": "redondeo-de-precios-subcategoria",
   "order": 4
 }

--- a/docs/es/tutorials/precios/reglas-de-precio/metadata.json
+++ b/docs/es/tutorials/precios/reglas-de-precio/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "price-rules",
   "name": "Reglas de precio",
-  "slug": "reglas-de-precio-subcategoría",
+  "slug": "reglas-de-precio-subcategoria",
   "order": 5
 }

--- a/docs/es/tutorials/proyectos-y-integraciones/integración-con-herramientas-de-monitoreo/metadata.json
+++ b/docs/es/tutorials/proyectos-y-integraciones/integración-con-herramientas-de-monitoreo/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "integration-with-monitoring-tools",
   "name": "Integración con herramientas de monitoreo",
-  "slug": "integración-con-herramientas-de-monitoreo-subcategoría",
+  "slug": "integracion-con-herramientas-de-monitoreo-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/proyectos-y-integraciones/metadata.json
+++ b/docs/es/tutorials/proyectos-y-integraciones/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "projects-and-integrations",
   "name": "Proyectos & Integraciones",
-  "slug": "proyectos-y-integraciones-categoría",
+  "slug": "proyectos-y-integraciones-categoria",
   "order": 33
 }

--- a/docs/es/tutorials/seguridad/cumplimiento-de-seguridad-de-la-información/metadata.json
+++ b/docs/es/tutorials/seguridad/cumplimiento-de-seguridad-de-la-información/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "information-security-compliance",
   "name": "Cumplimiento de seguridad de la información",
-  "slug": "cumplimiento-de-seguridad-de-la-información-subcategoría",
+  "slug": "cumplimiento-de-seguridad-de-la-informacion-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/seguridad/metadata.json
+++ b/docs/es/tutorials/seguridad/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "security",
   "name": "Seguridad",
-  "slug": "seguridad-categoría",
+  "slug": "seguridad-categoria",
   "order": 34
 }

--- a/docs/es/tutorials/seguridad/recursos-de-seguridad-de-la-plataforma/metadata.json
+++ b/docs/es/tutorials/seguridad/recursos-de-seguridad-de-la-plataforma/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "platform-security-resources",
   "name": "Recursos de seguridad de la plataforma",
-  "slug": "recursos-de-seguridad-de-la-plataforma-subcategoría",
+  "slug": "recursos-de-seguridad-de-la-plataforma-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/seguridad/seguridad-para-comerciantes/metadata.json
+++ b/docs/es/tutorials/seguridad/seguridad-para-comerciantes/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "store-security",
   "name": "Seguridad para comerciantes",
-  "slug": "seguridad-para-comerciantes-subcategoría",
+  "slug": "seguridad-para-comerciantes-subcategoria",
   "order": 4
 }

--- a/docs/es/tutorials/seguridad/vtex-shield/metadata.json
+++ b/docs/es/tutorials/seguridad/vtex-shield/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "vtex-shield",
   "name": "VTEX Shield",
-  "slug": "vtex-shield-subcategoría",
+  "slug": "vtex-shield-subcategoria",
   "order": 5
 }

--- a/docs/es/tutorials/sellers/categorías-y-marcas/metadata.json
+++ b/docs/es/tutorials/sellers/categorías-y-marcas/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "categories-and-brands",
   "name": "Categorías y marcas",
-  "slug": "categorías-y-marcas-subcategoría",
+  "slug": "categorias-y-marcas-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/sellers/gestión/metadata.json
+++ b/docs/es/tutorials/sellers/gestión/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "management",
   "name": "Gestión",
-  "slug": "gestión-subcategoría",
+  "slug": "gestion-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/sellers/metadata.json
+++ b/docs/es/tutorials/sellers/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "sellers",
   "name": "Sellers",
-  "slug": "sellers-categoría",
+  "slug": "sellers-categoria",
   "order": 35
 }

--- a/docs/es/tutorials/sellers/seller-portal/metadata.json
+++ b/docs/es/tutorials/sellers/seller-portal/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "seller-portal",
   "name": "Seller Portal",
-  "slug": "seller-portal-subcategoría",
+  "slug": "seller-portal-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/sellers/skus-recibidos/metadata.json
+++ b/docs/es/tutorials/sellers/skus-recibidos/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "received-skus",
   "name": "SKUs recibidos",
-  "slug": "skus-recibidos-subcategoría",
+  "slug": "skus-recibidos-subcategoria",
   "order": 4
 }

--- a/docs/es/tutorials/sellers/visión-de-conjunto-de-sellers/metadata.json
+++ b/docs/es/tutorials/sellers/visión-de-conjunto-de-sellers/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "sellers-overview",
   "name": "Visión de conjunto de Sellers",
-  "slug": "visión-de-conjunto-de-sellers-subcategoría",
+  "slug": "vision-de-conjunto-de-sellers-subcategoria",
   "order": 6
 }

--- a/docs/es/tutorials/sellers/vínculos-de-sku/metadata.json
+++ b/docs/es/tutorials/sellers/vínculos-de-sku/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "sku-binding",
   "name": "Vínculos de SKU",
-  "slug": "vínculos-de-sku-subcategoría",
+  "slug": "vinculos-de-sku-subcategoria",
   "order": 5
 }

--- a/docs/es/tutorials/storefront/configuración-de-la-tienda---storefront/metadata.json
+++ b/docs/es/tutorials/storefront/configuración-de-la-tienda---storefront/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "store-settings---storefront",
   "name": "Configuración de la Tienda - Storefront",
-  "slug": "configuración-de-la-tienda---storefront-subcategoría",
+  "slug": "configuracion-de-la-tienda---storefront-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/storefront/estilos/metadata.json
+++ b/docs/es/tutorials/storefront/estilos/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "styles",
   "name": "Estilos",
-  "slug": "estilos-subcategoría",
+  "slug": "estilos-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/storefront/headless-cms/metadata.json
+++ b/docs/es/tutorials/storefront/headless-cms/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "headless-cms",
   "name": "Headless CMS",
-  "slug": "headless-cms-subcategoría",
+  "slug": "headless-cms-subcategoria",
   "order": 4
 }

--- a/docs/es/tutorials/storefront/layout/metadata.json
+++ b/docs/es/tutorials/storefront/layout/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "layout",
   "name": "Layout",
-  "slug": "layout-subcategoría",
+  "slug": "layout-subcategoria",
   "order": 5
 }

--- a/docs/es/tutorials/storefront/metadata.json
+++ b/docs/es/tutorials/storefront/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "storefront",
   "name": "Storefront",
-  "slug": "storefront-categoría",
+  "slug": "storefront-categoria",
   "order": 38
 }

--- a/docs/es/tutorials/storefront/páginas/metadata.json
+++ b/docs/es/tutorials/storefront/páginas/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "pages",
   "name": "Páginas",
-  "slug": "páginas-subcategoría",
+  "slug": "paginas-subcategoria",
   "order": 6
 }

--- a/docs/es/tutorials/storefront/site-editor/metadata.json
+++ b/docs/es/tutorials/storefront/site-editor/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "site-editor",
   "name": "Site Editor",
-  "slug": "site-editor-subcategoría",
+  "slug": "site-editor-subcategoria",
   "order": 7
 }

--- a/docs/es/tutorials/storefront/visión-general-storefront/metadata.json
+++ b/docs/es/tutorials/storefront/visión-general-storefront/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "storefront-overview",
   "name": "Visión General Storefront",
-  "slug": "visión-general-storefront-subcategoría",
+  "slug": "vision-general-storefront-subcategoria",
   "order": 10
 }

--- a/docs/es/tutorials/sugerencias/en-procesamiento/metadata.json
+++ b/docs/es/tutorials/sugerencias/en-procesamiento/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "processing",
   "name": "En procesamiento",
-  "slug": "en-procesamiento-subcategoría",
+  "slug": "en-procesamiento-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/sugerencias/metadata.json
+++ b/docs/es/tutorials/sugerencias/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "suggestions",
   "name": "Sugerencias",
-  "slug": "sugerencias-categoría",
+  "slug": "sugerencias-categoria",
   "order": 39
 }

--- a/docs/es/tutorials/sugerencias/productos/metadata.json
+++ b/docs/es/tutorials/sugerencias/productos/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "pending",
   "name": "Productos",
-  "slug": "productos-subcategoría",
+  "slug": "productos-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/suscripciones/guía-de-suscripciones/metadata.json
+++ b/docs/es/tutorials/suscripciones/guía-de-suscripciones/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "subscription-guides",
   "name": "Guía de Suscripciones",
-  "slug": "guía-de-suscripciones-subcategoría",
+  "slug": "guia-de-suscripciones-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/suscripciones/metadata.json
+++ b/docs/es/tutorials/suscripciones/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "subscriptions",
   "name": "Suscripciones",
-  "slug": "suscripciones-categoría",
+  "slug": "suscripciones-categoria",
   "order": 40
 }

--- a/docs/es/tutorials/tasas-y-promociones/audiencia-de-las-campañas/metadata.json
+++ b/docs/es/tutorials/tasas-y-promociones/audiencia-de-las-campañas/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "campaign-audiences",
   "name": "Audiencia de las Campañas",
-  "slug": "audiencia-de-las-campañas-subcategoría",
+  "slug": "audiencia-de-las-campanas-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/tasas-y-promociones/cupones/metadata.json
+++ b/docs/es/tutorials/tasas-y-promociones/cupones/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "coupons",
   "name": "Cupones",
-  "slug": "cupones-subcategoría",
+  "slug": "cupones-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/tasas-y-promociones/impuestos/metadata.json
+++ b/docs/es/tutorials/tasas-y-promociones/impuestos/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "taxes",
   "name": "Impuestos",
-  "slug": "impuestos-subcategoría",
+  "slug": "impuestos-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/tasas-y-promociones/metadata.json
+++ b/docs/es/tutorials/tasas-y-promociones/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "promotions-and-taxes",
   "name": "Tasas y promociones",
-  "slug": "tasas-y-promociones-categoría",
+  "slug": "tasas-y-promociones-categoria",
   "order": 41
 }

--- a/docs/es/tutorials/tasas-y-promociones/promociones/metadata.json
+++ b/docs/es/tutorials/tasas-y-promociones/promociones/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "promotions",
   "name": "Promociones",
-  "slug": "promociones-subcategoría",
+  "slug": "promociones-subcategoria",
   "order": 4
 }

--- a/docs/es/tutorials/tasas-y-promociones/visión-de-conjunto-de-tasas-y-promociones/metadata.json
+++ b/docs/es/tutorials/tasas-y-promociones/visión-de-conjunto-de-tasas-y-promociones/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "rates-and-benefits-overview",
   "name": "Visión de conjunto de Tasas y Promociones",
-  "slug": "visión-de-conjunto-de-tasas-y-promociones-subcategoría",
+  "slug": "vision-de-conjunto-de-tasas-y-promociones-subcategoria",
   "order": 5
 }

--- a/docs/es/tutorials/vtex-tracking/aplicación-móvil/metadata.json
+++ b/docs/es/tutorials/vtex-tracking/aplicación-móvil/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "mobile-app",
   "name": "Aplicación Móvil",
-  "slug": "aplicación-móvil-subcategoría",
+  "slug": "aplicacion-movil-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/vtex-tracking/indicadores/metadata.json
+++ b/docs/es/tutorials/vtex-tracking/indicadores/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "indicators",
   "name": "Indicadores",
-  "slug": "indicadores-subcategoría",
+  "slug": "indicadores-subcategoria",
   "order": 5
 }

--- a/docs/es/tutorials/vtex-tracking/informes/metadata.json
+++ b/docs/es/tutorials/vtex-tracking/informes/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "reports",
   "name": "Informes",
-  "slug": "informes-subcategoría",
+  "slug": "informes-subcategoria",
   "order": 6
 }

--- a/docs/es/tutorials/vtex-tracking/metadata.json
+++ b/docs/es/tutorials/vtex-tracking/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "vtex-tracking",
   "name": "VTEX Tracking",
-  "slug": "vtex-tracking-categoría",
+  "slug": "vtex-tracking-categoria",
   "order": 45
 }

--- a/docs/es/tutorials/vtex-tracking/rutes/metadata.json
+++ b/docs/es/tutorials/vtex-tracking/rutes/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "routes",
   "name": "Rutes",
-  "slug": "rutes-subcategoría",
+  "slug": "rutes-subcategoria",
   "order": 7
 }

--- a/docs/es/tutorials/vtex-tracking/servicios/metadata.json
+++ b/docs/es/tutorials/vtex-tracking/servicios/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "services",
   "name": "Servicios",
-  "slug": "servicios-subcategoría",
+  "slug": "servicios-subcategoria",
   "order": 8
 }

--- a/docs/es/tutorials/vtex-tracking/visión-general-vtex-tracking/metadata.json
+++ b/docs/es/tutorials/vtex-tracking/visión-general-vtex-tracking/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "overview-vtex-tracking",
   "name": "Visión general VTEX Tracking",
-  "slug": "visión-general-vtex-tracking-subcategoría",
+  "slug": "vision-general-vtex-tracking-subcategoria",
   "order": 9
 }

--- a/docs/es/tutorials/vtex-tracking/vtex-tracking---todos-los-artículos/metadata.json
+++ b/docs/es/tutorials/vtex-tracking/vtex-tracking---todos-los-artículos/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "vtex-tracking---all-articles",
   "name": "VTEX Tracking - Todos los artículos",
-  "slug": "vtex-tracking---todos-los-artículos-subcategoría",
+  "slug": "vtex-tracking---todos-los-articulos-subcategoria",
   "order": 10
 }

--- a/docs/es/tutorials/weni-by-vtex/agent-builder/metadata.json
+++ b/docs/es/tutorials/weni-by-vtex/agent-builder/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "agent-builder",
   "name": "Agent Builder",
-  "slug": "agent-builder-subcategoría",
+  "slug": "agent-builder-subcategoria",
   "order": 1
 }

--- a/docs/es/tutorials/weni-by-vtex/chats/metadata.json
+++ b/docs/es/tutorials/weni-by-vtex/chats/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "chats",
   "name": "Chats",
-  "slug": "chats-subcategoría",
+  "slug": "chats-subcategoria",
   "order": 2
 }

--- a/docs/es/tutorials/weni-by-vtex/code-action/metadata.json
+++ b/docs/es/tutorials/weni-by-vtex/code-action/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "code-action",
   "name": "Code Action",
-  "slug": "code-action-subcategoría",
+  "slug": "code-action-subcategoria",
   "order": 3
 }

--- a/docs/es/tutorials/weni-by-vtex/configuraciones-weni/metadata.json
+++ b/docs/es/tutorials/weni-by-vtex/configuraciones-weni/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "weni-settings",
   "name": "Configuraciones Weni",
-  "slug": "configuraciones-weni-subcategoría",
+  "slug": "configuraciones-weni-subcategoria",
   "order": 4
 }

--- a/docs/es/tutorials/weni-by-vtex/estúdio/metadata.json
+++ b/docs/es/tutorials/weni-by-vtex/estúdio/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "studio",
   "name": "Estúdio",
-  "slug": "estúdio-subcategoría",
+  "slug": "estudio-subcategoria",
   "order": 5
 }

--- a/docs/es/tutorials/weni-by-vtex/flujos/metadata.json
+++ b/docs/es/tutorials/weni-by-vtex/flujos/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "flows",
   "name": "Flujos",
-  "slug": "flujos-subcategoría",
+  "slug": "flujos-subcategoria",
   "order": 6
 }

--- a/docs/es/tutorials/weni-by-vtex/insights/metadata.json
+++ b/docs/es/tutorials/weni-by-vtex/insights/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "insights",
   "name": "Insights",
-  "slug": "insights-subcategoría",
+  "slug": "insights-subcategoria",
   "order": 7
 }

--- a/docs/es/tutorials/weni-by-vtex/integraciones/metadata.json
+++ b/docs/es/tutorials/weni-by-vtex/integraciones/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "integrations",
   "name": "Integraciones",
-  "slug": "integraciones-subcategoría",
+  "slug": "integraciones-subcategoria",
   "order": 8
 }

--- a/docs/es/tutorials/weni-by-vtex/metadata.json
+++ b/docs/es/tutorials/weni-by-vtex/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "weni-by-vtex",
   "name": "Weni by VTEX",
-  "slug": "weni-by-vtex-categoría",
+  "slug": "weni-by-vtex-categoria",
   "order": 46
 }

--- a/docs/es/tutorials/weni-by-vtex/visión-de-conjunto-de-weni-by-vtex/metadata.json
+++ b/docs/es/tutorials/weni-by-vtex/visión-de-conjunto-de-weni-by-vtex/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "weni-by-vtex-overview",
   "name": "Visión de conjunto de Weni by VTEX",
-  "slug": "visión-de-conjunto-de-weni-by-vtex-subcategoría",
+  "slug": "vision-de-conjunto-de-weni-by-vtex-subcategoria",
   "order": 9
 }

--- a/docs/es/tutorials/weni-by-vtex/weni-agentic-ai/metadata.json
+++ b/docs/es/tutorials/weni-by-vtex/weni-agentic-ai/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "weni-agentic-ai",
   "name": "Weni Agentic AI",
-  "slug": "weni-agentic-ai-subcategoría",
+  "slug": "weni-agentic-ai-subcategoria",
   "order": 10
 }


### PR DESCRIPTION
## Summary
Normalizes slugs in Spanish tutorial metadata files by removing special characters (accents, tildes, etc.) to ensure URL-friendly slugs.

## Changes
- Updated 221 metadata.json files in `docs/es/tutorials/`
- Removed special characters from slug values (e.g., `autenticación-categoría` → `autenticacion-categoria`)

## Why
This ensures all slugs are URL-safe and consistent across the Spanish documentation, preventing potential routing issues with special characters.