### PR TITLE
docs: update B2B Buyer Portal callouts to be feature-agnostic

### DIFF
--- a/docs/en/tutorials/b2b/b2b-buyer-portal/b2b-contracts.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/b2b-contracts.md
@@ -10,7 +10,7 @@ locale: en
 
 A contract establishes the commercial conditions between a B2B customer and your store. It centralizes the management of purchase agreements, defining what products buyers can access, which prices apply to them, and which payment methods they can use.
 
->⚠️ Contracts are only available for B2B Buyer Portal. Authorization from the Commerce Engineer of the account is required for usage.
+> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to select accounts.
 
 Contracts are stored in the `CL` [Master Data v1](https://help.vtex.com/en/docs/tutorials/master-data) data entity. This is the same entity that stores shopper data in B2C scenarios, but for B2B contracts, it follows specifications that enable the B2B Buyer Portal functionality.
 

--- a/docs/en/tutorials/b2b/b2b-buyer-portal/budgets-overview.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/budgets-overview.md
@@ -12,7 +12,7 @@ Budget management allows B2B organizations to plan, allocate, and track their ex
 
 A budget can be subdivided into multiple allocations, and all value movements — such as debits, credits, and refunds — update these balances according to their rules. The feature is designed to support flows in which budgets and allocations are created, balances are consumed by transactions or temporary reservations, and statements are later used to reconcile financial activity over time.
 
->⚠️ The Budgets feature is only available for B2B Buyer Portal. Authorization from the Commerce Engineer of the account is required for usage.
+> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to select accounts.
 
 ## Key concepts
 

--- a/docs/en/tutorials/b2b/b2b-buyer-portal/buyer-organization-members.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/buyer-organization-members.md
@@ -10,6 +10,8 @@ locale: en
 
 In a B2B buyer organization, members are the people who interact with the store on behalf of the organization. Their actions are determined by the roles and permissions assigned to them, and by how the organization uses **contact information** and **buyer data.** This article explains the types of members and related concepts so you can understand who can do what in your organization.
 
+> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to select accounts.
+
 ## Permission-based roles
 
 Roles define what each user can do in the storefront, including Organization Account management. Each role has a set of permissions. When you assign one or more roles to a user, they gain the combined capabilities of those roles. Permissions are enforced in the storefront so that users only see and use the features they are allowed to.

--- a/docs/es/tutorials/b2b/b2b-buyer-portal/budgets-informacion-general.md
+++ b/docs/es/tutorials/b2b/b2b-buyer-portal/budgets-informacion-general.md
@@ -12,7 +12,7 @@ La gestión de presupuestos permite a las organizaciones B2B planificar, distrib
 
 Un presupuesto puede dividirse en varias asignaciones, y cada movimiento de valores, como débitos, créditos o reembolsos, actualiza los saldos de acuerdo con sus reglas. Esta funcionalidad está diseñada para manejar flujos en los que se crean presupuestos y asignaciones, los saldos se consumen por transacciones o reservas temporales y, posteriormente, los estados de cuenta se utilizan para conciliar la actividad financiera a lo largo del tiempo.
 
->⚠️ La funcionalidad de Presupuestos solo está disponible para B2B Buyer Portal. Se requiere autorización del Commerce Engineer de la cuenta para su uso.
+> ⚠️ La funcionalidad de Presupuestos solo está disponible para tiendas que usan B2B Buyer Portal, actualmente está disponible para cuentas seleccionadas.
 
 ## Conceptos clave
 

--- a/docs/pt/tutorials/b2b/b2b-buyer-portal/contratos-b2b.md
+++ b/docs/pt/tutorials/b2b/b2b-buyer-portal/contratos-b2b.md
@@ -10,7 +10,7 @@ locale: pt
 
 Um contrato estabelece as condições comerciais entre um cliente B2B e sua loja. Ele centraliza o gerenciamento de acordos de compra, definindo quais produtos os compradores podem acessar, quais preços se aplicam a eles e quais métodos de pagamento podem usar.
 
->⚠️ Contratos estão disponíveis apenas para B2B Buyer Portal. É necessária autorização do Commerce Engineer da conta para uso.
+> ⚠️ Esta funcionalidade está disponível apenas para lojas que usam B2B Buyer Portal, atualmente disponível para contas selecionadas.
 
 Os contratos são armazenados na entidade de dados `CL` do [Master Data v1](https://help.vtex.com/pt/docs/tutorials/master-data). Esta é a mesma entidade que armazena dados de compradores em cenários B2C, mas para contratos B2B, ela segue especificações que habilitam a funcionalidade do B2B Buyer Portal.
 

--- a/docs/pt/tutorials/b2b/b2b-buyer-portal/membros-da-organizacao-compradora.md
+++ b/docs/pt/tutorials/b2b/b2b-buyer-portal/membros-da-organizacao-compradora.md
@@ -10,6 +10,8 @@ locale: pt
 
 Em uma organização compradora B2B, os membros são as pessoas que interagem com a loja em nome da organização. Suas ações são definidas pelos perfis de acesso e permissões atribuídos a eles e pela forma como a organização usa **informações de contato** e **dados do comprador**. Este artigo explica os tipos de membros e conceitos relacionados para que você entenda quem pode fazer o quê na sua organização.
 
+> ⚠️ Esta funcionalidade está disponível apenas para lojas que usam B2B Buyer Portal, atualmente disponível para contas selecionadas.
+
 ## Perfis de acesso baseados em permissão
 
 Os perfis de acesso definem o que cada usuário pode fazer na loja, incluindo a gestão da Organization Account. Cada perfil de acesso possui um conjunto de permissões. Quando você atribui um ou mais perfis de acesso a um usuário, ele passa a ter as capacidades combinadas desses perfis. As permissões são aplicadas na loja para que os usuários vejam e usem apenas os recursos permitidos.

--- a/docs/pt/tutorials/b2b/b2b-buyer-portal/visao-geral-de-budgets.md
+++ b/docs/pt/tutorials/b2b/b2b-buyer-portal/visao-geral-de-budgets.md
@@ -12,7 +12,7 @@ O gerenciamento de orçamentos permite que organizações B2B planejem, distribu
 
 Um budget pode ser subdividido em múltiplas allocations, e toda movimentação de valores como débitos, créditos e reembolsos, atualiza esses saldos de acordo com suas regras. A funcionalidade foi projetada para suportar fluxos nos quais budgets e allocations são criados, os saldos são consumidos por transactions ou reservations temporárias e, posteriormente, os statements são utilizados para reconciliar a atividade financeira ao longo do tempo.
 
->⚠️ A funcionalidade de Budgets está disponível apenas para B2B Buyer Portal. É necessária autorização do Commerce Engineer da conta para uso.
+> ⚠️ Esta funcionalidade está disponível apenas para lojas que usam B2B Buyer Portal, atualmente disponível para contas selecionadas.
 
 ## Conceitos-chave
 


### PR DESCRIPTION
## Summary

Updated B2B Buyer Portal callouts across all language versions to be feature-agnostic and remove authorization requirements.

## Changes

- Updated callout text in all B2B Buyer Portal documentation articles (EN, PT, ES)
- Removed mention of "authorization from Commerce Engineer"
- Changed feature-specific callouts to generic "This feature" wording
- Fixed spacing between `>` and emoji in callouts
- Applied consistent messaging across contracts, budgets, and buyer organization members articles

## Why

The previous callouts mentioned authorization requirements that are no longer relevant and used feature-specific wording. The new callouts are:
- Feature-agnostic and reusable across all B2B Buyer Portal articles
- More accurate regarding availability (select accounts)
- Consistent in messaging and formatting

## Files Modified

- `docs/en/tutorials/b2b/b2b-buyer-portal/b2b-contracts.md`
- `docs/en/tutorials/b2b/b2b-buyer-portal/budgets-overview.md`
- `docs/en/tutorials/b2b/b2b-buyer-portal/buyer-organization-members.md`
- `docs/es/tutorials/b2b/b2b-buyer-portal/budgets-informacion-general.md`
- `docs/pt/tutorials/b2b/b2b-buyer-portal/contratos-b2b.md`
- `docs/pt/tutorials/b2b/b2b-buyer-portal/membros-da-organizacao-compradora.md`
- `docs/pt/tutorials/b2b/b2b-buyer-portal/visao-geral-de-budgets.md`
