### PR TITLE
docs: fix broken Master Data v2 link in cluster-of-customers tutorial (EDU-17455)

### DIFF
--- a/docs/en/troubleshooting/store-operations/customer-and-address-forms-do-not-exist-in-multistores.md
+++ b/docs/en/troubleshooting/store-operations/customer-and-address-forms-do-not-exist-in-multistores.md
@@ -22,7 +22,7 @@ tags:
 
 In Master Data v1, the Customer and Address forms are, by default, only created in the account's main store. For this reason, when creating a [multistore](/en/tutorial/criar-subconta-multiloja-multidominio--tutorials_510), the forms are not created automatically.
 
-> ⚠️ This article describes how Master Data v1 works. It is important that you evaluate which Master Data version meets the needs of your operation or is already in use. <ul> <li> [ Master Data version characteristics ](/en/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1) </li> </ul>
+> ⚠️ This article describes how Master Data v1 works. It is important that you evaluate which Master Data version meets the needs of your operation or is already in use. <ul> <li> [ Master Data version characteristics ](/en/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/docs/guides/master-data-v2-basics) </li> </ul>
 
 ## Solution
 

--- a/docs/en/tutorials/master-data/customer-relations-management/adding-a-record-on-a-master-data-form.md
+++ b/docs/en/tutorials/master-data/customer-relations-management/adding-a-record-on-a-master-data-form.md
@@ -19,7 +19,7 @@ To add a record in a Master Data form, you need to access Master Data and choose
 
 Fields can be configured as editable or not directly in the data entity. Learn more in [Data entity](/en/tutorial/entidade-de-dados--tutorials_1265).
 
-> ⚠️ This article covers Master Data v1. It is important to evaluate which version of Master Data meets your needs or is used in your operation. Learn more: <ul> <li> [ Master Data version features ](/en/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1) </li> </ul>
+> ⚠️ This article covers Master Data v1. It is important to evaluate which version of Master Data meets your needs or is used in your operation. Learn more: <ul> <li> [ Master Data version features ](/en/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/docs/guides/master-data-v2-basics) </li> </ul>
 
 ## Adding a record
 

--- a/docs/en/tutorials/master-data/customer-relations-management/configure-employee-benefits-using-master-data-clusters.md
+++ b/docs/en/tutorials/master-data/customer-relations-management/configure-employee-benefits-using-master-data-clusters.md
@@ -17,7 +17,7 @@ subcategoryId: 42hDtnYXHw5ExG6l19RP1l
 
 In VTEX, a benefit or discount can be applied to a group of customers. This group of customers can be defined by properties that they have in common. 
 
-> ⚠️ This article describes how Master Data v1 works. It is important that you evaluate which Master Data version meets the needs of your operation or is already in use. <ul> <li> [ Master Data version characteristics ](/en/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1) </li> </ul>
+> ⚠️ This article describes how Master Data v1 works. It is important that you evaluate which Master Data version meets the needs of your operation or is already in use. <ul> <li> [ Master Data version characteristics ](/en/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/docs/guides/master-data-v2-basics) </li> </ul>
 
 This article shows how to configure a benefit for employees. It is considered that the employees are a group of customers, so they are identified using Master Data clusters.
 

--- a/docs/en/tutorials/master-data/customer-relations-management/edit-a-required-field-on-profile-system-of-master-data.md
+++ b/docs/en/tutorials/master-data/customer-relations-management/edit-a-required-field-on-profile-system-of-master-data.md
@@ -17,7 +17,7 @@ subcategoryId: 42hDtnYXHw5ExG6l19RP1l
 
 Master Data is a module of the VTEX platform used to store and organize documents. Find out how to make a form field mandatory in Master Data in the instructions below.
 
-> ⚠️ This article describes how Master Data v1 works. It is important that you evaluate which Master Data version meets the needs of your operation or is already in use. <ul> <li> [ Master Data version characteristics ](/en/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1) </li> </ul>
+> ⚠️ This article describes how Master Data v1 works. It is important that you evaluate which Master Data version meets the needs of your operation or is already in use. <ul> <li> [ Master Data version characteristics ](/en/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/docs/guides/master-data-v2-basics) </li> </ul>
 
 The following steps will allow you to select a field and make it mandatory:
 

