### PR TITLE
docs: update B2B buyer organization members terminology

### DIFF
--- a/docs/en/tutorials/b2b/b2b-buyer-portal/buyer-organization-members.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/buyer-organization-members.md
@@ -1,7 +1,7 @@
 ---
 title: 'Buyer organization members'
 createdAt: '2025-02-06T10:00:00.000Z'
-updatedAt: '2025-03-03T10:00:00.000Z'
+updatedAt: '2025-03-12T10:00:00.000Z'
 contentType: tutorial
 productTeam: B2B
 slugEN: buyer-organization-members
@@ -12,7 +12,7 @@ In a B2B buyer organization, members are the people who interact with the store 
 
 > ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to select accounts.
 
-## Permission roles
+## Storefront roles
 
 Roles define what each user can do in the store, including managing the organization account. Each role has a set of permissions. When you assign one or more roles to a user, they acquire the combined capabilities of those roles. Applying permissions in the store allows restricting users to view and edit approved resources only.
 
@@ -35,9 +35,11 @@ The table below summarizes the main roles and their functions:
 | **Quote Manager** | Can create, edit, and delete quotes. |
 | **Personal card user**         | Can use a new credit card not saved in the contract by default at checkout.                                                                                                           |
 
-## Contact details
+> ℹ️ Learn more about Storefront roles and resources in the developer guide [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-roles).
 
-**Contacts** are the people who can be selected as order recipients — the people who'll receive the shipment. The order contact may be different from the user who placed the order. When placing an order, the buyer can choose the contact (recipient) the order is for.
+## Recipients
+
+**Recipients** or **Contacts** are the people who can be selected as order recipients — the people who'll receive the shipment. The order contact may be different from the user who placed the order. When placing an order, the buyer can choose the contact (recipient) the order is for.
 
 Contact details are managed at the organization level. Contacts can be linked to addresses so that, when selecting a shipping address, the user can choose from the contacts associated with that address. This keeps recipient information centralized and reusable between orders.
 

--- a/docs/es/tutorials/b2b/b2b-buyer-portal/miembros-de-la-organizacion-compradora.md
+++ b/docs/es/tutorials/b2b/b2b-buyer-portal/miembros-de-la-organizacion-compradora.md
@@ -1,7 +1,7 @@
 ---
 title: 'Miembros de la organización compradora'
 createdAt: '2025-02-06T10:00:00.000Z'
-updatedAt: '2025-03-03T10:00:00.000Z'
+updatedAt: '2025-03-12T10:00:00.000Z'
 contentType: tutorial
 productTeam: B2B
 slugEN: buyer-organization-members
@@ -12,7 +12,7 @@ En una organización compradora B2B, los miembros son las personas que interact�
 
 > ⚠️ Esta funcionalidad solo está disponible para tiendas que usan B2B Buyer Portal, actualmente está disponible para cuentas seleccionadas.
 
-## Roles basados en permisos
+## Roles del storefront
 
 Los roles definen lo que cada usuario puede hacer en la tienda, incluyendo la gestión de la cuenta de la organización. Cada rol tiene un conjunto de permisos. Cuando se asignan uno o más roles a un usuario, este obtiene los permisos combinados a dichos roles. El uso de permisos en la tienda permite restringir el aceso de los usuarios para que vean y usen únicamente los recursos autorizados.
 
@@ -35,9 +35,11 @@ La siguiente tabla resume los principales roles y sus funciones:
 | **Gerente de cotizaciones** | Puede crear, editar y eliminar cotizaciones. |
 | **Usuario de tarjetas personales**          | Puede usar una nueva tarjeta de crédito en el checkout que no se guarda en el contrato de forma predeterminada.                                                                                                         |
 
-## Información de contacto
+> ℹ️ Obtén más información sobre los roles del storefront y los recursos en la guía para desarrolladores [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-roles).
 
