### PR TITLE
docs: update buying policies availability wording (EN, ES, PT)

### DIFF
--- a/docs/en/tutorials/b2b/b2b-buyer-portal/buying-policies-overview.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/buying-policies-overview.md
@@ -8,7 +8,7 @@ slugEN: buying-policies-overview
 locale: en
 ---
 
-> ⚠️ The **Buying policies** feature is only available for the **B2B Buyer Portal**.
+> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to select accounts.
 
 **Buying policies** is a feature that allows users to configure mechanisms and define criteria to automatically authorize or deny orders. It operates as a control layer in the purchasing process, allowing users to create customized order review workflows.
 

--- a/docs/en/tutorials/b2b/organization-account/adding-or-editing-buying-policies.md
+++ b/docs/en/tutorials/b2b/organization-account/adding-or-editing-buying-policies.md
@@ -8,7 +8,7 @@ slugEN: adding-or-editing-buying-policies
 locale: en
 ---
 
-> ⚠️ The **Buying policies** feature is only available for the **B2B Buyer Portal**.
+> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to select accounts.
 
 [Buying policies](https://help.vtex.com/en/docs/tutorials/buying-policies-overview) is a feature that allows users from a buyer organization to configure rules to automatically authorize or deny orders. The dynamic mechanisms of this solution help increase the organization's governance and promote compliance with current buying policies.
 

--- a/docs/es/tutorials/b2b/b2b-buyer-portal/politicas-de-compras.md
+++ b/docs/es/tutorials/b2b/b2b-buyer-portal/politicas-de-compras.md
@@ -8,7 +8,7 @@ slugEN: buying-policies-overview
 locale: es
 ---
 
-> ⚠️ La funcionalidad **Políticas de compras** está disponible solo para **B2B Buyer Portal**.
+> ⚠️ Esta funcionalidad solo está disponible para tiendas que usan B2B Buyer Portal, actualmente está disponible para cuentas seleccionadas.
 
 La funcionalidad **Políticas de compras** permite que los usuarios de la organización compradora configuren mecanismos y definan criterios para autorizar o denegar pedidos automáticamente. Esta solución actúa como una capa de control en el proceso de compra, facilitando la creación de flujos personalizados para la revisión de pedidos.
 

--- a/docs/es/tutorials/b2b/organization-account/agregar-o-editar-politicas-de-compras.md
+++ b/docs/es/tutorials/b2b/organization-account/agregar-o-editar-politicas-de-compras.md
@@ -8,7 +8,7 @@ slugEN: adding-or-editing-buying-policies
 locale: es
 ---
 
-> ⚠️ La funcionalidad **Política de compras** está disponible solo para **B2B Buyer Portal**.
+> ⚠️ Esta funcionalidad solo está disponible para tiendas que usan B2B Buyer Portal, actualmente está disponible para cuentas seleccionadas.
 
 [Política de compras](https://help.vtex.com/es/docs/tutorials/politicas-de-compras) es la funcionalidad que permite a los usuarios de la organización compradora configurar reglas para autorizar o denegar pedidos automáticamente. Los mecanismos dinámicos de esta solución fortalecen la gobernanza de la organización y promueven el cumplimiento de las políticas de compras vigentes.
 

--- a/docs/pt/tutorials/b2b/b2b-buyer-portal/buying-policies.md
+++ b/docs/pt/tutorials/b2b/b2b-buyer-portal/buying-policies.md
@@ -8,7 +8,7 @@ slugEN: buying-policies-overview
 locale: pt
 ---
 
-> ⚠️ A funcionalidade **Buying Policies** está disponível apenas para o **B2B Buyer Portal**.
+> ⚠️ Esta funcionalidade está disponível apenas para lojas que usam B2B Buyer Portal, atualmente disponível para contas selecionadas.
 
 **Buying Policies** é a funcionalidade pela qual os usuários da organização compradora configuram mecanismos e definem critérios para autorizar ou negar pedidos automaticamente. Ela opera como uma camada de controle no processo de compra, permitindo a criação de fluxos personalizados de revisão de pedidos.
 

--- a/docs/pt/tutorials/b2b/organization-account/adicionar-ou-editar-buying-policies.md
+++ b/docs/pt/tutorials/b2b/organization-account/adicionar-ou-editar-buying-policies.md
@@ -8,7 +8,7 @@ slugEN: adding-or-editing-buying-policies
 locale: pt
 ---
 
-> ⚠️ A funcionalidade **Buying Policies** está disponível apenas para o **B2B Buyer Portal**.
+> ⚠️ Esta funcionalidade está disponível apenas para lojas que usam B2B Buyer Portal, atualmente disponível para contas selecionadas.
 
 [Buying Policies](https://help.vtex.com/pt/docs/tutorials/buying-policies) é a funcionalidade que permite aos usuários da organização compradora configurar regras para autorizar ou negar pedidos automaticamente. Os mecanismos dinâmicos desta solução contribuem para uma maior governança da organização e promovem a conformidade com as políticas de compra vigentes.
 


### PR DESCRIPTION
## Summary

Updates the buying policies availability warning in EN, ES, and PT docs to clarify that the feature is available for stores using B2B Buyer Portal, currently for select accounts.

## Changes

- **EN:** `buying-policies-overview.md`, `adding-or-editing-buying-policies.md` — callout text updated.
- **ES:** `politicas-de-compras.md`, `agregar-o-editar-politicas-de-compras.md` — same change in Spanish.
- **PT:** `buying-policies.md`, `adicionar-ou-editar-buying-policies.md` — same change in Portuguese.

## Why

Aligns the availability disclaimer with current product positioning (B2B Buyer Portal, select accounts) across all three locales.