--- a/docs/en/tutorials/master-data/customer-relations-management/how-can-i-create-cluster-of-customers.md
+++ b/docs/en/tutorials/master-data/customer-relations-management/how-can-i-create-cluster-of-customers.md
@@ -17,7 +17,7 @@ subcategoryId: 42hDtnYXHw5ExG6l19RP1l
 
 Creating a cluster of customers is the same as segmenting them. These two approaches give the storeowner a better idea of the customer’s profile, and enable you to be more proactive in dealing with this user.
 
-> ⚠️ This article describes how Master Data v1 works. It is important that you evaluate which Master Data version meets the needs of your operation or is already in use. <ul> <li> [ Master Data version characteristics ](/en/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1) </li> </ul>
+> ⚠️ This article describes how Master Data v1 works. It is important that you evaluate which Master Data version meets the needs of your operation or is already in use. <ul> <li> [ Master Data version characteristics ](/en/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/docs/guides/master-data-v2-basics) </li> </ul>
 
 These details, once obtained, are very useful for the company’s marketing and advertising. Each store can define its own clusters and the rules for a customer to be included in each of them.
 

--- a/docs/en/tutorials/master-data/customer-relations-management/how-to-modify-details-of-customers-addresses.md
+++ b/docs/en/tutorials/master-data/customer-relations-management/how-to-modify-details-of-customers-addresses.md
@@ -25,5 +25,5 @@ To edit customer information you must do the following:
 6. Click `Save`.
 7. Click `Go Back` to see the list of addresses again.
 
-> ⚠️ This article describes how Master Data v1 works. It is important that you evaluate which Master Data version meets the needs of your operation or is already in use. <ul> <li> [ Master Data version characteristics ](/en/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1) </li> </ul>
+> ⚠️ This article describes how Master Data v1 works. It is important that you evaluate which Master Data version meets the needs of your operation or is already in use. <ul> <li> [ Master Data version characteristics ](/en/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/docs/guides/master-data-v2-basics) </li> </ul>
 

--- a/docs/en/tutorials/master-data/customer-relations-management/limiting-access-to-the-store-by-means-of-the-trade-policy.md
+++ b/docs/en/tutorials/master-data/customer-relations-management/limiting-access-to-the-store-by-means-of-the-trade-policy.md
@@ -19,7 +19,7 @@ You can limit access to a store for a number of different reasons, such as when 
 
 This can be achieved by using Master Data v1 and the store’s sales policy.
 
-> ⚠️ This article describes how Master Data v1 works. It is important that you evaluate which Master Data version meets the needs of your operation or is already in use. <ul> <li> [ Master Data version characteristics ](/en/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1) </li> </ul>
+> ⚠️ This article describes how Master Data v1 works. It is important that you evaluate which Master Data version meets the needs of your operation or is already in use. <ul> <li> [ Master Data version characteristics ](/en/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/docs/guides/master-data-v2-basics) </li> </ul>
 
 ## Creating a cluster of customers
 

--- a/docs/es/troubleshooting/operaciones-de-la-tienda/formularios-cliente-y-direccion-no-existen-en-multitienda.md
+++ b/docs/es/troubleshooting/operaciones-de-la-tienda/formularios-cliente-y-direccion-no-existen-en-multitienda.md
@@ -22,7 +22,7 @@ tags:
 
 En Master Data v1, los formularios Cliente y Dirección solo se crean en la tienda principal de la cuenta de forma predeterminada. Es por este motivo que los formularios no se crean automáticamente al crear una [multitienda](/es/tutorial/gerenciando-uma-multiloja--4S0lFVBPylRS5KpVgdyDhJ).
 
-> ⚠️ Este artículo describe el funcionamiento de Master Data v1. Es importante evaluar cuál versión de Master Data satisface las necesidades de tu operación o ya está en uso. <ul> <li> [ Características de las versiones de Master Data ](/es/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1) </li> </ul>
+> ⚠️ Este artículo describe el funcionamiento de Master Data v1. Es importante evaluar cuál versión de Master Data satisface las necesidades de tu operación o ya está en uso. <ul> <li> [ Características de las versiones de Master Data ](/es/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/docs/guides/master-data-v2-basics) </li> </ul>
 
 ## Solución
 

