### PR TITLE
fix: add missing front matter delimiter in buyer-organization-members.md

### DIFF
--- a/docs/en/tutorials/b2b/b2b-buyer-portal/buyer-organization-members.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/buyer-organization-members.md
@@ -1,3 +1,4 @@
+---
 title: 'Buyer organization members'
 createdAt: '2025-02-06T10:00:00.000Z'
 updatedAt: '2025-03-03T10:00:00.000Z'

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -17098,6 +17098,21 @@
                 },
                 {
                   "name": {
+                    "en": "Buyer organization members",
+                    "es": "Miembros de la organización compradora",
+                    "pt": "Membros da organização compradora"
+                  },
+                  "slug": {
+                    "en": "buyer-organization-members",
+                    "es": "miembros-de-la-organizacion-compradora",
+                    "pt": "membros-da-organizacao-compradora"
+                  },
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                },
+                {
+                  "name": {
                     "en": "Buying policies overview",
                     "es": "Políticas de compras",
                     "pt": "Buying Policies"
@@ -17121,21 +17136,6 @@
                     "en": "custom-checkout-fields",
                     "es": "campos-personalizables-del-checkout",
                     "pt": "campos-customizaveis-do-checkout"
-                  },
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": {
-                    "es": "Miembros de la organización compradora",
-                    "pt": "Membros da organização compradora",
-                    "en": "Miembros de la organización compradora"
-                  },
-                  "slug": {
-                    "es": "miembros-de-la-organizacion-compradora",
-                    "pt": "membros-da-organizacao-compradora",
-                    "en": ""
                   },
                   "origin": "",
                   "type": "markdown",


### PR DESCRIPTION
Add missing opening `---` delimiter to the front matter in `buyer-organization-members.md`.

Without the opening `---`, the front matter is not parsed correctly, which can cause rendering or metadata issues on the Help Center.
