### PR TITLE
docs: rename B2B budget and checkout fields articles and update slug references

### DIFF
--- a/docs/en/tutorials/b2b/b2b-buyer-portal/custom-checkout-fields.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/custom-checkout-fields.md
@@ -83,7 +83,7 @@ You can set the following as defaults:
 
 > ⚠️ Only fields of type `option` can be set as default values.
 
-> ℹ️ For more information on how to add or configure custom fields, see [Add or edit custom checkout fields](https://help.vtex.com/en/docs/tutorials/add-or-edit-custom-checkout-fields)
+> ℹ️ For more information on how to add or configure custom fields, see [Add or edit custom checkout fields](https://help.vtex.com/en/docs/tutorials/adding-or-editing-custom-checkout-fields)
 
 ## Impact for administrators
 

--- a/docs/en/tutorials/b2b/organization-account/adding-or-editing-budgets.md
+++ b/docs/en/tutorials/b2b/organization-account/adding-or-editing-budgets.md
@@ -1,10 +1,10 @@
 ---
-title: 'Add or edit budgets'
+title: 'Adding or editing budgets'
 createdAt: '2025-02-27T10:00:00.000Z'
 updatedAt: '2025-02-27T10:00:00.000Z'
 contentType: tutorial
 productTeam: B2B
-slugEN: add-or-edit-budgets
+slugEN: adding-or-editing-budgets
 locale: en
 ---
 

--- a/docs/en/tutorials/b2b/organization-account/adding-or-editing-custom-checkout-fields.md
+++ b/docs/en/tutorials/b2b/organization-account/adding-or-editing-custom-checkout-fields.md
@@ -1,10 +1,10 @@
 ---
-title: 'Add or edit custom checkout fields'
+title: 'Adding or editing custom checkout fields'
 createdAt: '2025-03-27T10:00:00.000Z'
 updatedAt: '2025-03-27T10:00:00.000Z'
 contentType: tutorial
 productTeam: B2B
-slugEN: add-or-edit-custom-checkout-fields
+slugEN: adding-or-editing-custom-checkout-fields
 locale: en
 ---
 
@@ -24,7 +24,7 @@ This article covers:
 
 ## Edit custom field
 
-![Buyer Portal B2B Organization Unit information page](https://cdn.statically.io/gh/vtexdocs/help-center-content/refs/heads/main/docs/pt/tutorials/b2b/b2b-buyer-portal/buyer-portal-b2b-organization-unit-information-page.png)
+![Buyer Portal B2B Organization Unit information page](https://cdn.statically.io/gh/vtexdocs/help-center-content/refs/heads/main/docs/pt/tutorials/b2b/organization-account/buyer-portal-b2b-organization-unit-information-page.png)
 
 1. From the B2B Buyer Portal home screen, click the `Company` icon.
 2. In the Organization Unit modal, click **Manage**.

--- a/docs/es/tutorials/b2b/organization-account/agregar-o-editar-campos-personalizables-del-checkout.md
+++ b/docs/es/tutorials/b2b/organization-account/agregar-o-editar-campos-personalizables-del-checkout.md
@@ -4,7 +4,7 @@ createdAt: '2025-03-27T10:00:00.000Z'
 updatedAt: '2025-03-27T10:00:00.000Z'
 contentType: tutorial
 productTeam: B2B
-slugEN: add-or-edit-custom-checkout-fields
+slugEN: adding-or-editing-custom-checkout-fields
 locale: es
 ---
 

--- a/docs/es/tutorials/b2b/organization-account/agregar-o-editar-presupuestos.md
+++ b/docs/es/tutorials/b2b/organization-account/agregar-o-editar-presupuestos.md
@@ -4,7 +4,7 @@ createdAt: '2025-02-27T10:00:00.000Z'
 updatedAt: '2025-02-27T10:00:00.000Z'
 contentType: tutorial
 productTeam: B2B
-slugEN: add-or-edit-budgets
+slugEN: adding-or-editing-budgets
 locale: es
 ---
 

--- a/docs/pt/tutorials/b2b/organization-account/adicionar-ou-editar-budgets.md
+++ b/docs/pt/tutorials/b2b/organization-account/adicionar-ou-editar-budgets.md
@@ -4,7 +4,7 @@ createdAt: '2025-02-27T10:00:00.000Z'
 updatedAt: '2025-02-27T10:00:00.000Z'
 contentType: tutorial
 productTeam: B2B
-slugEN: add-or-edit-budgets
+slugEN: adding-or-editing-budgets
 locale: pt
 ---
 

--- a/docs/pt/tutorials/b2b/organization-account/adicionar-ou-editar-campos-customizaveis.md
+++ b/docs/pt/tutorials/b2b/organization-account/adicionar-ou-editar-campos-customizaveis.md
@@ -4,7 +4,7 @@ createdAt: '2025-03-27T10:00:00.000Z'
 updatedAt: '2025-03-27T10:00:00.000Z'
 contentType: tutorial
 productTeam: B2B
-slugEN: add-or-edit-custom-checkout-fields
+slugEN: adding-or-editing-custom-checkout-fields
 locale: pt
 ---
 
@@ -24,7 +24,7 @@ Este artigo aborda:
 
 ## Editar campo customizável
 
-![Buyer Portal B2B organization unit information page](https://cdn.statically.io/gh/vtexdocs/help-center-content/refs/heads/main/docs/pt/tutorials/b2b/b2b-buyer-portal/buyer-portal-b2b-organization-unit-information-page.png)
+![Buyer Portal B2B organization unit information page](https://cdn.statically.io/gh/vtexdocs/help-center-content/refs/heads/main/docs/pt/tutorials/b2b/organization-account/buyer-portal-b2b-organization-unit-information-page.png)
 
 1. Na tela inicial do Organization Account, clique no ícone `Company`.
 2. No modal da organization unit, clique no botão **Manage**.

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -17175,29 +17175,14 @@
               "children": [
                 {
                   "name": {
-                    "en": "Add or edit budgets",
+                    "en": "Adding or editing budgets",
                     "es": "Agregar o editar presupuestos",
                     "pt": "Adicionar ou editar budgets"
                   },
                   "slug": {
-                    "en": "add-or-edit-budgets",
+                    "en": "adding-or-editing-budgets",
                     "es": "agregar-o-editar-presupuestos",
                     "pt": "adicionar-ou-editar-budgets"
-                  },
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": {
-                    "en": "Add or edit custom checkout fields",
-                    "es": "Agregar o editar campos personalizables del checkout",
-                    "pt": "Adicionar ou editar campos customizáveis do checkout"
-                  },
-                  "slug": {
-                    "en": "add-or-edit-custom-checkout-fields",
-                    "es": "agregar-o-editar-campos-personalizables-del-checkout",
-                    "pt": "adicionar-ou-editar-campos-customizaveis"
                   },
                   "origin": "",
                   "type": "markdown",
@@ -17213,6 +17198,21 @@
                     "en": "adding-or-editing-buying-policies",
                     "es": "agregar-o-editar-politicas-de-compras",
                     "pt": "adicionar-ou-editar-buying-policies"
+                  },
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                },
+                {
+                  "name": {
+                    "en": "Adding or editing custom checkout fields",
+                    "es": "Agregar o editar campos personalizables del checkout",
+                    "pt": "Adicionar ou editar campos customizáveis do checkout"
+                  },
+                  "slug": {
+                    "en": "adding-or-editing-custom-checkout-fields",
+                    "es": "agregar-o-editar-campos-personalizables-del-checkout",
+                    "pt": "adicionar-ou-editar-campos-customizaveis"
                   },
                   "origin": "",
                   "type": "markdown",


### PR DESCRIPTION
## Summary

- Renamed two EN B2B articles from `add-or-edit-*` to `adding-or-editing-*` naming convention (`budgets` and `custom-checkout-fields`).
- Updated `slugEN` references across ES and PT locale files to match the new slugs.
- Updated internal link in `custom-checkout-fields.md` and fixed image path in PT locale file.

## Changes

| File | Change |
|------|--------|
| `docs/en/.../add-or-edit-budgets.md` | Renamed to `adding-or-editing-budgets.md` |
| `docs/en/.../add-or-edit-custom-checkout-fields.md` | Renamed to `adding-or-editing-custom-checkout-fields.md` |
| `docs/en/.../custom-checkout-fields.md` | Updated internal link to new slug |
| `docs/es/.../agregar-o-editar-presupuestos.md` | Updated `slugEN` |
| `docs/es/.../agregar-o-editar-campos-personalizables-del-checkout.md` | Updated `slugEN` |
| `docs/pt/.../adicionar-ou-editar-budgets.md` | Updated `slugEN` |
| `docs/pt/.../adicionar-ou-editar-campos-customizaveis.md` | Updated `slugEN` + fixed image path |