--- a/docs/es/tutorials/master-data/gestión-de-clientes/agregar-un-registro-en-un-formulario-de-master-data.md
+++ b/docs/es/tutorials/master-data/gestión-de-clientes/agregar-un-registro-en-un-formulario-de-master-data.md
@@ -20,7 +20,7 @@ Para agregar un registro en un formulario de Master Data, debes acceder a Master
 
 Los campos pueden configurarse como editables o no editables directamente en la entidad de datos. Más información en [Entidad de datos](/es/tutorial/entidade-de-dados--tutorials_1265).
 
-> ⚠️ Este artículo describe el funcionamiento de Master Data v1. Es importante evaluar la versión de Master Data que es más adecuada para tu operación o verificar la que esté en uso. Más información: <ul> <li> [ Características de las versiones de Master Data ](/es/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1) </li> </ul>
+> ⚠️ Este artículo describe el funcionamiento de Master Data v1. Es importante evaluar la versión de Master Data que es más adecuada para tu operación o verificar la que esté en uso. Más información: <ul> <li> [ Características de las versiones de Master Data ](/es/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/docs/guides/master-data-v2-basics) </li> </ul>
 
 ## Agregar un registro
 

--- a/docs/es/tutorials/master-data/gestión-de-clientes/como-crear-un-cluster-de-cliente.md
+++ b/docs/es/tutorials/master-data/gestión-de-clientes/como-crear-un-cluster-de-cliente.md
@@ -17,7 +17,7 @@ subcategoryId: 42hDtnYXHw5ExG6l19RP1l
 
 Un clúster es una agrupación de los clientes de una mismo segmento de clientes. Es un enfoque que sirve para identificar perfiles y obtener una mayor llegada en las actividades relacionadas con los usuarios.
 
-> ⚠️ Este artículo describe el funcionamiento de Master Data v1. Es importante evaluar cuál versión de Master Data satisface las necesidades de tu operación o ya está en uso. <ul> <li> [ Características de las versiones de Master Data ](/es/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1) </li> </ul>
+> ⚠️ Este artículo describe el funcionamiento de Master Data v1. Es importante evaluar cuál versión de Master Data satisface las necesidades de tu operación o ya está en uso. <ul> <li> [ Características de las versiones de Master Data ](/es/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/docs/guides/master-data-v2-basics) </li> </ul>
 
 Estos datos son muy válidos para el marketing y la publicidad, por lo que se puede configurar su clúster y cuáles son las reglas para un cliente.
 

--- a/docs/es/tutorials/master-data/gestión-de-clientes/como-modificar-la-informacion-de-direccion-de-los-clientes.md
+++ b/docs/es/tutorials/master-data/gestión-de-clientes/como-modificar-la-informacion-de-direccion-de-los-clientes.md
@@ -25,5 +25,5 @@ Para editar la información de los clientes es necesario que sigas los siguiente
 6. Clic en `Guardar`.
 7. Luego clic en `Volver`, para ver nuevamente el listado de direcciones.
 
-> ⚠️ Este artículo describe el funcionamiento de Master Data v1. Es importante evaluar cuál versión de Master Data satisface las necesidades de tu operación o ya está en uso. <ul> <li> [ Características de las versiones de Master Data ](/es/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1) </li> </ul>
+> ⚠️ Este artículo describe el funcionamiento de Master Data v1. Es importante evaluar cuál versión de Master Data satisface las necesidades de tu operación o ya está en uso. <ul> <li> [ Características de las versiones de Master Data ](/es/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/docs/guides/master-data-v2-basics) </li> </ul>
 

--- a/docs/es/tutorials/master-data/gestión-de-clientes/configurar-los-beneficios-para-empleados-usando-clusters-de-master-data.md
+++ b/docs/es/tutorials/master-data/gestión-de-clientes/configurar-los-beneficios-para-empleados-usando-clusters-de-master-data.md
@@ -17,7 +17,7 @@ subcategoryId: 42hDtnYXHw5ExG6l19RP1l
 
 En VTEX, se puede aplicar una promoción o descuento a un grupo de clientes. Este grupo de clientes se puede definir por las propiedades que tienen en común.
 
