### PR TITLE
docs: update B2B buyer portal availability callouts

### DIFF
--- a/docs/en/tutorials/b2b/b2b-buyer-portal/accounting-fields.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/accounting-fields.md
@@ -10,7 +10,7 @@ slugEN: accounting-fields
 
 **Accounting fields** allow you to collect additional information from purchases in the **B2B Buyer Portal**, such as **cost center**, **internal purchase order (PO) number**, and other control information. This information is associated with the order, helping the company standardize information, apply internal rules, and facilitate audits.
 
-> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to select accounts.
+> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to selected accounts.
 
 ## Using accounting fields
 

--- a/docs/en/tutorials/b2b/b2b-buyer-portal/b2b-contracts.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/b2b-contracts.md
@@ -10,7 +10,7 @@ locale: en
 
 A contract establishes the commercial conditions between a B2B customer and your store. It also centralizes purchase agreement management by defining the products buyers can access, the prices that will apply to them, and the payment methods they can use.
 
-> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to select accounts.
+> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to selected accounts.
 
 Contracts are stored in the `CL` data entity of [Master Data v1](https://help.vtex.com/docs/tutorials/master-data). This is the same entity that stores buyer information in B2C scenarios; however, for B2B contracts, it follows specifications that enable the B2B Buyer Portal feature.
 

--- a/docs/en/tutorials/b2b/b2b-buyer-portal/budgets-overview.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/budgets-overview.md
@@ -12,7 +12,7 @@ Budget management allows B2B organizations to plan, allocate, and track their ex
 
 A budget can be subdivided into multiple allocations, and all value movements — such as debits, credits, and refunds — update these balances according to their rules. The feature is designed to support flows in which budgets and allocations are created, balances are consumed by transactions or temporary reservations, and statements are later used to reconcile financial activity over time.
 
-> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to select accounts.
+> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to selected accounts.
 
 ## Key concepts
 

--- a/docs/en/tutorials/b2b/b2b-buyer-portal/buyer-organization-members.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/buyer-organization-members.md
@@ -10,7 +10,7 @@ locale: en
 
 In a B2B buyer organization, members are the people who interact with the store on behalf of the organization. Their actions are defined by roles and permissions assigned to them, as well as by how the organization uses **recipients** and **buyer information**. This article describes the types of members and related concepts to explain the actions different users can perform in your organization.
 
-> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to select accounts.
+> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to selected accounts.
 
 ## Storefront roles
 

--- a/docs/en/tutorials/b2b/b2b-buyer-portal/buying-policies-overview.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/buying-policies-overview.md
@@ -8,7 +8,7 @@ slugEN: buying-policies-overview
 locale: en
 ---
 
-> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to select accounts.
+> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to selected accounts.
 
 **Buying policies** is a feature that allows users to configure mechanisms and define criteria to automatically authorize or deny orders. It operates as a control layer in the purchasing process, allowing users to create customized order review workflows.
 

--- a/docs/en/tutorials/b2b/b2b-buyer-portal/contracts-manager-agent.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/contracts-manager-agent.md
@@ -8,7 +8,7 @@ slugEN: contracts-manager-agent
 locale: en
 ---
 
-> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to select accounts.
+> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to selected accounts.
 
 The **Contracts Manager Agent** helps B2B operators manage [contracts](https://help.vtex.com/en/docs/tutorials/b2b-contracts) using natural language. Instead of manually updating each contract, you can describe what you want to change, review the proposed plan, and execute it directly from the interface.
 

--- a/docs/en/tutorials/b2b/organization-account/adding-or-editing-accounting-fields.md
+++ b/docs/en/tutorials/b2b/organization-account/adding-or-editing-accounting-fields.md
@@ -8,7 +8,7 @@ slugEN: adding-or-editing-accounting-fields
 locale: en
 ---
 
-> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to select accounts.
+> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to selected accounts.
 
 The Accounting Fields feature allows you to standardize information collection during the purchase process by adding accounting fields based on your business rules.
 

--- a/docs/en/tutorials/b2b/organization-account/adding-or-editing-budgets.md
+++ b/docs/en/tutorials/b2b/organization-account/adding-or-editing-budgets.md
@@ -10,7 +10,7 @@ locale: en
 
 Budgets allow you to set and track spending limits centrally. This feature helps control the use of funds over time and organize budgets for different business contexts. 
 
-> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to select accounts.
+> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to selected accounts.
 
 It also allows you to create budgets, configure consumption notifications, set allocations, and control when and how these amounts are available at checkout.
 

--- a/docs/en/tutorials/b2b/organization-account/adding-or-editing-buying-policies.md
+++ b/docs/en/tutorials/b2b/organization-account/adding-or-editing-buying-policies.md
@@ -8,7 +8,7 @@ slugEN: adding-or-editing-buying-policies
 locale: en
 ---
 
-> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to select accounts.
+> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to selected accounts.
 
 [Buying policies](https://help.vtex.com/en/docs/tutorials/buying-policies-overview) is a feature that allows users from a buyer organization to configure rules to automatically authorize or deny orders. The dynamic mechanisms of this solution help increase the organization's governance and promote compliance with current buying policies.
 

--- a/docs/en/tutorials/b2b/organization-account/contract-settings.md
+++ b/docs/en/tutorials/b2b/organization-account/contract-settings.md
@@ -8,7 +8,7 @@ slugEN: contract-settings
 locale: en
 ---
 
-> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to select accounts.
+> ⚠️ This feature is only available for stores using B2B Buyer Portal, which is currently available to selected accounts.
 
 The **Contract** section in the [Organization Account](https://help.vtex.com/en/docs/tutorials/organization-account) groups settings that define how a buyer organization operates within a B2B Buyer Portal store. From this section, the user can view profile information, manage addresses, configure payment methods and credit cards, select product assortments, and manage [custom checkout fields](https://help.vtex.com/en/docs/tutorials/accounting-fields).
 


### PR DESCRIPTION
- Replaces "select accounts" with "selected accounts" in the affected B2B Buyer Portal and Organization Account docs.
- Keeps the availability note consistent across the English documentation set updated in this branch.
