### PR TITLE
docs: add Master Data article to navigation under Master Data basics

### DIFF
--- a/docs/en/tutorials/master-data/master-data-basics/master-data.md
+++ b/docs/en/tutorials/master-data/master-data-basics/master-data.md
@@ -1,7 +1,7 @@
 ---
 title: 'Master Data'
 id: 4otjBnR27u4WUIciQsmkAw
-status: CHANGED
+status: PUBLISHED
 createdAt: 2018-04-02T19:01:38.026Z
 updatedAt: 2025-09-02T23:26:45.478Z
 publishedAt: 2025-08-29T14:19:54.707Z

--- a/docs/es/tutorials/master-data/conceptos-básicos-de-master-data/master-data.md
+++ b/docs/es/tutorials/master-data/conceptos-básicos-de-master-data/master-data.md
@@ -1,7 +1,7 @@
 ---
 title: 'Master Data'
 id: 4otjBnR27u4WUIciQsmkAw
-status: CHANGED
+status: PUBLISHED
 createdAt: 2018-04-02T19:01:38.026Z
 updatedAt: 2025-09-02T23:26:45.478Z
 publishedAt: 2025-08-29T14:19:54.707Z

--- a/docs/pt/tutorials/master-data/conceitos-básicos-do-master-data/master-data.md
+++ b/docs/pt/tutorials/master-data/conceitos-básicos-do-master-data/master-data.md
@@ -1,7 +1,7 @@
 ---
 title: 'Master Data'
 id: 4otjBnR27u4WUIciQsmkAw
-status: CHANGED
+status: PUBLISHED
 createdAt: 2018-04-02T19:01:38.026Z
 updatedAt: 2025-09-02T23:26:45.478Z
 publishedAt: 2025-08-29T14:19:54.707Z

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -25094,6 +25094,21 @@
               "children": [
                 {
                   "name": {
+                    "en": "Master Data",
+                    "es": "Master Data",
+                    "pt": "Master Data"
+                  },
+                  "slug": {
+                    "en": "master-data",
+                    "es": "master-data",
+                    "pt": "master-data"
+                  },
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                },
+                {
+                  "name": {
                     "en": "Data entity",
                     "es": "Entidad de datos",
                     "pt": "Entidade de dados"

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -25106,6 +25106,21 @@
                   "origin": "",
                   "type": "markdown",
                   "children": []
+                },
+                {
+                  "name": {
+                    "en": "Master Data",
+                    "es": "Master Data",
+                    "pt": "Master Data"
+                  },
+                  "slug": {
+                    "en": "master-data",
+                    "es": "master-data",
+                    "pt": "master-data"
+                  },
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
                 }
               ]
             },

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -25094,21 +25094,6 @@
               "children": [
                 {
                   "name": {
-                    "en": "Master Data",
-                    "es": "Master Data",
-                    "pt": "Master Data"
-                  },
-                  "slug": {
-                    "en": "master-data",
-                    "es": "master-data",
-                    "pt": "master-data"
-                  },
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": {
                     "en": "Data entity",
                     "es": "Entidad de datos",
                     "pt": "Entidade de dados"


### PR DESCRIPTION
Adds the Master Data overview article to the help center navigation under the Master Data basics subcategory.

## Changes

- **public/navigation.json**: New "Master Data" entry as the first item under "Master Data basics", before "Data entity". Uses slug `master-data` for en, es, and pt.

