### PR TITLE
docs: update image URLs to use CDN instead of raw GitHub URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ If you need to use images to help the user understand procedures more easily, fo
 
     > ℹ️ If the article has more than one image, they must be named in numerical sequence. For instance, `how-to-create-a-catalog-category_1.png`, `how-to-create-a-catalog-category_2.png`.
 
-3. Open the article and add `![{{Image name}}](https://raw.githubusercontent.com/vtexdocs/help-center-content/refs/heads/main/docs/{{locale}}/{{path}}/{{image-slug-name}})`, replacing:
+3. Open the article and add `![{{Image name}}](https://cdn.statically.io/gh/vtexdocs/help-center-content/refs/heads/main/docs/{{locale}}/{{path}}/{{image-slug-name}})`, replacing:
 
   - `{{Image name}}` by an image identification name of your choice
   - `{{path}}` by the path where you saved the image
   - `{{image-slug-name}}` by the image slug name
 
-Example: `![Instalação B2B Suite - PT](https://raw.githubusercontent.com/vtexdocs/help-center-content/refs/heads/main/docs/pt/tutorials/B2B/Overview/b2b-suite-visao-geral_1.gif)`.
+Example: `![Instalação B2B Suite - PT](https://cdn.statically.io/gh/vtexdocs/help-center-content/refs/heads/main/docs/pt/tutorials/B2B/Overview/b2b-suite-visao-geral_1.gif)`.
 
    >⚠️ After localization completes the translations, you must repeat this same process in the respective article folders for the EN and ES versions, modifying the information according to the specific language.
 

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -40606,6 +40606,21 @@
             },
             {
               "name": {
+                "en": "Catalog Search inconsistencies may not return products due to an indexing issue",
+                "es": "Es posible que la búsqueda en el catálogo no devuelva los productos debido a un problema de indexación.",
+                "pt": "As inconsistências da Pesquisa de catálogo podem não retornar produtos devido a um problema de indexação"
+              },
+              "slug": {
+                "en": "catalog-search-inconsistencies-may-not-return-products-due-to-an-indexing-issue",
+                "es": "es-posible-que-la-busqueda-en-el-catalogo-no-devuelva-los-productos-debido-a-un-problema-de-indexacion",
+                "pt": "as-inconsistencias-da-pesquisa-de-catalogo-podem-nao-retornar-produtos-devido-a-um-problema-de-indexacao"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
                 "en": "Catalog Select brand in catalog doesn't work",
                 "es": "Catálogo Seleccionar marca en catálogo no funciona",
                 "pt": "Catalog Selecionar marca no catálogo não funciona"


### PR DESCRIPTION
## Summary

Updates image URL references in README.md to use Statically CDN (cdn.statically.io/gh) instead of raw GitHub URLs (raw.githubusercontent.com) for better performance and reliability.

## Changes

- Updated image URL template in README.md documentation
- Updated example image URL to use CDN

## Why

Using a CDN provides better performance, caching, and reliability compared to raw GitHub URLs.