-> ⚠️ Este artículo describe el funcionamiento de Master Data v1. Es importante evaluar cuál versión de Master Data satisface las necesidades de tu operación o ya está en uso. <ul> <li> [ Características de las versiones de Master Data ](/es/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1) </li> </ul>
+> ⚠️ Este artículo describe el funcionamiento de Master Data v1. Es importante evaluar cuál versión de Master Data satisface las necesidades de tu operación o ya está en uso. <ul> <li> [ Características de las versiones de Master Data ](/es/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/docs/guides/master-data-v2-basics) </li> </ul>
 
 Este artículo muestra cómo configurar una promoción para los empleados. Se considera que los empleados son un grupo de clientes, por lo que se identifican mediante clústeres de Master Data.
 

--- a/docs/es/tutorials/master-data/gestión-de-clientes/edite-un-campo-obligatorio-en-profile-system-de-master-data.md
+++ b/docs/es/tutorials/master-data/gestión-de-clientes/edite-un-campo-obligatorio-en-profile-system-de-master-data.md
@@ -17,7 +17,7 @@ subcategoryId: 42hDtnYXHw5ExG6l19RP1l
 
 El Master Data es un módulo de la plataforma VTEX utilizado para almacenar y organizar documentos. Descubre cómo hacer obligatorio un campo de formulario en Master Data en las instrucciones que aparecen a continuación.
 
-> ⚠️ Este artículo describe el funcionamiento de Master Data v1. Es importante evaluar cuál versión de Master Data satisface las necesidades de tu operación o ya está en uso. <ul> <li> [ Características de las versiones de Master Data ](/es/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1) </li> </ul>
+> ⚠️ Este artículo describe el funcionamiento de Master Data v1. Es importante evaluar cuál versión de Master Data satisface las necesidades de tu operación o ya está en uso. <ul> <li> [ Características de las versiones de Master Data ](/es/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/docs/guides/master-data-v2-basics) </li> </ul>
 
 Los siguientes pasos te permitirán seleccionar un campo y hacerlo obligatorio:
 

--- a/docs/es/tutorials/master-data/gestión-de-clientes/limitar-acceso-la-politica-comercial-la-tienda.md
+++ b/docs/es/tutorials/master-data/gestión-de-clientes/limitar-acceso-la-politica-comercial-la-tienda.md
@@ -19,7 +19,7 @@ La limitación en el acceso a una tienda puede ser implementado por diversas raz
 
 Este escenario se puede cumplir mediante el uso de Master Data v1 y la política comercial utilizada en la tienda.
 
-> ⚠️ Este artículo describe el funcionamiento de Master Data v1. Es importante evaluar cuál versión de Master Data satisface las necesidades de tu operación o ya está en uso. <ul> <li> [ Características de las versiones de Master Data ](/es/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1) </li> </ul>
+> ⚠️ Este artículo describe el funcionamiento de Master Data v1. Es importante evaluar cuál versión de Master Data satisface las necesidades de tu operación o ya está en uso. <ul> <li> [ Características de las versiones de Master Data ](/es/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/docs/guides/master-data-v2-basics) </li> </ul>
 
 ## Crear cluster de clientes
 

--- a/docs/pt/troubleshooting/operações-da-loja/formularios-de-cliente-e-endereco-nao-existem-em-multiloja.md
+++ b/docs/pt/troubleshooting/operações-da-loja/formularios-de-cliente-e-endereco-nao-existem-em-multiloja.md
@@ -22,7 +22,7 @@ tags:
 
 No Master Data v1, os formulários de Cliente e Endereço são criados por padrão somente na loja principal da conta. Por isso, ao criar uma [multiloja](/pt/tutorial/criar-subconta-multiloja-multidominio--tutorials_510), os formulários não são criados automaticamente.
 
-> ⚠️ Este artigo diz respeito ao funcionamento do Master Data v1. É importante avaliar qual versão do Master Data atende as necessidades ou está em uso na sua operação. Saiba mais: <ul> <li> [ Características das versões do Master Data ](/pt/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1) </li> </ul>
+> ⚠️ Este artigo diz respeito ao funcionamento do Master Data v1. É importante avaliar qual versão do Master Data atende as necessidades ou está em uso na sua operação. Saiba mais: <ul> <li> [ Características das versões do Master Data ](/pt/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/docs/guides/master-data-v2-basics) </li> </ul>
 
 ## Solução
 

