### PR TITLE
EDU-17260 | Update Marketplace In data model

### DIFF
--- a/docs/en/tutorials/beta/vtex-data-pipeline-beta/marketplace-in-data-pipeline.md
+++ b/docs/en/tutorials/beta/vtex-data-pipeline-beta/marketplace-in-data-pipeline.md
@@ -3,7 +3,7 @@ title: 'Marketplace in Data Pipeline'
 id: 4L3hlSqsnxGqVyxmoYvjTV
 status: PUBLISHED
 createdAt: 2024-11-22T18:54:14.211Z
-updatedAt: 2025-03-07T11:30:02.324Z
+updatedAt: 2025-02-11T12:01:02.324Z
 publishedAt: 2025-03-07T11:30:02.324Z
 firstPublishedAt: 2024-11-22T20:13:33.475Z
 contentType: tutorial
@@ -16,6 +16,7 @@ subcategoryId: oMrzcOMVbBpH0reeMFHFg
 ---
 
 The `marketplace_in` dataset contains historical information regarding every seller of a marketplace, and its most important information, such as orders and inventory.  
+Only the `sellers_latest` table includes all sellers (External Sellers, Seller Portal, and VTEX Sellers). The other tables only include data for Seller Portal sellers.  
 
 This section includes the following information:  
 