-**La información de contacto** se refiere a las personas que pueden seleccionarse como destinatarias de los pedidos, es decir, la persona que recibirá el envío. El contacto de un pedido puede ser diferente del usuario que lo realizó. Al realizar un pedido, el comprador puede elegir el contacto destinatario del pedido.
+## Destinatarios
+
+**Los destinatarios** o **contactos** son las personas que pueden seleccionarse como destinatarias de los pedidos, es decir, la persona que recibirá el envío. El contacto de un pedido puede ser diferente del usuario que lo realizó. Al realizar un pedido, el comprador puede elegir el contacto destinatario del pedido.
 
 La información de contacto se gestiona a nivel de la organización. Los contactos pueden estar vinculados a direcciones para que, al seleccionar una dirección de envío, el usuario pueda elegir entre los contactos asociados a esa dirección. Esto mantiene los datos de los destinatarios centralizados y permite que se reutilicen en otros pedidos.
 

--- a/docs/pt/tutorials/b2b/b2b-buyer-portal/membros-da-organizacao-compradora.md
+++ b/docs/pt/tutorials/b2b/b2b-buyer-portal/membros-da-organizacao-compradora.md
@@ -1,7 +1,7 @@
 ---
 title: 'Membros da organização compradora'
 createdAt: '2025-02-06T10:00:00.000Z'
-updatedAt: '2025-03-03T10:00:00.000Z'
+updatedAt: '2025-03-12T10:00:00.000Z'
 contentType: tutorial
 productTeam: B2B
 slugEN: buyer-organization-members
@@ -12,7 +12,7 @@ Em uma organização compradora B2B, os membros são as pessoas que interagem co
 
 > ⚠️ Esta funcionalidade está disponível apenas para lojas que usam B2B Buyer Portal, atualmente disponível para contas selecionadas.
 
-## Perfis de acesso baseados em permissão
+## Perfis de acesso do storefront
 
 Os perfis de acesso definem o que cada usuário pode fazer na loja, incluindo a gestão da Organization Account. Cada perfil de acesso possui um conjunto de permissões. Quando você atribui um ou mais perfis de acesso a um usuário, ele passa a ter as capacidades combinadas desses perfis. As permissões são aplicadas na loja para que os usuários vejam e usem apenas os recursos permitidos.
 
@@ -35,9 +35,11 @@ A tabela abaixo resume os principais perfis de acesso e suas funções:
 | **Gerente de cotações** | Pode criar, editar e excluir cotações. |
 | **Usuário de cartões pessoais** | Pode usar um novo cartão de crédito no checkout que não é salvo no contrato por padrão. |
 
-## Informações de contato
+> ℹ️ Saiba mais sobre perfis de acesso do storefront e recursos no guia do desenvolvedor [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-roles).
 
-**Informações de contato** referem-se às pessoas que podem ser selecionadas como destinatárias dos pedidos, ou seja, a pessoa que receberá a entrega. O contato de um pedido pode ser diferente do usuário que fez o pedido. Ao realizar um pedido, o comprador pode escolher para qual contato (destinatário) é o pedido.
+## Recipients
+
+**Recipients** ou **contatos** são as pessoas que podem ser selecionadas como destinatárias dos pedidos, ou seja, a pessoa que receberá a entrega. O contato de um pedido pode ser diferente do usuário que fez o pedido. Ao realizar um pedido, o comprador pode escolher para qual contato (destinatário) é o pedido.
 
 As informações de contato são gerenciadas no nível da organização. Os contatos podem ser vinculados a endereços para que, ao selecionar um endereço de entrega, o usuário possa escolher entre os contatos associados a esse endereço. Isso mantém os dados de destinatários centralizados e reutilizáveis entre pedidos.
 


### PR DESCRIPTION
Updates B2B Buyer Portal documentation terminology across English, Spanish, and Portuguese versions of the buyer organization members tutorial.

## Changes

- Renamed the section about role permissions to "Storefront roles" (and localized equivalents).
- Added a reference note linking to the developer guide for Storefront Roles.
- Renamed the contact section to recipients-focused terminology.

## Why

Keeps terminology aligned with current Storefront Roles naming and improves clarity around recipients/contacts in buyer organization guidance.

## Affected Files

- docs/en/tutorials/b2b/b2b-buyer-portal/buyer-organization-members.md
- docs/es/tutorials/b2b/b2b-buyer-portal/miembros-de-la-organizacion-compradora.md
- docs/pt/tutorials/b2b/b2b-buyer-portal/membros-da-organizacao-compradora.md