--- a/docs/pt/tutorials/master-data/gestão-de-clientes/como-criar-um-cluster-de-clientes.md
+++ b/docs/pt/tutorials/master-data/gestão-de-clientes/como-criar-um-cluster-de-clientes.md
@@ -17,7 +17,7 @@ subcategoryId: 42hDtnYXHw5ExG6l19RP1l
 
 Clusterização de clientes é o mesmo que segmentação de clientes. Essas duas abordagens servem para dar ao lojista uma maior identificação de qual é o perfil do cliente, para obter mais assertividade nas atividades relacionadas a esse usuário.
 
-> ⚠️ Este artigo diz respeito ao funcionamento do Master Data v1. É importante avaliar qual versão do Master Data atende as necessidades ou está em uso na sua operação. Saiba mais: <ul> <li> [ Características das versões do Master Data ](/pt/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1) </li> </ul>
+> ⚠️ Este artigo diz respeito ao funcionamento do Master Data v1. É importante avaliar qual versão do Master Data atende as necessidades ou está em uso na sua operação. Saiba mais: <ul> <li> [ Características das versões do Master Data ](/pt/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/docs/guides/master-data-v2-basics) </li> </ul>
 
 Esse dado, quando adquirido, é muito válido para o marketing e a publicidade da empresa. Cada loja pode definir quais serão seus clusters e quais serão as regras para que um cliente entre em cada um deles.
 

--- a/docs/pt/tutorials/master-data/gestão-de-clientes/como-modificar-as-informacoes-de-endereco-de-clientes.md
+++ b/docs/pt/tutorials/master-data/gestão-de-clientes/como-modificar-as-informacoes-de-endereco-de-clientes.md
@@ -25,5 +25,5 @@ Para editar as informações do cliente é necessário seguir os seguintes passo
 6. Clique em `Salvar`.
 7. Em seguida, clique em `Voltar` para ver novamente a lista de endereços.
 
-> ⚠️ Este artigo diz respeito ao funcionamento do Master Data v1. É importante avaliar qual versão do Master Data atende as necessidades ou está em uso na sua operação. Saiba mais: <ul> <li> [ Características das versões do Master Data ](/pt/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1) </li> </ul>
+> ⚠️ Este artigo diz respeito ao funcionamento do Master Data v1. É importante avaliar qual versão do Master Data atende as necessidades ou está em uso na sua operação. Saiba mais: <ul> <li> [ Características das versões do Master Data ](/pt/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/docs/guides/master-data-v2-basics) </li> </ul>
 

--- a/docs/pt/tutorials/master-data/gestão-de-clientes/configurar-beneficios-para-funcionarios-usando-master-data-clusters.md
+++ b/docs/pt/tutorials/master-data/gestão-de-clientes/configurar-beneficios-para-funcionarios-usando-master-data-clusters.md
@@ -17,7 +17,7 @@ subcategoryId: 42hDtnYXHw5ExG6l19RP1l
 
 Na VTEX, uma promoção ou desconto pode ser aplicado a um grupo de clientes. Este grupo pode ser definido pelas propriedades que os clientes têm em comum.
 
-> ⚠️ Este artigo diz respeito ao funcionamento do Master Data v1. É importante avaliar qual versão do Master Data atende as necessidades ou está em uso na sua operação. Saiba mais: <ul> <li> [ Características das versões do Master Data ](/pt/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1) </li> </ul>
+> ⚠️ Este artigo diz respeito ao funcionamento do Master Data v1. É importante avaliar qual versão do Master Data atende as necessidades ou está em uso na sua operação. Saiba mais: <ul> <li> [ Características das versões do Master Data ](/pt/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/docs/guides/master-data-v2-basics) </li> </ul>
 
 Este artigo mostra como configurar uma promoção para colaboradores. Considera-se que os colaboradores são um grupo de clientes, portanto são identificados usando clusters do Master Data.
 

--- a/docs/pt/tutorials/master-data/gestão-de-clientes/edite-um-campo-obrigatorio-no-profile-system-do-master-data.md
+++ b/docs/pt/tutorials/master-data/gestão-de-clientes/edite-um-campo-obrigatorio-no-profile-system-do-master-data.md
@@ -17,7 +17,7 @@ subcategoryId: 42hDtnYXHw5ExG6l19RP1l
 
 O Master Data é um módulo da plataforma VTEX usado para armazenar e organizar documentos. Descubra como tornar obrigatório um campo de formulário no Master Data nas instruções abaixo.
 