@@ -23,7 +24,10 @@ This section includes the following information:
 - [Table: sellers_latest](#table-sellers-latest)  
 - [Table: sellers_inventory](#table-sellers-inventory)
 - [Table: sellers_pricing](#table-sellers-pricing)  
+- [Table: sellers_promotions](#table-sellers-promotions)  
 - [Table: sellers_orders](#table-sellers-orders)  
+- [Table: sellers_orders_items](#table-sellers-orders-items)  
+- [Table: sellers_orders_rateandbenefitsidentifiers](#table-sellers-orders-rateandbenefitsidentifiers)  
 - [Analyses with Marketplace in](#analyses-with-marketplace-in)  
 - [Correlations with other data](#correlations-with-other-data)  
 
@@ -33,7 +37,7 @@ This section includes the following information:
 |:-----:|:---:|
 | Data source | Obtained from the marketplace module. |
 | Availability| VTEX Admin.|
-| History| The data history starts in September 2024. For clients already using the VTEX platform, data is retained for two years starting in 2024. |
+| History| The data history starts in September 2024. The data is retained for two years starting in 2024. |
 | Minimum update interval| One hour.|
 
 ## Table: sellers_latest
@@ -53,7 +57,7 @@ The table fields are described below:
 | trust_policy| character varying(50)| Trust policy used by the seller. |
 | sales_channels| character varying(65535)| The seller's sales channels.|
 | integration| character varying(50)| The name of the integration used by the seller.|
-| integration_type | character varying(25) | Integrations are classified as: VTEX Seller, VTEX Seller Portal, External Seller, Not Configured.|
+| integration_type | character varying(25) | Integrations are classified as: VTEX Seller: The seller is another VTEX account. VTEX Seller Portal: The seller uses the VTEX Seller Portal. External Seller: The seller uses an external connection not related to VTEX. Not Configured: The seller has not configured integration yet.|
 | created_at | timestamp without time zone| The timestamp of the seller creation. |
 | updated_at| timestamp without time zone | The timestamp of the last time the seller was updated.|
 | batch_id| character(13)| The ID of the batch where this data arrived. Allows you to know when this data was delivered.|
@@ -134,11 +138,75 @@ The table fields are described below:
 | value | double precision | Total monetary value of the order. It may include taxes, discounts, and shipping costs.|
 | is_completed | boolean| Specifies whether the order was completed.|
 | status| character varying(16383)| Current status of the order, such as __pending, shipped,__ __or invoiced.__|
-| order_date| timestamp without time zone | Date and time when the order was placed.|
-| payment_method| character varying(100)| Payment method used to purchase the order.|
-| shipping_cost| double precision| Cost of shipping for the order.|
-| item_ids| character varying(1000)| List of items in the order.|
-| batch_id| character(13)| The ID of the batch where this data arrived. Allows you to know when this data was delivered.|
+| sales_channel | character varying(16383) | Sales channel where the order was placed (online store, physical store, etc.).|
+| marketplace_name | character varying(16383) | Name of the marketplace associated with the order.|
+| creation_date | timestamp with time zone | Date and time when the order was created, including time zone.|
+| authorized_date | timestamp with time zone | Date and time when the order was authorized.|
+| invoiced_date | timestamp with time zone | Date and time when the order invoice was issued.|
+| last_change | timestamp with time zone | Date and time of the last order update.|
+| shippingdata_address_city | character varying(65535) | Order shipping city.|
+| shippingdata_address_state | character varying(65535) | Order shipping state.|
+| shippingdata_address_country | character varying(65535) | Order shipping country.|
+
+## Table: sellers_orders_items
+
+The *sellers_orders_items* table stores details of items in orders placed by VTEX Seller Portal sellers. The table fields are described below:
+
+|**Column name** | **Column type** | **Column description**|
+|:---:|:---:|:---:|
+|item_id | character varying(65535) | Unique item identifier within the order. It can be associated with the sellers_inventory table for additional details.|
+|product_id | character varying(65535) | Identifier of the product associated with the item.|
+|order_id | character varying(16383) | Unique order identifier. It can be associated with the order tables for additional details.|
+|seller_id | character varying | Seller identifier in `sellers_latest`.|
+|main_account | character varying | Main account associated with the seller.|
+|hostname | character varying(16383) | Host name associated with the order, indicating the server or domain managing the order.|
+|marketplace_name | character varying(16383) | Marketplace name where the order was placed.|
+|seller_integration_type | character varying | Seller integration type. In this table, it is always 'VTEX Seller Portal'.|
+|seller_is_active | boolean | Indicates whether the seller is currently active.|
+|status | character varying(16383) | Current order status.|
+|tax | double precision | Tax value applied to the item (converted from cents to currency units).|
+|quantity | integer | Quantity of the product in the order.|
+|seller | character varying(65535) | Identifier or name of the seller for the product as recorded in the order.|
+|sellersku | character varying(65535) | Product SKU as listed by the seller.|
+|pricevaliduntil | timestamp with time zone | Date and time until the product price is valid.|
+|name | character varying(65535) | Product name.|
+|additionalinfo_brandname | character varying(65535) | Product brand.|
+|additionalinfo_brandid | character varying(65535) | Product brand identifier.|
+|additionalinfo_categoriesid | character varying(65535) | Identifiers of categories associated with the product.|
+|additionalinfo_dimension_cubicweight | double precision | Product cubic weight for shipping.|
+|additionalinfo_dimension_height | double precision | Product height.|
+|additionalinfo_dimension_length | double precision | Product length.|
+|additionalinfo_dimension_weight | double precision | Product weight.|
+|additionalinfo_dimension_width | double precision | Product width.|
+|price | double precision | Product price (converted from cents to currency units).|
+|pricetags | super | Price tags associated with the product, including discounts and offers.|
+|sellingprice | double precision | Product selling price (converted from cents to currency units).|
+|listprice | double precision | Product list price (converted from cents to currency units).|
+|imageurl | character varying(65535) | Product image URL.|
+|measurementunit | character varying(65535) | Product measurement unit.|
+|unitmultiplier | double precision | Product unit multiplier used in price and quantity calculations.|
+|creationdate | timestamp with time zone | Date and time when the order was created, including time zone.|
+|lastchange | timestamp with time zone | Date and time of the last order update.|
+|batch_id | character varying(13) | Identifier used when data is loaded for ingestion quality control.|
+|uniqueid | character varying(65535) | Unique item identifier that can be used to relate this row to other tables.|
+
+## Table: sellers_orders_rateandbenefitsidentifiers
+
+The *sellers_orders_rateandbenefitsidentifiers* table contains data about promotions applied to seller orders. The table fields are described below:
+
+|**Column name** | **Column type** | **Column description**|
+|:---:|:---:|:---:|
+|orderid | character varying(16383) | Unique identifier of each order.|
+|hostname | character varying(16383) | Host name associated with the order, indicating the server or domain managing the order.|
+|marketplace_name | character varying(16383) | Marketplace name associated with the order.|
+|creationdate | timestamp with time zone | Date and time when the order was created, including time zone.|
+|lastchange | timestamp with time zone | Date and time of the last order update, reflecting the most recent status or content.|
+|status | character varying(16383) | Current order status.|
+|rateandbenefitsidentifiers_id | character varying(65535) | Unique identifier of the rate and benefits identifiers associated with the order.|
+|rateandbenefitsidentifiers_name | character varying(65535) | Name of the rate and benefits identifiers, identifying the promotion or surcharge.|
+|rateandbenefitsidentifiers_featured | boolean | Indicates whether the rate and benefits identifiers are featured or have any special attribute.|
+|rateandbenefitsidentifiers_description | character varying(65535) | Detailed description of the rate and benefits identifiers and their benefits.|
+|batch_id | character varying(13) | Identifier used when data is loaded into the table for ingestion quality control.|
 
 ## Analyses with Marketplace in
 
@@ -154,12 +222,12 @@ Marketplace in data is closely tied to order data, providing a deeper analysis o
 
 ### Discover other Datasets
 
-[Inventory](/en/docs/tutorials/inventory-data-pipeline-beta)  
-[Navigation](/en/docs/tutorials/navigation-data-pipeline)  
-[Payments](/en/docs/tutorials/payments)  
-[Orders](/en/docs/tutorials/orders-data-pipeline-beta)  
-[Prices](/en/docs/tutorials/prices-data-pipeline-beta)  
-[Promotions](/en/docs/tutorials/promotions)  
-[Gift Cards](/en/docs/tutorials/gift-card-data-pipeline)  
-[Bridge Logs](/en/docs/tutorials/bridge-logs-data-pipeline)
-
+- [Catalog](/en/docs/tutorials/catalog-data-pipeline)
+- [Inventory](/en/docs/tutorials/inventory-data-pipeline-beta)  
+- [Navigation](/en/docs/tutorials/navigation-data-pipeline)  
+- [Payments](/en/docs/tutorials/payments)  
+- [Orders](/en/docs/tutorials/orders-data-pipeline-beta)  
+- [Prices](/en/docs/tutorials/prices-data-pipeline-beta)  
+- [Promotions](/en/docs/tutorials/promotions)  
+- [Gift Cards](/en/docs/tutorials/gift-card-data-pipeline)  
+- [Bridge Logs](/en/docs/tutorials/bridge-logs-data-pipeline)

--- a/docs/en/tutorials/beta/vtex-data-pipeline-beta/marketplace-in-data-pipeline.md
+++ b/docs/en/tutorials/beta/vtex-data-pipeline-beta/marketplace-in-data-pipeline.md
@@ -205,7 +205,7 @@ The *sellers_orders_rateandbenefitsidentifiers* table contains data about promot
 |rateandbenefitsidentifiers_id | character varying(65535) | Unique identifier of the rate and benefits identifiers associated with the order.|
 |rateandbenefitsidentifiers_name | character varying(65535) | Name of the rate and benefits identifiers, identifying the promotion or surcharge.|
 |rateandbenefitsidentifiers_featured | boolean | Indicates whether the rate and benefits identifiers are featured or have any special attribute.|
-|rateandbenefitsidentifiers_description | character varying(65535) | Detailed description of the rate and benefits identifiers and their benefits.|
+|rateandbenefitidentifiers_description | character varying(65535) | Detailed description of the rate and benefit identifiers and their benefits.|
 |batch_id | character varying(13) | Identifier used when data is loaded into the table for ingestion quality control.|
 
 ## Analyses with Marketplace in

--- a/docs/en/tutorials/beta/vtex-data-pipeline-beta/marketplace-in-data-pipeline.md
+++ b/docs/en/tutorials/beta/vtex-data-pipeline-beta/marketplace-in-data-pipeline.md
@@ -57,7 +57,7 @@ The table fields are described below:
 | trust_policy| character varying(50)| Trust policy used by the seller. |
 | sales_channels| character varying(65535)| The seller's sales channels.|
 | integration| character varying(50)| The name of the integration used by the seller.|
-| integration_type | character varying(25) | Integrations are classified as: VTEX Seller: The seller is another VTEX account. VTEX Seller Portal: The seller uses the VTEX Seller Portal. External Seller: The seller uses an external connection not related to VTEX. Not Configured: The seller has not configured integration yet.|
+| integration_type | character varying(25) | Integrations are classified as: VTEX Seller: The seller is another VTEX account. VTEX Seller Portal: The seller uses the VTEX Seller Portal. External Seller: The seller uses an external connection not related to VTEX. Not Configured: The seller has not configured an integration yet. |
 | created_at | timestamp without time zone| The timestamp of the seller creation. |
 | updated_at| timestamp without time zone | The timestamp of the last time the seller was updated.|
 | batch_id| character(13)| The ID of the batch where this data arrived. Allows you to know when this data was delivered.|

--- a/docs/es/tutorials/beta/vtex-data-pipeline-beta/marketplace-in-data-pipeline.md
+++ b/docs/es/tutorials/beta/vtex-data-pipeline-beta/marketplace-in-data-pipeline.md
@@ -3,7 +3,7 @@ title: 'Marketplace in Data Pipeline'
 id: 4L3hlSqsnxGqVyxmoYvjTV
 status: PUBLISHED
 createdAt: 2024-11-22T18:54:14.211Z
-updatedAt: 2025-03-07T11:30:02.324Z
+updatedAt: 2025-02-11T12:01:02.324Z
 publishedAt: 2025-03-07T11:30:02.324Z
 firstPublishedAt: 2024-11-22T20:13:33.475Z
 contentType: tutorial
@@ -16,6 +16,7 @@ subcategoryId: oMrzcOMVbBpH0reeMFHFg
 ---
 
 El conjunto de datos `marketplace_in` contiene información histórica sobre cada vendedor de un marketplace, incluyendo su información más importante, como pedidos e inventario.
+Solo la tabla `sellers_latest` incluye todos los vendedores (Sellers externos, Seller Portal y VTEX Sellers). Las demás tablas incluyen datos solo de vendedores del Seller Portal.
 
 Esta sección incluye la siguiente información:
 
@@ -23,9 +24,12 @@ Esta sección incluye la siguiente información:
 - [Tabla: sellers_latest](#tabla-sellers-latest)  
 - [Tabla: sellers_inventory](#tabla-sellers-inventory)  
 - [Tabla: sellers_pricing](#tabla-sellers-pricing)  
+- [Tabla: sellers_promotions](#tabla-sellers-promotions)  
 - [Tabla: sellers_orders](#tabla-sellers-orders)  
+- [Tabla: sellers_orders_items](#tabla-sellers-orders-items)  
+- [Tabla: sellers_orders_rateandbenefitsidentifiers](#tabla-sellers-orders-rateandbenefitsidentifiers)  
 - [Análisis con Marketplace in](#analisis-con-marketplace-in)  
-- [Correlaciones con otros datos](#correlacioines-con-otros-datos)  
+- [Correlaciones con otros datos](#correlaciones-con-otros-datos)  
 
 ## Características de los Datos
 
@@ -135,6 +139,7 @@ Los campos de la tabla se describen a continuación:
 |is_completed|boolean|Especifica si el pedido fue completado.|
 |status|character varying(16383)|Estado actual del pedido, como 'pendiente', 'enviado' o 'facturado'.|
 |sales_channel|character varying(16383)|Canal de ventas a través del cual se realizó el pedido (tienda online, tienda física, etc.).|
+|marketplace_name|character varying(16383)|Nombre del marketplace asociado al pedido.|
 |creation_date|timestamp con zona horaria|Fecha y hora de la creación del pedido, incluyendo la zona horaria.|
 |authorized_date|timestamp con zona horaria|Fecha y hora de autorización del pedido.|
 |invoiced_date|timestamp con zona horaria|Fecha y hora de emisión de la factura del pedido.|
@@ -142,6 +147,66 @@ Los campos de la tabla se describen a continuación:
 |shippingdata_address_city|character varying(65535)|Ciudad de envío del pedido.|
 |shippingdata_address_state|character varying(65535)|Estado de envío del pedido.|
 |shippingdata_address_country|character varying(65535)|País de envío del pedido.|
+
+## Tabla: sellers_orders_items
+
+La tabla *sellers_orders_items* almacena detalles de los ítems en pedidos realizados por vendedores del VTEX Seller Portal. Los campos de la tabla se describen a continuación:
+
+|**Nombre de la Columna** | **Tipo de Columna** | **Descripción de la Columna**|
+|:---:|:---:|:---:|
+|item_id | character varying(65535) | Identificador único del ítem dentro del pedido. Puede asociarse con la tabla sellers_inventory para detalles adicionales.|
+|product_id | character varying(65535) | Identificador del producto asociado al ítem.|
+|order_id | character varying(16383) | Identificador único del pedido. Puede asociarse con las tablas de pedidos para detalles adicionales.|
+|seller_id | character varying | Identificador del vendedor en `sellers_latest`.|
+|main_account | character varying | Cuenta principal asociada al vendedor.|
+|hostname | character varying(16383) | Nombre del host asociado al pedido, que indica el servidor o dominio que gestiona el pedido.|
+|marketplace_name | character varying(16383) | Nombre del marketplace donde se realizó el pedido.|
+|seller_integration_type | character varying | Tipo de integración del vendedor. En esta tabla, siempre es 'VTEX Seller Portal'.|
+|seller_is_active | boolean | Indica si el vendedor está activo en este momento.|
+|status | character varying(16383) | Estado actual del pedido.|
+|tax | double precision | Valor de impuestos aplicado al ítem (convertido de centavos a unidades monetarias).|
+|quantity | integer | Cantidad del producto en el pedido.|
+|seller | character varying(65535) | Identificador o nombre del vendedor del producto conforme registrado en el pedido.|
+|sellersku | character varying(65535) | SKU del producto conforme listado por el vendedor.|
+|pricevaliduntil | timestamp with time zone | Fecha y hora hasta cuando el precio del producto es válido.|
+|name | character varying(65535) | Nombre del producto.|
+|additionalinfo_brandname | character varying(65535) | Marca del producto.|
+|additionalinfo_brandid | character varying(65535) | Identificador de la marca del producto.|
+|additionalinfo_categoriesid | character varying(65535) | Identificadores de categorías asociadas al producto.|
+|additionalinfo_dimension_cubicweight | double precision | Peso cúbico del producto para fines de envío.|
+|additionalinfo_dimension_height | double precision | Altura del producto.|
+|additionalinfo_dimension_length | double precision | Longitud del producto.|
+|additionalinfo_dimension_weight | double precision | Peso del producto.|
+|additionalinfo_dimension_width | double precision | Ancho del producto.|
+|price | double precision | Precio del producto (convertido de centavos a unidades monetarias).|
+|pricetags | super | Price tags asociadas al producto, incluyendo descuentos y ofertas.|
+|sellingprice | double precision | Precio de venta del producto (convertido de centavos a unidades monetarias).|
+|listprice | double precision | Precio de lista del producto (convertido de centavos a unidades monetarias).|
+|imageurl | character varying(65535) | URL de la imagen del producto.|
+|measurementunit | character varying(65535) | Unidad de medida del producto.|
+|unitmultiplier | double precision | Multiplicador de unidad del producto, usado en cálculos de precio y cantidad.|
+|creationdate | timestamp with time zone | Fecha y hora de creación del pedido, incluyendo la zona horaria.|
+|lastchange | timestamp with time zone | Fecha y hora de la última modificación al pedido.|
+|batch_id | character varying(13) | Identificador usado cuando los datos se cargan para control de calidad de la ingestión.|
+|uniqueid | character varying(65535) | Identificador único del ítem, que puede usarse para relacionar esta fila con otras tablas.|
+
+## Tabla: sellers_orders_rateandbenefitsidentifiers
+
+La tabla *sellers_orders_rateandbenefitsidentifiers* contiene datos sobre promociones aplicadas a pedidos de vendedores. Los campos de la tabla se describen a continuación:
+
+|**Nombre de la Columna** | **Tipo de Columna** | **Descripción de la Columna**|
+|:---:|:---:|:---:|
+|orderid | character varying(16383) | Identificador único de cada pedido.|
+|hostname | character varying(16383) | Nombre del host asociado al pedido, que indica el servidor o dominio que gestiona el pedido.|
+|marketplace_name | character varying(16383) | Nombre del marketplace asociado al pedido.|
+|creationdate | timestamp with time zone | Fecha y hora de creación del pedido, incluyendo la zona horaria.|
+|lastchange | timestamp with time zone | Fecha y hora de la última modificación al pedido, reflejando el estado o contenido más reciente.|
+|status | character varying(16383) | Estado actual del pedido.|
+|rateandbenefitsidentifiers_id | character varying(65535) | Identificador único de los rate and benefits identifiers asociados al pedido.|
+|rateandbenefitsidentifiers_name | character varying(65535) | Nombre de los rate and benefits identifiers, que identifica la promoción o recargo.|
+|rateandbenefitsidentifiers_featured | boolean | Indica si los rate and benefits identifiers están destacados o tienen alguna característica especial.|
+|rateandbenefitsidentifiers_description | character varying(65535) | Descripción detallada de los rate and benefits identifiers y sus beneficios.|
+|batch_id | character varying(13) | Identificador usado cuando los datos se cargan en la tabla para control de calidad de la ingestión.|
 
 ## Análisis con marketplace_in
 
@@ -165,5 +230,4 @@ Los datos de marketplace in están estrechamente relacionados con los datos de p
 - [Precios](/es/docs/tutorials/precios-data-pipeline-beta)  
 - [Promociones](/es/docs/tutorials/promociones)  
 - [Tarjetas de Regalo](/es/docs/tutorials/tarjeta-de-regalo-data-pipeline)  
-[Registros del Bridge](/es/docs/tutorials/registros-del-bridge-data-pipeline)
-
+- [Registros del Bridge](/es/docs/tutorials/registros-del-bridge-data-pipeline)

--- a/docs/es/tutorials/beta/vtex-data-pipeline-beta/marketplace-in-data-pipeline.md
+++ b/docs/es/tutorials/beta/vtex-data-pipeline-beta/marketplace-in-data-pipeline.md
@@ -205,7 +205,7 @@ La tabla *sellers_orders_rateandbenefitsidentifiers* contiene datos sobre promoc
 |rateandbenefitsidentifiers_id | character varying(65535) | Identificador único de los rate and benefits identifiers asociados al pedido.|
 |rateandbenefitsidentifiers_name | character varying(65535) | Nombre de los rate and benefits identifiers, que identifica la promoción o recargo.|
 |rateandbenefitsidentifiers_featured | boolean | Indica si los rate and benefits identifiers están destacados o tienen alguna característica especial.|
-|rateandbenefitsidentifiers_description | character varying(65535) | Descripción detallada de los rate and benefits identifiers y sus beneficios.|
+|rateandbenefitsidentifiers_description | character varying(65535) | Descripción detallada de los rate and benefit identifiers y sus beneficios.|
 |batch_id | character varying(13) | Identificador usado cuando los datos se cargan en la tabla para control de calidad de la ingestión.|
 
 ## Análisis con marketplace_in

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -40161,21 +40161,6 @@
           "children": [
             {
               "name": {
-                "en": "'Large Indexed Text' and 'Indexed Text' not being changed by Specification Import",
-                "es": "'Texto grande indexado' y 'Texto indexado' no se modifican con la importación de la especificación",
-                "pt": "'Texto Grande Indexado' e 'Texto Indexado' não sendo alterados pela Importação de Especificação"
-              },
-              "slug": {
-                "en": "large-indexed-text-and-indexed-text-not-being-changed-by-specification-import",
-                "es": "texto-grande-indexado-y-texto-indexado-no-se-modifican-con-la-importacion-de-la-especificacion",
-                "pt": "texto-grande-indexado-e-texto-indexado-nao-sendo-alterados-pela-importacao-de-especificacao"
-              },
-              "origin": "",
-              "type": "markdown",
-              "children": []
-            },
-            {
-              "name": {
                 "en": "'maximum number of eligible items for each cart' + more for less applies incorrect discount when using the same item.",
                 "es": "'número máximo de artículos elegibles para cada cesta' + más por menos aplica un descuento incorrecto al utilizar el mismo artículo.",
                 "pt": "'número máximo de itens qualificados para cada carrinho' + more for less aplica desconto incorreto ao usar o mesmo item."
@@ -40244,6 +40229,21 @@
                 "en": "url-logo-field-in-the-update-seller-request-not-updating",
                 "es": "el-campo-url-logo-en-la-solicitud-de-actualizacion-del-vendedor-no-se-actualiza",
                 "pt": "campo-url-logo-no-campo-update-seller-request-not-updating"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
+                "en": "\"Large Indexed Text\" and \"Indexed Text\" not being changed by Specification Import",
+                "es": "«Texto indexado grande» y «Texto indexado» no se modifican al importar especificaciones.",
+                "pt": "“Texto indexado grande” e “Texto indexado” não são alterados pela importação de especificações"
+              },
+              "slug": {
+                "en": "large-indexed-text-and-indexed-text-not-being-changed-by-specification-import",
+                "es": "texto-indexado-grande-y-texto-indexado-no-se-modifican-al-importar-especificaciones",
+                "pt": "texto-indexado-grande-e-texto-indexado-nao-sao-alterados-pela-importacao-de-especificacoes"
               },
               "origin": "",
               "type": "markdown",
@@ -61847,6 +61847,21 @@
                 "en": "transaction-settling-while-giftcard-payment-stuck-in-authorized-status-after-autosettle-error",
                 "es": "transaccion-liquidada-mientras-el-pago-con-giftcard-se-atasca-en-estado-autorizado-despues-de-un-error-de-autoliquidacion",
                 "pt": "liquidacao-da-transacao-enquanto-o-pagamento-com-cartaopresente-fica-preso-no-status-autorizado-apos-erro-de-liquidacao-automatica"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
+                "en": "Transaction stuck in \"Cancelling\" when payments are \"Finished\"",
+                "es": "La transacción se queda bloqueada en «Cancelando» cuando los pagos están «Finalizados».",
+                "pt": "Transação presa em “Cancelando” quando os pagamentos estão “Concluídos”"
+              },
+              "slug": {
+                "en": "transaction-stuck-in-cancelling-when-payments-are-finished",
+                "es": "la-transaccion-se-queda-bloqueada-en-cancelando-cuando-los-pagos-estan-finalizados",
+                "pt": "transacao-presa-em-cancelando-quando-os-pagamentos-estao-concluidos"
               },
               "origin": "",
               "type": "markdown",

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -40926,14 +40926,14 @@
             },
             {
               "name": {
-                "en": "Catalog Indexing Report 'Total' Section Calculation Error",
-                "es": "Error de cálculo de la sección 'total' del informe de indexación del catálogo",
-                "pt": "Erro de Cálculo da Seção 'Total' do Relatório de Indexação do Catálogo"
+                "en": "Catalog Indexing Report returning wrong stats",
+                "es": "El informe de indexación del catálogo devuelve estadísticas erróneas.",
+                "pt": "Relatório de indexação do catálogo retornando estatísticas incorretas"
               },
               "slug": {
-                "en": "catalog-indexing-report-total-section-calculation-error",
-                "es": "error-de-calculo-de-la-seccion-total-del-informe-de-indexacion-del-catalogo",
-                "pt": "erro-de-calculo-da-secao-total-do-relatorio-de-indexacao-do-catalogo"
+                "en": "catalog-indexing-report-returning-wrong-stats",
+                "es": "el-informe-de-indexacion-del-catalogo-devuelve-estadisticas-erroneas",
+                "pt": "relatorio-de-indexacao-do-catalogo-retornando-estatisticas-incorretas"
               },
               "origin": "",
               "type": "markdown",
@@ -41684,6 +41684,21 @@
                 "en": "error-leituradedadosdoadministrador-when-trying-to-access-catalog-pages-on-admin",
                 "es": "error-leituradedadosdoadministrador-al-intentar-acceder-a-las-paginas-del-catalogo-en-admin",
                 "pt": "erro-leituradedadosdoadministrador-ao-tentar-acessar-as-paginas-do-catalogo-no-admin"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
+                "es": "Error de cálculo de la sección 'total' del informe de indexación del catálogo",
+                "pt": "Erro de Cálculo da Seção 'Total' do Relatório de Indexação do Catálogo",
+                "en": "Error de cálculo de la sección 'total' del informe de indexación del catálogo"
+              },
+              "slug": {
+                "es": "error-de-calculo-de-la-seccion-total-del-informe-de-indexacion-del-catalogo",
+                "pt": "erro-de-calculo-da-secao-total-do-relatorio-de-indexacao-do-catalogo",
+                "en": ""
               },
               "origin": "",
               "type": "markdown",
@@ -58975,12 +58990,12 @@
             {
               "name": {
                 "en": "Affiliation created in subaccount not listed in Admin; ‘Affiliation name is already used’ on retry",
-                "es": "Afiliación creada en subcuenta no listada en Admin",
+                "es": "Afiliación creada en una subcuenta que no aparece en Admin; «El nombre de la afiliación ya está en uso» al volver a intentarlo.",
                 "pt": "Afiliação criada na subconta não listada no Admin"
               },
               "slug": {
                 "en": "affiliation-created-in-subaccount-not-listed-in-admin-affiliation-name-is-already-used-on-retry",
-                "es": "afiliacion-creada-en-subcuenta-no-listada-en-admin",
+                "es": "afiliacion-creada-en-una-subcuenta-que-no-aparece-en-admin-el-nombre-de-la-afiliacion-ya-esta-en-uso-al-volver-a-intentarlo",
                 "pt": "afiliacao-criada-na-subconta-nao-listada-no-admin"
               },
               "origin": "",
@@ -62110,12 +62125,12 @@
             {
               "name": {
                 "en": "Transactions stuck in \"Canceling\" and payments remain in \"Authorized\"",
-                "es": "Las transacciones se atascan en \"Cancelando\" y los pagos permanecen en \"Autorizado\".",
+                "es": "Las transacciones se quedan atascadas en «Cancelando» y los pagos permanecen en «Autorizado».",
                 "pt": "As transações ficam presas em \"Cancelando\" e os pagamentos permanecem em \"Autorizados\""
               },
               "slug": {
                 "en": "transactions-stuck-in-canceling-and-payments-remain-in-authorized",
-                "es": "las-transacciones-se-atascan-en-cancelando-y-los-pagos-permanecen-en-autorizado",
+                "es": "las-transacciones-se-quedan-atascadas-en-cancelando-y-los-pagos-permanecen-en-autorizado",
                 "pt": "as-transacoes-ficam-presas-em-cancelando-e-os-pagamentos-permanecem-em-autorizados"
               },
               "origin": "",


### PR DESCRIPTION
I've updated the marketplace_in documentation to clarify that only the sellers_latest table includes all types of sellers (external, Seller Portal, and VTEX Sellers), and that the other tables only contain Seller Portal data. I added the new sellers_orders_items and sellers_orders_rateandbenefitsidentifiers tables with their fields to the index and body; I included the marketplace_name column in the sellers_orders table with the requested type and description; and I corrected a formatting error in the creation_date row.