### PR TITLE
EDU-17853: Rename B2B Contact Information to Recipients

### DIFF
--- a/docs/en/tutorials/b2b/b2b-buyer-portal/buyer-organization-members.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/buyer-organization-members.md
@@ -8,7 +8,7 @@ slugEN: buyer-organization-members
 locale: en
 ---
 
-In a B2B buyer organization, members are the people who interact with the store on behalf of the organization. Their actions are defined by roles and permissions assigned to them, as well as by how the organization uses **contact details** and **buyer information**. This article describes the types of members and related concepts to explain the actions different users can perform in your organization.
+In a B2B buyer organization, members are the people who interact with the store on behalf of the organization. Their actions are defined by roles and permissions assigned to them, as well as by how the organization uses **recipients** and **buyer information**. This article describes the types of members and related concepts to explain the actions different users can perform in your organization.
 
 > ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to select accounts.
 
@@ -41,9 +41,9 @@ The table below summarizes the main roles and their functions:
 
 **Recipients** or **Contacts** are the people who can be selected as order recipients — the people who'll receive the shipment. The order contact may be different from the user who placed the order. When placing an order, the buyer can choose the contact (recipient) the order is for.
 
-Contact details are managed at the organization level. Contacts can be linked to addresses so that, when selecting a shipping address, the user can choose from the contacts associated with that address. This keeps recipient information centralized and reusable between orders.
+Recipient information is managed at the organization level. Contacts can be linked to addresses so that, when selecting a shipping address, the user can choose from the contacts associated with that address. This keeps recipient information centralized and reusable between orders.
 