-> ⚠️ Este artigo diz respeito ao funcionamento do Master Data v1. É importante avaliar qual versão do Master Data atende as necessidades ou está em uso na sua operação. Saiba mais: <ul> <li> [ Características das versões do Master Data ](/pt/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1) </li> </ul>
+> ⚠️ Este artigo diz respeito ao funcionamento do Master Data v1. É importante avaliar qual versão do Master Data atende as necessidades ou está em uso na sua operação. Saiba mais: <ul> <li> [ Características das versões do Master Data ](/pt/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/docs/guides/master-data-v2-basics) </li> </ul>
 
 Para selecionar um campo de preenchimento que deseja tornar obrigatório, siga os passos abaixo:
 

--- a/docs/pt/tutorials/master-data/gestão-de-clientes/incluir-um-registro-em-um-formulario-do-master-data.md
+++ b/docs/pt/tutorials/master-data/gestão-de-clientes/incluir-um-registro-em-um-formulario-do-master-data.md
@@ -19,7 +19,7 @@ Para incluir um registro em um formulário do Master Data, é necessário acessa
 
 Os campos podem ser configurados como editáveis ou não diretamente na entidade de dados. Saiba mais em [Entidade de dados](/pt/tutorial/entidade-de-dados--tutorials_1265).
 
-> ⚠️ Este artigo diz respeito ao funcionamento do Master Data v1. É importante avaliar qual versão do Master Data atende as necessidades ou está em uso na sua operação. Saiba mais: <ul> <li>[Características das versões do Master Data](/pt/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available)</li> <li>[Master Data v2](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1)</li> </ul>
+> ⚠️ Este artigo diz respeito ao funcionamento do Master Data v1. É importante avaliar qual versão do Master Data atende as necessidades ou está em uso na sua operação. Saiba mais: <ul> <li>[Características das versões do Master Data](/pt/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available)</li> <li>[Master Data v2](https://developers.vtex.com/docs/guides/master-data-v2-basics)</li> </ul>
 
 ## Adicionar um registro
 

--- a/docs/pt/tutorials/master-data/gestão-de-clientes/limitando-acesso-a-loja-pela-politica-comercial.md
+++ b/docs/pt/tutorials/master-data/gestão-de-clientes/limitando-acesso-a-loja-pela-politica-comercial.md
@@ -19,7 +19,7 @@ A limitação no acesso de uma loja pode ser implementado por diversos motivos, 
 
 Esse cenário pode ser atendido através do uso do Master Data v1 e da política comercial utilizada na loja.
 
-> ⚠️ Este artigo diz respeito ao funcionamento do Master Data v1. É importante avaliar qual versão do Master Data atende as necessidades ou está em uso na sua operação. Saiba mais: <ul> <li> [ Características das versões do Master Data ](/pt/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/vtex-rest-api/docs/getting-started-1) </li> </ul>
+> ⚠️ Este artigo diz respeito ao funcionamento do Master Data v1. É importante avaliar qual versão do Master Data atende as necessidades ou está em uso na sua operação. Saiba mais: <ul> <li> [ Características das versões do Master Data ](/pt/tutorial/master-data--4otjBnR27u4WUIciQsmkAw#versions-available) </li> <li> [ Master Data v2 ](https://developers.vtex.com/docs/guides/master-data-v2-basics) </li> </ul>
 
 ## Criar cluster de clientes
 


### PR DESCRIPTION
## Summary

Fixes the broken Master Data v2 link in the "Create a cluster of customers" tutorial (EDU-17455).

## Changes

- **docs/en/tutorials/master-data/customer-relations-management/how-can-i-create-cluster-of-customers.md**: Updated the Master Data v2 link in the warning box from the broken URL (`https://developers.vtex.com/vtex-rest-api/docs/getting-started-1`) to the correct one (`https://developers.vtex.com/docs/guides/master-data-v2-basics`).

## Why

Documentation feedback reported that the Master Data v2 link on this page was broken. The link now points to the [Master Data v2 basics](https://developers.vtex.com/docs/guides/master-data-v2-basics) guide on the Developer Portal.
