### PR TITLE
EDU-17653: Update B2B docs for Storefront Roles rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ netlify.toml
 file-migration-plan.md
 .vscode/settings.json
 local_playground/
+temp/

--- a/docs/en/tutorials/b2b/b2b-buyer-portal/buying-policies-overview.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/buying-policies-overview.md
@@ -30,9 +30,9 @@ The steps to configure a buying policy are:
    - Require manual approval
 3. For manual approval, the user configures one to five levels of hierarchical approval. While any level can deny an order, final approval requires authorization from all levels.
 
-## Storefront permissions
+## Storefront Roles
 
-To configure buying policies, the user's [Storefront permissions](https://developers.vtex.com/docs/guides/storefront-permissions) role must have the `ManageBuyingPolicies` resource. To manually approve orders, the `ApproveOrders` resource is required.
+To configure buying policies, the user's [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-roles) role must have the `ManageBuyingPolicies` resource. To manually approve orders, the `ApproveOrders` resource is required.
 
 ## Configuring buying policies
 

--- a/docs/en/tutorials/b2b/b2b-buyer-portal/scopes-overview.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/scopes-overview.md
@@ -35,8 +35,8 @@ The restrictions that can be applied to **Organizational Units** are related to:
 
 > ℹ️ **Scopes** management via API is done through the [Organization Units API](https://developers.vtex.com/docs/api-reference/organization-units-api#overview).
 
-## Storefront permissions
+## Storefront Roles
 
-To view and manage the scope of an organizational unit, the user's [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-permissions) profile must have the `View_Organization_Unit` and `Edit_Organization_Unit` resources.
+To view and manage the scope of an organizational unit, the user's [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-roles) profile must have the `View_Organization_Unit` and `Edit_Organization_Unit` resources.
 
 > ℹ️ For more information, see the article [Buyer organization members](https://help.vtex.com/en/docs/tutorials/buyer-organization-members).

--- a/docs/en/tutorials/b2b/organization-account/adding-or-editing-buying-policies.md
+++ b/docs/en/tutorials/b2b/organization-account/adding-or-editing-buying-policies.md
@@ -19,7 +19,7 @@ In this guide, you'll learn how to manage buying policies through the following 
 - Editing a buying policy
 - Deleting a buying policy
 
-> ⚠️ To configure buying policies, the user's [Storefront permissions](https://developers.vtex.com/docs/guides/storefront-permissions) role must have the `ManageBuyingPolicies` resource. To authorize orders, the `ApproveOrders` resource is required.
+> ⚠️ To configure buying policies, the user's [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-roles) role must have the `ManageBuyingPolicies` resource. To authorize orders, the `ApproveOrders` resource is required.
 
 ## Adding a buying policy
 

--- a/docs/en/tutorials/b2b/organization-account/adding-or-editing-organizational-units.md
+++ b/docs/en/tutorials/b2b/organization-account/adding-or-editing-organizational-units.md
@@ -20,7 +20,7 @@ This article covers the management of organizational units and is divided into t
 * [Add child organizational unit (subordinate)](#add-child-organizational-unit-subordinate)
 * [Remove organizational unit](#remove-organizational-unit)
 
-> ⚠️ To configure organizational units, the user's [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-permissions) profile must be `Organizational Unit Admin`, `Super Buyer Admin`, or have the `ManageOrganizationHierarchy` resource.
+> ⚠️ To configure organizational units, the user's [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-roles) profile must be `Organizational Unit Admin`, `Super Buyer Admin`, or have the `ManageOrganizationHierarchy` resource.
 
 ## Add organizational unit
 
@@ -51,7 +51,7 @@ After creating an organizational unit, it will appear listed on the **Organizati
     * Username
 3. Select the access profiles you want to assign to the user.
 
-    > ℹ️ For more information about access profiles in the **B2B Buyer Portal**, see the article [Storefront Permissions](https://developers.vtex.com/docs/guides/storefront-permissions).
+    > ℹ️ For more information about access profiles in the **B2B Buyer Portal**, see the article [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-roles).
 4. Click `Add`.
 
 ## Add child organizational unit (subordinate)

--- a/docs/es/tutorials/b2b/b2b-buyer-portal/politicas-de-compras.md
+++ b/docs/es/tutorials/b2b/b2b-buyer-portal/politicas-de-compras.md
@@ -30,9 +30,9 @@ Los pasos para configurar una política de compras son:
    - Exigir aprobación manual
 3. Para la aprobación manual, el usuario configura de uno a cinco niveles de aprobación jerárquica, en los cuales cada nivel puede denegar el pedido, pero su aprobación depende de la evaluación de todos.
 
-## Permisos de storefront
+## Storefront Roles
 
-Para configurar las políticas de compras de la organización, el rol de [storefront permissions](https://developers.vtex.com/docs/guides/storefront-permissions) del usuario debe tener el recurso `ManageBuyingPolicies`. Para la autorización manual de pedidos, se requiere el recurso `ApproveOrders`.
+Para configurar las políticas de compras de la organización, el rol de [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-roles) del usuario debe tener el recurso `ManageBuyingPolicies`. Para la autorización manual de pedidos, se requiere el recurso `ApproveOrders`.
 
 ## Configurar políticas de compras
 

--- a/docs/es/tutorials/b2b/organization-account/agregar-o-editar-politicas-de-compras.md
+++ b/docs/es/tutorials/b2b/organization-account/agregar-o-editar-politicas-de-compras.md
@@ -19,7 +19,7 @@ Este artículo orienta a los usuarios sobre la gestión de las políticas de com
 - Editar políticas de compras
 - Eliminar políticas de compras
 
-> ⚠️ Para configurar las políticas de compras, el rol de [Storefront permissions](https://developers.vtex.com/docs/guides/storefront-permissions) del usuario debe tener el recurso `ManageBuyingPolicies`. Para autorizar pedidos, es necesario el recurso `ApproveOrders`.
+> ⚠️ Para configurar las políticas de compras, el rol de [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-roles) del usuario debe tener el recurso `ManageBuyingPolicies`. Para autorizar pedidos, es necesario el recurso `ApproveOrders`.
 
 ## Agregar políticas de compras
 

--- a/docs/pt/tutorials/b2b/b2b-buyer-portal/buying-policies.md
+++ b/docs/pt/tutorials/b2b/b2b-buyer-portal/buying-policies.md
@@ -30,9 +30,9 @@ Os passos para a configuração de uma buying policy são:
     * Exigir aprovação manual
 3. Para a aprovação manual, o usuário configura de um a cinco níveis de aprovação hierárquica, nos quais cada nível pode negar o pedido, mas sua aprovação depende da avaliação de todos.
 
-## Permissões de Storefront
+## Storefront Roles
 
-Para configurar as buying policies da organização, o perfil de [Storefront Permissions](https://developers.vtex.com/docs/guides/storefront-permissions) do usuário deve ter o recurso `ManageBuyingPolicies`. Para autorizar manualmente pedidos, é necessário o recurso `ApproveOrders`.
+Para configurar as buying policies da organização, o perfil de [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-roles) do usuário deve ter o recurso `ManageBuyingPolicies`. Para autorizar manualmente pedidos, é necessário o recurso `ApproveOrders`.
 
 ## Configurar buying policies
 

--- a/docs/pt/tutorials/b2b/b2b-buyer-portal/visao-geral-de-scopes.md
+++ b/docs/pt/tutorials/b2b/b2b-buyer-portal/visao-geral-de-scopes.md
@@ -35,8 +35,8 @@ As restrições que podem ser impostas a **Organizational Units** estão relacio
 
 > ℹ️ O gerenciamento de **Scopes** via API é feito pela [Organization Units API](https://developers.vtex.com/docs/api-reference/organization-units-api#overview).
 
-## Permissões de Storefront
+## Storefront Roles
 
-Para visualizar e gerenciar o scope de uma organizational unit, o perfil de [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-permissions) do usuário deve ter os recursos `View_Organization_Unit` e `Edit_Organization_Unit`.
+Para visualizar e gerenciar o scope de uma organizational unit, o perfil de [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-roles) do usuário deve ter os recursos `View_Organization_Unit` e `Edit_Organization_Unit`.
 
 > ℹ️ Para mais informações, veja o artigo [Membros da organização compradora](https://help.vtex.com/pt/docs/tutorials/membros-da-organizacao-compradora).

--- a/docs/pt/tutorials/b2b/organization-account/adicionar-ou-editar-buying-policies.md
+++ b/docs/pt/tutorials/b2b/organization-account/adicionar-ou-editar-buying-policies.md
@@ -19,7 +19,7 @@ Este artigo orienta os usuários no gerenciamento de buying policies e está div
 * Editar buying policy
 * Remover buying policy
 
-> ⚠️ Para configurar buying policies, o perfil de [Storefront Permissions](https://developers.vtex.com/docs/guides/storefront-permissions) do usuário deve ter o recurso `ManageBuyingPolicies`. Para autorizar pedidos, é necessário o recurso `ApproveOrders`.
+> ⚠️ Para configurar buying policies, o perfil de [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-roles) do usuário deve ter o recurso `ManageBuyingPolicies`. Para autorizar pedidos, é necessário o recurso `ApproveOrders`.
 
 ## Adicionar buying policy
 

--- a/docs/pt/tutorials/b2b/organization-account/adicionar-ou-editar-organizational-units.md
+++ b/docs/pt/tutorials/b2b/organization-account/adicionar-ou-editar-organizational-units.md
@@ -20,7 +20,7 @@ Este artigo orienta sobre o gerenciamento de organizational units e está dividi
 * [Adicionar organizational unit filha (subordinada)](#adicionar-organizational-unit-filha-subordinada)
 * [Remover organizational unit](#remover-organizational-unit)
 
-> ⚠️ Para configurar organizational units, o perfil de [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-permissions) do usuário deve ser `Organizational Unit Admin`, `Super Buyer Admin`, ou ter o recurso `ManageOrganizationHierarchy`.
+> ⚠️ Para configurar organizational units, o perfil de [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-roles) do usuário deve ser `Organizational Unit Admin`, `Super Buyer Admin`, ou ter o recurso `ManageOrganizationHierarchy`.
 
 ## Adicionar organizational unit
 
@@ -51,7 +51,7 @@ Após criar uma organizational unit, ela aparecerá listada na tela **Organizati
     * Username
 3. Selecione os perfis de acesso que deseja atribuir ao usuário.
 
-    > ℹ️ Para mais informações sobre perfis de acesso no **B2B Buyer Portal**, veja o artigo [Storefront Permissions](https://developers.vtex.com/docs/guides/storefront-permissions).
+    > ℹ️ Para mais informações sobre perfis de acesso no **B2B Buyer Portal**, veja o artigo [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-roles).
 4. Clique em `Add`.
 
 ## Adicionar organizational unit filha (subordinada)


### PR DESCRIPTION
## Summary

Updates B2B documentation to reflect the rename from **Storefront permissions** to **Storefront Roles**, including updated links to the new developer guide.

## Changes

- Replace “Storefront permissions” references with “Storefront Roles” across EN/ES/PT B2B guides.
- Update developer guide links from `storefront-permissions` to `storefront-roles`.
- Ignore `temp/` outputs via `.gitignore`.

## Context

- Jira: EDU-17653