-For technical details on how to create, update, and integrate contact details via APIs, see the [B2B Contact Details API](https://developers.vtex.com/docs/api-reference/b2b-contact-information-api).
+For technical details on how to create, update, and integrate recipients via APIs, see the [B2B Recipients API](https://developers.vtex.com/docs/api-reference/b2b-recipients-api).
 
 ## Buyers
 

--- a/docs/es/tutorials/b2b/b2b-buyer-portal/miembros-de-la-organizacion-compradora.md
+++ b/docs/es/tutorials/b2b/b2b-buyer-portal/miembros-de-la-organizacion-compradora.md
@@ -8,7 +8,7 @@ slugEN: buyer-organization-members
 locale: es
 ---
 
-En una organización compradora B2B, los miembros son las personas que interactúan con la tienda en nombre de la organización. Sus acciones se definen por los roles y permisos que se les asignan y por la forma en que la organización utiliza la **información de contacto** y los **datos del comprador**. Este artículo explica los tipos de miembros y los conceptos relacionados para definir las acciones que diferentes usuarios pueden realizar en la organización.
+En una organización compradora B2B, los miembros son las personas que interactúan con la tienda en nombre de la organización. Sus acciones se definen por los roles y permisos que se les asignan y por la forma en que la organización utiliza los **destinatarios** y los **datos del comprador**. Este artículo explica los tipos de miembros y los conceptos relacionados para definir las acciones que diferentes usuarios pueden realizar en la organización.
 
 > ⚠️ Esta funcionalidad solo está disponible para tiendas que usan B2B Buyer Portal, actualmente está disponible para cuentas seleccionadas.
 
@@ -39,11 +39,11 @@ La siguiente tabla resume los principales roles y sus funciones:
 
 ## Destinatarios
 
-**Los destinatarios** o **contactos** son las personas que pueden seleccionarse como destinatarias de los pedidos, es decir, la persona que recibirá el envío. El contacto de un pedido puede ser diferente del usuario que lo realizó. Al realizar un pedido, el comprador puede elegir el contacto destinatario del pedido.
+**Los destinatarios** son las personas que pueden seleccionarse como destinatarias de los pedidos, es decir, la persona que recibirá el envío. El contacto de un pedido puede ser diferente del usuario que lo realizó. Al realizar un pedido, el comprador puede elegir el contacto destinatario del pedido.
 
-La información de contacto se gestiona a nivel de la organización. Los contactos pueden estar vinculados a direcciones para que, al seleccionar una dirección de envío, el usuario pueda elegir entre los contactos asociados a esa dirección. Esto mantiene los datos de los destinatarios centralizados y permite que se reutilicen en otros pedidos.
+La información de los destinatarios se gestiona a nivel de la organización. Los contactos pueden estar vinculados a direcciones para que, al seleccionar una dirección de envío, el usuario pueda elegir entre los contactos asociados a esa dirección. Esto mantiene los datos de los destinatarios centralizados y permite que se reutilicen en otros pedidos.
 
-Para detalles técnicos sobre cómo crear, actualizar e integrar información de contacto vía APIs, consulta la [API B2B Contact Information](https://developers.vtex.com/docs/api-reference/b2b-contact-information-api).
+Para detalles técnicos sobre cómo crear, actualizar e integrar destinatarios vía APIs, consulta la [API de Destinatarios B2B](https://developers.vtex.com/docs/api-reference/b2b-recipients-api).
 
 ## Compradores
 

--- a/docs/pt/tutorials/b2b/b2b-buyer-portal/membros-da-organizacao-compradora.md
+++ b/docs/pt/tutorials/b2b/b2b-buyer-portal/membros-da-organizacao-compradora.md
@@ -8,7 +8,7 @@ slugEN: buyer-organization-members
 locale: pt
 ---
 
-Em uma organização compradora B2B, os membros são as pessoas que interagem com a loja em nome da organização. Suas ações são definidas pelos perfis de acesso e permissões atribuídos a eles e pela forma como a organização usa **informações de contato** e **dados do comprador**. Este artigo explica os tipos de membros e conceitos relacionados para que você entenda quem pode fazer o quê na sua organização.
+Em uma organização compradora B2B, os membros são as pessoas que interagem com a loja em nome da organização. Suas ações são definidas pelos perfis de acesso e permissões atribuídos a eles e pela forma como a organização usa **destinatários** e **dados do comprador**. Este artigo explica os tipos de membros e conceitos relacionados para que você entenda quem pode fazer o quê na sua organização.
 
 > ⚠️ Esta funcionalidade está disponível apenas para lojas que usam B2B Buyer Portal, atualmente disponível para contas selecionadas.
 
@@ -37,13 +37,13 @@ A tabela abaixo resume os principais perfis de acesso e suas funções:
 
 > ℹ️ Saiba mais sobre perfis de acesso do storefront e recursos no guia do desenvolvedor [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-roles).
 
-## Recipients
+## Destinatários
 
-**Recipients** ou **contatos** são as pessoas que podem ser selecionadas como destinatárias dos pedidos, ou seja, a pessoa que receberá a entrega. O contato de um pedido pode ser diferente do usuário que fez o pedido. Ao realizar um pedido, o comprador pode escolher para qual contato (destinatário) é o pedido.
+**Destinatários** ou **contatos** são as pessoas que podem ser selecionadas como destinatárias dos pedidos, ou seja, a pessoa que receberá a entrega. O contato de um pedido pode ser diferente do usuário que fez o pedido. Ao realizar um pedido, o comprador pode escolher para qual contato (destinatário) é o pedido.
 
-As informações de contato são gerenciadas no nível da organização. Os contatos podem ser vinculados a endereços para que, ao selecionar um endereço de entrega, o usuário possa escolher entre os contatos associados a esse endereço. Isso mantém os dados de destinatários centralizados e reutilizáveis entre pedidos.
+As informações dos destinatários são gerenciadas no nível da organização. Os contatos podem ser vinculados a endereços para que, ao selecionar um endereço de entrega, o usuário possa escolher entre os contatos associados a esse endereço. Isso mantém os dados de destinatários centralizados e reutilizáveis entre pedidos.
 
-Para detalhes técnicos sobre como criar, atualizar e integrar informações de contato via APIs, consulte a [API de informações de contato B2B](https://developers.vtex.com/docs/api-reference/b2b-contact-information-api).
+Para detalhes técnicos sobre como criar, atualizar e integrar destinatários via APIs, consulte a [API de Destinatários B2B](https://developers.vtex.com/docs/api-reference/b2b-recipients-api).
 
 ## Compradores
 


### PR DESCRIPTION
## Summary

Rename the B2B feature formerly called "Contact Information" to "Recipients" across Help Center documentation in all three languages (EN, ES, PT).

## Changes

- **EN** (`buyer-organization-members.md`): Renamed "contact details" to "recipients", updated API link text to "B2B Recipients API", updated slug to `b2b-recipients-api`.
- **ES** (`miembros-de-la-organizacion-compradora.md`): Renamed "información de contacto" to "destinatarios", updated API link text to "API de Destinatarios B2B", updated slug.
- **PT** (`membros-da-organizacao-compradora.md`): Renamed "informações de contato" / "Recipients" to "destinatários", localized heading and bold terms, updated API link text to "API de Destinatários B2B", updated slug.

## Why

The B2B feature has been renamed from "Contact Information" to "Recipients" (ref: [vtex/openapi-schemas#1631](https://github.com/vtex/openapi-schemas/pull/1631)). This is a documentation-only rename — API paths and the `contact_information` data entity are unchanged.

## Jira

EDU-17853
