### PR TITLE
EDU-17640 Add new Audit events documentation

### DIFF
--- a/docs/en/tutorials/security/platform-security-resources/events-available-in-audit.md
+++ b/docs/en/tutorials/security/platform-security-resources/events-available-in-audit.md
@@ -228,19 +228,19 @@ Below, you will find a list of the potential events available in [Audit](/en/tut
 |---|---|---|
 | PasswordCreated | Creation of a first-time password in the store or the VTEX Admin | User ID. |
 | PasswordUpdated | Change of store or VTEX Admin password by the user. | User ID. |
-| UserLogin | User login to the store or VTEX Admin. | User ID. |
-| UserLogout | User logout from the store or VTEX Admin. | User ID. |
+| UserLogin | User login to the VTEX Admin. | User ID. |
+| UserLogout | User logout from the VTEX Admin. | User ID. |
 | IdentityProviderChanged | Identity provider configuration change. For example: Creating a customized OAuth integration and changing information in an existing OAuth configuration. | Identity provider. |
 
 ## Master Data
 
 | Action | Event description | Event details |
 |---|---|---|
-| ReadDocument | Document read. | Document ID. |
-| CreateDocument | Document creation. | Document ID. |
-| UpdateDocument | Document update. | Document ID. |
+| ReadDocument | Document read. Applicable only for interactions with the CL and AD data entities in the CRM interface. | Document ID. |
+| CreateDocument | Document creation. Applicable only for interactions with the CL and AD data entities in the CRM interface. | Document ID. |
+| UpdateDocument | Document update. Applicable only for interactions with the CL and AD data entities in the CRM interface. | Document ID. |
 | DeleteDocument | Deleted document. | Document ID. |
-| SearchDocuments | Document search. | Search query details. |
+| SearchDocuments | Document search. Applicable only for interactions with the CL and AD data entities in the CRM interface. | Search query details. |
 | UpdateSchema | Created or updated schema on Master Data v2. | Schema name. |
 | DeleteSchema | Deleted schema on Master Data v2. | Schema name. |
 

--- a/docs/en/tutorials/security/platform-security-resources/events-available-in-audit.md
+++ b/docs/en/tutorials/security/platform-security-resources/events-available-in-audit.md
@@ -3,7 +3,7 @@ title: 'Events available in Audit'
 id: 6r1Mzcu5NmkmmDLJlz9CCZ
 status: PUBLISHED
 createdAt: 2022-06-22T16:05:16.214Z
-updatedAt: 2025-08-25T18:20:54.585Z
+updatedAt: 2026-03-02T18:20:54.585Z
 publishedAt: 2025-08-25T18:20:54.585Z
 firstPublishedAt: 2022-06-22T16:28:52.801Z
 contentType: tutorial
@@ -228,13 +228,19 @@ Below, you will find a list of the potential events available in [Audit](/en/tut
 |---|---|---|
 | PasswordCreated | Creation of a first-time password in the store or the VTEX Admin | User ID. |
 | PasswordUpdated | Change of store or VTEX Admin password by the user. | User ID. |
+| UserLogin | User login to the store or VTEX Admin. | User ID. |
+| UserLogout | User logout from the store or VTEX Admin. | User ID. |
 | IdentityProviderChanged | Identity provider configuration change. For example: Creating a customized OAuth integration and changing information in an existing OAuth configuration. | Identity provider. |
 
 ## Master Data
 
 | Action | Event description | Event details |
 |---|---|---|
+| ReadDocument | Document read. | Document ID. |
+| CreateDocument | Document creation. | Document ID. |
+| UpdateDocument | Document update. | Document ID. |
 | DeleteDocument | Deleted document. | Document ID. |
+| SearchDocuments | Document search. | Search query details. |
 | UpdateSchema | Created or updated schema on Master Data v2. | Schema name. |
 | DeleteSchema | Deleted schema on Master Data v2. | Schema name. |
 

--- a/docs/es/tutorials/seguridad/recursos-de-seguridad-de-la-plataforma/eventos-disponibles-en-audit.md
+++ b/docs/es/tutorials/seguridad/recursos-de-seguridad-de-la-plataforma/eventos-disponibles-en-audit.md
@@ -3,7 +3,7 @@ title: 'Eventos disponibles en Audit'
 id: 6r1Mzcu5NmkmmDLJlz9CCZ
 status: PUBLISHED
 createdAt: 2022-06-22T16:05:16.214Z
-updatedAt: 2025-08-25T18:20:54.585Z
+updatedAt: 2026-03-02T18:20:54.585Z
 publishedAt: 2025-08-25T18:20:54.585Z
 firstPublishedAt: 2022-06-22T16:28:52.801Z
 contentType: tutorial
@@ -228,13 +228,19 @@ A continuación, verás la lista de posibles eventos disponibles en [Audit](/es/
 |---|---|---|
 | PasswordCreated | El usuario registra una contraseña por primera vez en la tienda o en el Admin VTEX. | ID de usuario. |
 | PasswordUpdated | El usuario cambia su contraseña de la tienda o del Admin VTEX. | ID de usuario. |
+| UserLogin | Inicio de sesión del usuario en la tienda o en el Admin VTEX. | ID de usuario. |
+| UserLogout | Cierre de sesión del usuario en la tienda o en el Admin VTEX. | ID de usuario. |
 | IdentityProviderChanged | Cambios en la configuración del proveedor de identidad. Por ejemplo, cuando se crea una integración OAuth personalizada, o se modifica la información de una configuración OAuth existente. | Proveedor de identidad. |
 
 ## Master Data
 
 | Acción  | Descripción  | Detalles del evento |
 |---|---|---|
+| ReadDocument | Lectura de documento. | ID del documento. |
+| CreateDocument | Creación de documento. | ID del documento. |
+| UpdateDocument | Actualización de documento. | ID del documento. |
 | DeleteDocument | Eliminación de un documento. | ID del documento. |
+| SearchDocuments | Búsqueda de documentos. | Detalles de la consulta de búsqueda. |
 | UpdateSchema | Creación o edición de schema en Master Data v2. | Nombre del schema. |
 | DeleteSchema | Eliminación de schema en Master Data v2. | Nombre del schema. |
 

--- a/docs/es/tutorials/seguridad/recursos-de-seguridad-de-la-plataforma/eventos-disponibles-en-audit.md
+++ b/docs/es/tutorials/seguridad/recursos-de-seguridad-de-la-plataforma/eventos-disponibles-en-audit.md
@@ -228,19 +228,19 @@ A continuación, verás la lista de posibles eventos disponibles en [Audit](/es/
 |---|---|---|
 | PasswordCreated | El usuario registra una contraseña por primera vez en la tienda o en el Admin VTEX. | ID de usuario. |
 | PasswordUpdated | El usuario cambia su contraseña de la tienda o del Admin VTEX. | ID de usuario. |
-| UserLogin | Inicio de sesión del usuario en la tienda o en el Admin VTEX. | ID de usuario. |
-| UserLogout | Cierre de sesión del usuario en la tienda o en el Admin VTEX. | ID de usuario. |
+| UserLogin | Inicio de sesión del usuario en el Admin VTEX. | ID de usuario. |
+| UserLogout | Cierre de sesión del usuario en el Admin VTEX. | ID de usuario. |
 | IdentityProviderChanged | Cambios en la configuración del proveedor de identidad. Por ejemplo, cuando se crea una integración OAuth personalizada, o se modifica la información de una configuración OAuth existente. | Proveedor de identidad. |
 
 ## Master Data
 
 | Acción  | Descripción  | Detalles del evento |
 |---|---|---|
-| ReadDocument | Lectura de documento. | ID del documento. |
-| CreateDocument | Creación de documento. | ID del documento. |
-| UpdateDocument | Actualización de documento. | ID del documento. |
+| ReadDocument | Lectura de documento. Aplicable solo a las interacciones con las entidades de datos CL y AD en la interfaz del CRM. | ID del documento. |
+| CreateDocument | Creación de documento. Aplicable solo a las interacciones con las entidades de datos CL y AD en la interfaz del CRM. | ID del documento. |
+| UpdateDocument | Actualización de documento. Aplicable solo a las interacciones con las entidades de datos CL y AD en la interfaz del CRM. | ID del documento. |
 | DeleteDocument | Eliminación de un documento. | ID del documento. |
-| SearchDocuments | Búsqueda de documentos. | Detalles de la consulta de búsqueda. |
+| SearchDocuments | Búsqueda de documentos. Aplicable solo a las interacciones con las entidades de datos CL y AD en la interfaz del CRM. | Detalles de la consulta de búsqueda. |
 | UpdateSchema | Creación o edición de schema en Master Data v2. | Nombre del schema. |
 | DeleteSchema | Eliminación de schema en Master Data v2. | Nombre del schema. |
 

--- a/docs/pt/tutorials/segurança/recursos-de-segurança-da-plataforma/eventos-disponiveis-no-audit.md
+++ b/docs/pt/tutorials/segurança/recursos-de-segurança-da-plataforma/eventos-disponiveis-no-audit.md
@@ -147,7 +147,7 @@ Confira a seguir a lista dos possíveis eventos disponíveis no [Audit](/pt/docs
 | Unarchive Coupon | Desarquivamento de cupom. | Código do cupom. |
 | Change Rate Configuration | Alteração de configuração de taxa. | ID da configuração da taxa. |
 | Change Promotion Configuration | Alteração de configuração de promoção. | ID da configuração da promoção. |
-| Change Coupon Configuration | Alteração em coupom. | Código do cupom. |
+| Change Coupon Configuration | Alteração em cupom. | Código do cupom. |
 | Unarchived Calculator | Desarquivamento de promoção ou taxa. | ID da configuração da promoção ou taxa. |
 | Archived Calculator | Arquivamento de promoção ou taxa. | ID da configuração da promoção ou taxa. |
 
@@ -212,7 +212,7 @@ Confira a seguir a lista dos possíveis eventos disponíveis no [Audit](/pt/docs
 | Save User | Criação de usuário ou alteração de informações de usuário. | ID do usuário. |
 | Save Account | Criação de conta ou edição de informações de conta. | Conta criada ou alterada. |
 | Change Role | Edição de perfil de acesso. | Perfil de acesso editado. |
-| Delete Role | Exclusão perfil de acesso. | Perfil de acesso excluído. |
+| Delete Role | Exclusão de perfil de acesso. | Perfil de acesso excluído. |
 | Unblock AppToken | Desbloqueio de chave de aplicação. | Chave de aplicação desbloqueada. |
 | Resource Access Allowed | Acesso a recurso permitido. | Chave do recurso e ID do usuário ao qual foi permitido. |
 | Cancel Sponsor Invite | Cancelamento de convite para usuário titular. | ID do usuário convidado. |
@@ -274,7 +274,7 @@ Na coluna **Ação**, todos os eventos do Headless CMS também apresentam as seg
 
 ## Site Editor
 
-| Ação | Descrição do evento | Detalhe do evento |
+| Ação | Descrição do evento | Detalhes do evento |
 |---|---|---|
 | Schedule change | Agendamento de edição no conteúdo. | ID da entidade alterada. |
 | Edit content block | Edição de bloco de conteúdo. | ID da entidade alterada. |

--- a/docs/pt/tutorials/segurança/recursos-de-segurança-da-plataforma/eventos-disponiveis-no-audit.md
+++ b/docs/pt/tutorials/segurança/recursos-de-segurança-da-plataforma/eventos-disponiveis-no-audit.md
@@ -228,19 +228,19 @@ Confira a seguir a lista dos possíveis eventos disponíveis no [Audit](/pt/docs
 |---|---|---|
 | PasswordCreated | Usuário registra uma senha pela primeira vez na loja ou no Admin VTEX. | ID do usuário. |
 | PasswordUpdated | Usuário altera sua senha da loja ou do Admin VTEX. | ID do usuário. |
-| UserLogin | Login do usuário na loja ou no Admin VTEX. | ID do usuário. |
-| UserLogout | Logout do usuário da loja ou do Admin VTEX. | ID do usuário. |
+| UserLogin | Login do usuário no Admin VTEX. | ID do usuário. |
+| UserLogout | Logout do usuário do Admin VTEX. | ID do usuário. |
 | IdentityProviderChanged | Mudança de configurações de provedor de identidade. Por exemplo: criação de integração OAuth customizada, alteração de informações em configuração de OAuth existente, entre outros. | Provedor de identidade. |
 
 ## Master Data
 
 | Ação | Descrição do evento | Detalhes do evento |
 |---|---|---|
-| ReadDocument | Leitura de documento. | ID do documento. |
-| CreateDocument | Criação de documento. | ID do documento. |
-| UpdateDocument | Atualização de documento. | ID do documento. |
+| ReadDocument | Leitura de documento. Aplicável apenas a interações com as entidades de dados CL e AD na interface do CRM. | ID do documento. |
+| CreateDocument | Criação de documento. Aplicável apenas a interações com as entidades de dados CL e AD na interface do CRM. | ID do documento. |
+| UpdateDocument | Atualização de documento. Aplicável apenas a interações com as entidades de dados CL e AD na interface do CRM. | ID do documento. |
 | DeleteDocument | Exclusão de documento. | ID do documento. |
-| SearchDocuments | Busca de documentos. | Detalhes da consulta de busca. |
+| SearchDocuments | Busca de documentos. Aplicável apenas a interações com as entidades de dados CL e AD na interface do CRM. | Detalhes da consulta de busca. |
 | UpdateSchema | Criação ou edição de schema no Master Data v2. | Nome do schema. |
 | DeleteSchema | Exclusão de schema no Master Data v2. | Nome do schema. |
 

--- a/docs/pt/tutorials/segurança/recursos-de-segurança-da-plataforma/eventos-disponiveis-no-audit.md
+++ b/docs/pt/tutorials/segurança/recursos-de-segurança-da-plataforma/eventos-disponiveis-no-audit.md
@@ -3,7 +3,7 @@ title: 'Eventos disponíveis no Audit'
 id: 6r1Mzcu5NmkmmDLJlz9CCZ
 status: PUBLISHED
 createdAt: 2022-06-22T16:05:16.214Z
-updatedAt: 2025-08-25T18:20:54.585Z
+updatedAt: 2026-03-02T18:20:54.585Z
 publishedAt: 2025-08-25T18:20:54.585Z
 firstPublishedAt: 2022-06-22T16:28:52.801Z
 contentType: tutorial
@@ -228,13 +228,19 @@ Confira a seguir a lista dos possíveis eventos disponíveis no [Audit](/pt/docs
 |---|---|---|
 | PasswordCreated | Usuário registra uma senha pela primeira vez na loja ou no Admin VTEX. | ID do usuário. |
 | PasswordUpdated | Usuário altera sua senha da loja ou do Admin VTEX. | ID do usuário. |
+| UserLogin | Login do usuário na loja ou no Admin VTEX. | ID do usuário. |
+| UserLogout | Logout do usuário da loja ou do Admin VTEX. | ID do usuário. |
 | IdentityProviderChanged | Mudança de configurações de provedor de identidade. Por exemplo: criação de integração OAuth customizada, alteração de informações em configuração de OAuth existente, entre outros. | Provedor de identidade. |
 
 ## Master Data
 
 | Ação | Descrição do evento | Detalhes do evento |
 |---|---|---|
+| ReadDocument | Leitura de documento. | ID do documento. |
+| CreateDocument | Criação de documento. | ID do documento. |
+| UpdateDocument | Atualização de documento. | ID do documento. |
 | DeleteDocument | Exclusão de documento. | ID do documento. |
+| SearchDocuments | Busca de documentos. | Detalhes da consulta de busca. |
 | UpdateSchema | Criação ou edição de schema no Master Data v2. | Nome do schema. |
 | DeleteSchema | Exclusão de schema no Master Data v2. | Nome do schema. |
 

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -51255,13 +51255,13 @@
             {
               "name": {
                 "en": "Products with selling price is zero cannot be added to the cart in FastStore",
-                "es": "Los productos cuyo precio de venta es cero no se pueden añadir al carrito en FastStore",
-                "pt": "Produtos com preço de venda igual a zero não podem ser adicionados ao carrinho no FastStore"
+                "es": "Los productos con precio de venta cero no se pueden añadir al carrito en FastStore.",
+                "pt": "Os produtos com preço de venda zero não podem ser adicionados ao carrinho no FastStore."
               },
               "slug": {
                 "en": "products-with-selling-price-is-zero-cannot-be-added-to-the-cart-in-faststore",
-                "es": "los-productos-cuyo-precio-de-venta-es-cero-no-se-pueden-anadir-al-carrito-en-faststore",
-                "pt": "produtos-com-preco-de-venda-igual-a-zero-nao-podem-ser-adicionados-ao-carrinho-no-faststore"
+                "es": "los-productos-con-precio-de-venta-cero-no-se-pueden-anadir-al-carrito-en-faststore",
+                "pt": "os-produtos-com-preco-de-venda-zero-nao-podem-ser-adicionados-ao-carrinho-no-faststore"
               },
               "origin": "",
               "type": "markdown",
@@ -51300,13 +51300,13 @@
             {
               "name": {
                 "en": "Secrets take hours to propagate to builds in WebOps (FastStore Platform)",
-                "pt": "Os segredos levam horas para serem propagados para as compilações no WebOps (Plataforma FastStore)",
-                "es": "Secrets take hours to propagate to builds in WebOps (FastStore Platform)"
+                "es": "Los secretos tardan horas en propagarse a las compilaciones en WebOps (plataforma FastStore).",
+                "pt": "Os segredos levam horas para serem propagados para as compilações no WebOps (Plataforma FastStore)"
               },
               "slug": {
                 "en": "secrets-take-hours-to-propagate-to-builds-in-webops-faststore-platform",
-                "pt": "os-segredos-levam-horas-para-serem-propagados-para-as-compilacoes-no-webops-plataforma-faststore",
-                "es": ""
+                "es": "los-secretos-tardan-horas-en-propagarse-a-las-compilaciones-en-webops-plataforma-faststore",
+                "pt": "os-segredos-levam-horas-para-serem-propagados-para-as-compilacoes-no-webops-plataforma-faststore"
               },
               "origin": "",
               "type": "markdown",


### PR DESCRIPTION
## Summary

Documentation update for Audit: new events added to the "Events available in Audit" guide in EN, PT, and ES.

## Changes

- **VTEX ID:** UserLogin, UserLogout (with descriptions and event details).
- **Master Data:** ReadDocument, CreateDocument, UpdateDocument, SearchDocuments (with descriptions and event details).
- Updated EN, PT, and ES versions of the events-available-in-audit docs.

## Why

Align help center content with platform changes (new Audit events from product PRs).
