### PR TITLE
docs: fix B2B buyer portal docs consistency

### DIFF
--- a/docs/en/tutorials/b2b/b2b-buyer-portal/b2b-buyer-portal.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/b2b-buyer-portal.md
@@ -45,7 +45,7 @@ To streamline contract management at scale, the [Contract Manager Agent](https:/
 
 ### Organizational units
 
-[Organization units](https://help.vtex.com/en/docs/tutorials/organization-units) represent the subdivisions within a buyer organization, such as departments, regional offices, or subsidiaries. They follow a hierarchical tree model. A root unit represents the organization as a whole, and child units reflect its internal areas.
+[Organization units](https://help.vtex.com/en/docs/tutorials/organizational-units) represent the subdivisions within a buyer organization, such as departments, regional offices, or subsidiaries. They follow a hierarchical tree model. A root unit represents the organization as a whole, and child units reflect its internal areas.
 
 Each unit can have specific configurations for product visibility, payment methods, delivery addresses, accounting fields, and order approval rules, allowing the store to align with the buyer company’s internal policies without requiring multiple contracts or accounts. Unit-specific settings are always subject to the contract conditions.
 

--- a/docs/en/tutorials/b2b/b2b-buyer-portal/b2b-buyer-portal.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/b2b-buyer-portal.md
@@ -134,5 +134,5 @@ This capability supports organizations that use centralized procurement software
 ## Learn more
 
 - [Adding or editing organizational units](https://help.vtex.com/en/docs/tutorials/adding-or-editing-organizational-units)
-- [Adding users to a buyer organization](https://help.vtex.com/en/docs/tutorials/adding-users-to-buyer-organization)
+- [Adding users to a buyer organization](https://help.vtex.com/en/docs/tutorials/adding-users-to-buyer-organizations)
 - [B2B Buyer Portal integration overview](https://developers.vtex.com/docs/guides/b2b-buyer-portal-integration-overview) (developer documentation)

--- a/docs/en/tutorials/b2b/b2b-buyer-portal/contract-manager-agent.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/contract-manager-agent.md
@@ -10,7 +10,7 @@ locale: en
 
 > ⚠️ This feature is only available to stores using [B2B Buyer Portal](https://help.vtex.com/en/docs/tutorials/b2b-buyer-portal), which is currently available for selected accounts.
 
-**Contract Manager Agent** helps B2B operators manage [contracts](https://help.vtex.com/docs/tutorials/b2b-contracts) using natural language. Instead of manually updating each contract, you can describe what you want to change, review the proposed plan, and execute it directly from the interface.
+**Contract Manager Agent** helps B2B operators manage [contracts](https://help.vtex.com/en/docs/tutorials/b2b-contracts) using natural language. Instead of manually updating each contract, you can describe what you want to change, review the proposed plan, and execute it directly from the interface.
 
 In this guide, you'll learn more about **Contract Manager Agent** in the following sections:
 

--- a/docs/en/tutorials/b2b/b2b-buyer-portal/contract-manager-agent.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/contract-manager-agent.md
@@ -8,7 +8,7 @@ slugEN: contract-manager-agent
 locale: en
 ---
 
-> ⚠️ This feature is only available to stores using B2B Buyer Portal, which is currently available for selected accounts.
+> ⚠️ This feature is only available to stores using [B2B Buyer Portal](https://help.vtex.com/en/docs/tutorials/b2b-buyer-portal), which is currently available for selected accounts.
 
 **Contract Manager Agent** helps B2B operators manage [contracts](https://help.vtex.com/docs/tutorials/b2b-contracts) using natural language. Instead of manually updating each contract, you can describe what you want to change, review the proposed plan, and execute it directly from the interface.
 

--- a/docs/en/tutorials/b2b/b2b-buyer-portal/organizational-units.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/organizational-units.md
@@ -8,7 +8,7 @@ slugEN: organizational-units
 locale: en
 ---
 
-> ⚠️ This feature is only available to stores using B2B Buyer Portal, which is currently available for selected accounts.
+> ⚠️ This feature is only available to stores using [B2B Buyer Portal](https://help.vtex.com/en/docs/tutorials/b2b-buyer-portal), which is currently available for selected accounts.
 
 In B2B operations, the buyer is a company and not an individual consumer. Each company is represented by a buyer organization that maintains a business relationship with the store.
 

--- a/docs/en/tutorials/b2b/b2b-buyer-portal/organizational-units.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/organizational-units.md
@@ -69,7 +69,7 @@ The business conditions defined in the contract are inherited by the child units
 
 To understand how contracts are configured and managed, see:
 
-- [B2B contracts](https://help.vtex.com/en/docs/tutorials/contratos-b2b)
+- [B2B contracts](https://help.vtex.com/en/docs/tutorials/b2b-contracts)
 
 ## Organizational unit settings
 
@@ -86,8 +86,8 @@ This segmentation allows aligning store operations with the internal policies of
 For more information, see:
 
 - [Buying Policies](https://help.vtex.com/en/docs/tutorials/buying-policies-overview)
-- [Budgets overview](https://help.vtex.com/en/docs/tutorials/visao-geral-de-budgets)
-- [Custom checkout fields](https://help.vtex.com/en/docs/tutorials/campos-customizaveis-do-checkout)
+- [Budgets overview](https://help.vtex.com/en/docs/tutorials/budgets-overview)
+- [Custom checkout fields](https://help.vtex.com/en/docs/tutorials/accounting-fields)
 
 ## Organizational unit users
 

--- a/docs/en/tutorials/b2b/organization-account/adding-users-to-buyer-organizations.md
+++ b/docs/en/tutorials/b2b/organization-account/adding-users-to-buyer-organizations.md
@@ -74,5 +74,5 @@ The code will be valid for 12 hours. The user will only be able to log in for th
 Unlike other user types, adding a user with permission to make purchases in the store requires other steps beyond creating it and assigning them roles. You also need to add the user as a buyer via API. To enable a user to make purchases in the store, follow the steps below:
 
 1. Add the user to the buyer organization as described in the [instructions](#instructions).
-2. Assign them a role that allows making purchases. See roles and permissions in the article [Buyer organization members](https://help.vtex.com/en/docs/tutorials/membros-da-organizacao-compradora).
+2. Assign them a role that allows making purchases. See roles and permissions in the article [Buyer organization members](https://help.vtex.com/en/docs/tutorials/buyer-organization-members).
 3. Add the user as a buyer. To learn how to add and manage buyer details, see the [B2B Buyer Data API](https://developers.vtex.com/docs/api-reference/b2b-buyer-data-api).

--- a/docs/en/tutorials/b2b/organization-account/adding-users-to-buyer-organizations.md
+++ b/docs/en/tutorials/b2b/organization-account/adding-users-to-buyer-organizations.md
@@ -12,7 +12,7 @@ This article explains how an **Organization Admin** can create a user as a membe
 
 When a user is added to a buyer organization, they're linked to an organizational unit and are assigned a storefront role that allows them to perform actions in the store.
 
-> ⚠️ This feature is only available to stores using B2B Buyer Portal, which is currently available for selected accounts.
+> ⚠️ This feature is only available to stores using [B2B Buyer Portal](https://help.vtex.com/en/docs/tutorials/b2b-buyer-portal), which is currently available for selected accounts.
 
 ## Before you begin
 

--- a/docs/en/tutorials/b2b/organization-account/organization-account.md
+++ b/docs/en/tutorials/b2b/organization-account/organization-account.md
@@ -66,7 +66,7 @@ The **Organization** section allows you to manage the organizational structure o
 
 The options include:
 
-- **Users** — Manage [organization users](https://help.vtex.com/en/docs/tutorials/membros-da-organizacao-compradora).
+- **Users** — Manage [organization users](https://help.vtex.com/en/docs/tutorials/buyer-organization-members).
 - **Roles** — Define permissions and roles.
 - **Organizational units** — Create and manage [organizational units](https://help.vtex.com/en/docs/tutorials/organization-units-pt).
 
@@ -76,7 +76,7 @@ The **Finance and compliance** section brings together tools for financial contr
 
 You can manage:
 
-- **Budgets** — [Budget](https://help.vtex.com/en/docs/tutorials/visao-geral-de-budgets) definition.
+- **Budgets** — [Budget](https://help.vtex.com/en/docs/tutorials/budgets-overview) definition.
 - **Buying policies** — [Buying policies](https://help.vtex.com/en/docs/tutorials/buying-policies), rules that control approval, denial, or order review.
 
 ### Adding entities
@@ -90,7 +90,7 @@ By clicking this button, a menu displays with options to create different entiti
 - **Add credit card** — Add a credit card.
 - **Add user** — Add a user to the organization.
 - **Add organizational unit** — Create a new [organizational unit](https://help.vtex.com/en/docs/tutorials/organization-units-pt).
-- **Add budget** — Create a [budget](https://help.vtex.com/en/docs/tutorials/visao-geral-de-budgets).
+- **Add budget** — Create a [budget](https://help.vtex.com/en/docs/tutorials/budgets-overview).
 - **Add buying policy** — Create a [buying policy](https://help.vtex.com/en/docs/tutorials/buying-policies).
 
 ### Back to the store

--- a/docs/en/tutorials/b2b/organization-account/organization-account.md
+++ b/docs/en/tutorials/b2b/organization-account/organization-account.md
@@ -49,7 +49,7 @@ The main page of the **organization account** is divided into three main section
 
 ### Contract details
 
-The contract details section is identified by the name of the [organizational unit](https://help.vtex.com/en/docs/tutorials/organization-units-pt) where the settings are being managed.
+The contract details section is identified by the name of the [organizational unit](https://help.vtex.com/en/docs/tutorials/organizational-units) where the settings are being managed.
 
 In this section, you can access:
 
@@ -68,7 +68,7 @@ The options include:
 
 - **Users** — Manage [organization users](https://help.vtex.com/en/docs/tutorials/buyer-organization-members).
 - **Roles** — Define permissions and roles.
-- **Organizational units** — Create and manage [organizational units](https://help.vtex.com/en/docs/tutorials/organization-units-pt).
+- **Organizational units** — Create and manage [organizational units](https://help.vtex.com/en/docs/tutorials/organizational-units).
 
 ### Finance and compliance
 
@@ -77,7 +77,7 @@ The **Finance and compliance** section brings together tools for financial contr
 You can manage:
 
 - **Budgets** — [Budget](https://help.vtex.com/en/docs/tutorials/budgets-overview) definition.
-- **Buying policies** — [Buying policies](https://help.vtex.com/en/docs/tutorials/buying-policies), rules that control approval, denial, or order review.
+- **Buying policies** — [Buying policies](https://help.vtex.com/en/docs/tutorials/buying-policies-overview), rules that control approval, denial, or order review.
 
 ### Adding entities
 
@@ -89,9 +89,9 @@ By clicking this button, a menu displays with options to create different entiti
 - **Add address** — Add an address.
 - **Add credit card** — Add a credit card.
 - **Add user** — Add a user to the organization.
-- **Add organizational unit** — Create a new [organizational unit](https://help.vtex.com/en/docs/tutorials/organization-units-pt).
+- **Add organizational unit** — Create a new [organizational unit](https://help.vtex.com/en/docs/tutorials/organizational-units).
 - **Add budget** — Create a [budget](https://help.vtex.com/en/docs/tutorials/budgets-overview).
-- **Add buying policy** — Create a [buying policy](https://help.vtex.com/en/docs/tutorials/buying-policies).
+- **Add buying policy** — Create a [buying policy](https://help.vtex.com/en/docs/tutorials/buying-policies-overview).
 
 ### Back to the store
 
@@ -101,12 +101,7 @@ In the upper right corner of the page, when you click the **Start shopping** opt
 
 Check the articles below for more details on the different tasks you can perform in the **organization account** interface.
 
-- [Adding users to a buyer organization](https://help.vtex.com/en/docs/tutorials/adicionar-usuarios-a-organizacao-compradora)
-- [Adding or editing budgets](https://help.vtex.com/en/docs/tutorials/adicionar-ou-editar-budgets)
-- [Adding or editing buying policies](https://help.vtex.com/en/docs/tutorials/adicionar-ou-editar-buying-policies)
-- [Adding or editing custom checkout fields](https://help.vtex.com/en/docs/tutorials/adicionar-ou-editar-campos-customizaveis)
-
-- [Add users to the buyer organization](https://help.vtex.com/en/docs/tutorials/adding-users-to-buyer-organization)
-- [Add or edit budgets](https://help.vtex.com/docs/tutorials/adding-or-editing-budgets)
-- [Add or edit Buying Policies](https://help.vtex.com/en/docs/tutorials/adding-users-to-buyer-organization)
-- [Add or edit accounting fields](https://help.vtex.com/docs/tutorials/adding-or-editing-accounting-fields)
+- [Adding users to a buyer organization](https://help.vtex.com/en/docs/tutorials/adding-users-to-buyer-organizations)
+- [Adding or editing budgets](https://help.vtex.com/en/docs/tutorials/adding-or-editing-budgets)
+- [Adding or editing buying policies](https://help.vtex.com/en/docs/tutorials/adding-or-editing-buying-policies)
+- [Adding or editing accounting fields](https://help.vtex.com/en/docs/tutorials/adding-or-editing-accounting-fields)

--- a/docs/es/tutorials/b2b/b2b-buyer-portal/agente-de-gestion-de-contratos.md
+++ b/docs/es/tutorials/b2b/b2b-buyer-portal/agente-de-gestion-de-contratos.md
@@ -8,7 +8,7 @@ slugEN: contract-manager-agent
 locale: es
 ---
 
-> ⚠️ Esta funcionalidad está disponible solo para tiendas que usan B2B Buyer Portal, y por el momento, únicamente para cuentas seleccionadas.
+> ⚠️ Esta funcionalidad está disponible solo para tiendas que usan [B2B Buyer Portal](https://help.vtex.com/es/docs/tutorials/b2b-buyer-portal-es), y por el momento, únicamente para cuentas seleccionadas.
 
 El **Agente de gestión de contratos** ayuda a los operadores B2B a gestionar [contratos](https://help.vtex.com/es/docs/tutorials/contratos-b2b-es) usando lenguaje natural. En vez de actualizar manualmente cada contrato, puedes describir lo que deseas cambiar, revisar el plan propuesto y ejecutarlo directamente desde la interfaz.
 

--- a/docs/es/tutorials/b2b/b2b-buyer-portal/unidades-organizativas.md
+++ b/docs/es/tutorials/b2b/b2b-buyer-portal/unidades-organizativas.md
@@ -69,7 +69,7 @@ Las unidades hijas heredan las condiciones comerciales definidas en el contrato.
 
 Para más información sobre configuración y gestión de contratos consulta:
 
-- [Contratos B2B](https://help.vtex.com/es/docs/tutorials/contratos-b2b)
+- [Contratos B2B](https://help.vtex.com/es/docs/tutorials/contratos-b2b-es)
 
 ## Configuración por unidad organizativa
 
@@ -87,7 +87,7 @@ Para más información, consulta:
 
 - [Políticas de compra](https://help.vtex.com/es/docs/tutorials/politicas-de-compras)
 - [Información general de presupuestos](https://help.vtex.com/es/docs/tutorials/presupuestos-informacion-general)
-- [Campos personalizables en el checkout](https://help.vtex.com/es/docs/tutorials/campos-personalizables-del-checkout)
+- [Campos personalizables en el checkout](https://help.vtex.com/es/docs/tutorials/campos-contables)
 
 ## Usuarios de unidades organizativas
 

--- a/docs/es/tutorials/b2b/b2b-buyer-portal/unidades-organizativas.md
+++ b/docs/es/tutorials/b2b/b2b-buyer-portal/unidades-organizativas.md
@@ -8,7 +8,7 @@ slugEN: organizational-units
 locale: es
 ---
 
-> ⚠️ Esta funcionalidad está disponible solo para tiendas que usan B2B Buyer Portal, y por el momento, únicamente para cuentas seleccionadas.
+> ⚠️ Esta funcionalidad está disponible solo para tiendas que usan [B2B Buyer Portal](https://help.vtex.com/es/docs/tutorials/b2b-buyer-portal-es), y por el momento, únicamente para cuentas seleccionadas.
 
 En operaciones B2B, el comprador es una empresa y no un consumidor individual. Cada empresa está representada por una organización compradora que mantiene una relación comercial con la tienda.
 

--- a/docs/es/tutorials/b2b/organization-account/agregar-usuarios-a-la-organizacion-compradora.md
+++ b/docs/es/tutorials/b2b/organization-account/agregar-usuarios-a-la-organizacion-compradora.md
@@ -12,7 +12,7 @@ Este artículo explica cómo un **Organization Admin** puede crear un usuario mi
 
 El usuario agregado a una organización compradora está vinculado a una unidad organizativa y tiene un rol en el storefront que le permite ejecutar acciones en la tienda.
 
-> ⚠️ Esta funcionalidad está disponible solo para tiendas que usan B2B Buyer Portal, y por el momento, únicamente para cuentas seleccionadas.
+> ⚠️ Esta funcionalidad está disponible solo para tiendas que usan [B2B Buyer Portal](https://help.vtex.com/es/docs/tutorials/b2b-buyer-portal-es), y por el momento, únicamente para cuentas seleccionadas.
 
 ## Antes de empezar
 

--- a/docs/es/tutorials/b2b/organization-account/cuenta-de-la-organizacion.md
+++ b/docs/es/tutorials/b2b/organization-account/cuenta-de-la-organizacion.md
@@ -49,7 +49,7 @@ La página principal de la **cuenta de la organización** está dividida en tres
 
 ### Información de contrato
 
-La sección de información de contrato está identificada por el nombre de la [unidad organizativa](https://help.vtex.com/es/docs/tutorials/organization-units-es) en la que se están gestionando las configuraciones.
+La sección de información de contrato está identificada por el nombre de la [unidad organizativa](https://help.vtex.com/es/docs/tutorials/unidades-organizativas) en la que se están gestionando las configuraciones.
 
 En esta sección se puede acceder a:
 
@@ -68,7 +68,7 @@ Las opciones incluyen:
 
 - **Usuarios** — gestión de los [usuarios de la organización](https://help.vtex.com/es/docs/tutorials/miembros-de-la-organizacion-compradora).
 - **Roles** — definición de permisos y funciones.
-- **Unidades organizativas** — creación y gestión de [unidades organizativas](https://help.vtex.com/es/docs/tutorials/organization-units-es).
+- **Unidades organizativas** — creación y gestión de [unidades organizativas](https://help.vtex.com/es/docs/tutorials/unidades-organizativas).
 
 ### Finanzas y compliance
 
@@ -89,7 +89,7 @@ Al hacer clic en ese botón se mostrará un menú con opciones para crear difere
 - **Agregar dirección** — agregar una dirección.
 - **Agregar tarjeta de crédito** — agregar una tarjeta de crédito.
 - **Agregar usuario** — agregar un usuario a la organización.
-- **Agregar unidad organizativa** — crear una nueva [unidad organizativa](https://help.vtex.com/es/docs/tutorials/organization-units-es).
+- **Agregar unidad organizativa** — crear una nueva [unidad organizativa](https://help.vtex.com/es/docs/tutorials/unidades-organizativas).
 - **Agregar presupuesto** — crear un [presupuesto](https://help.vtex.com/es/docs/tutorials/presupuestos-informacion-general).
 - **Agregar política de compra** — crear una [política de compras](https://help.vtex.com/es/docs/tutorials/politicas-de-compras).
 
@@ -104,4 +104,4 @@ Consulta en los artículos a continuación más detalles sobre las distintas tar
 - [Agregar usuarios a la organización compradora](https://help.vtex.com/es/docs/tutorials/agregar-usuarios-a-la-organizacion-compradora)
 - [Agregar o editar presupuestos](https://help.vtex.com/es/docs/tutorials/agregar-o-editar-presupuestos)
 - [Agregar o editar políticas de compras](https://help.vtex.com/es/docs/tutorials/agregar-o-editar-politicas-de-compras)
-- [Agregar o editar campos personalizables del checkout](https://help.vtex.com/pt/docs/tutorials/adicionar-ou-editar-campos-customizaveis)
+- [Agregar o editar campos personalizables del checkout](https://help.vtex.com/es/docs/tutorials/agregar-o-editar-campos-contables)

--- a/docs/es/tutorials/b2b/organization-account/cuenta-de-la-organizacion.md
+++ b/docs/es/tutorials/b2b/organization-account/cuenta-de-la-organizacion.md
@@ -58,7 +58,7 @@ En esta sección se puede acceder a:
 - **Medios de pago** — Medios de pago disponibles.
 - **Tarjetas de crédito** — Tarjetas registradas para compras.
 - **Surtido de productos** — Catálogo de productos disponible para la unidad.
-- **Campos personalizables del checkout** — [Campos personalizables](https://help.vtex.com/es/docs/tutorials/campos-personalizables-del-checkout) configurados por la organización. Por ejemplo: "Números de PO" o "Centros de costos".
+- **Campos contables** — [Campos contables](https://help.vtex.com/es/docs/tutorials/campos-contables) configurados por la organización. Por ejemplo: "Números de PO" o "Centros de costos".
 
 ### Organización
 

--- a/docs/pt/tutorials/b2b/b2b-buyer-portal/b2b-buyer-portal-pt.md
+++ b/docs/pt/tutorials/b2b/b2b-buyer-portal/b2b-buyer-portal-pt.md
@@ -16,7 +16,7 @@ Este artigo resume as principais funcionalidades do **B2B Buyer Portal** e direc
 
 - [Contratos](#contratos)
 - [Gestão organizacional](#gestao-organizacional)
-  - [Organizational Units](#organizational-units)
+  - [Unidades organizacionais](#unidades-organizacionais)
   - [Scopes](#scopes)
   - [Membros e perfis](#membros-e-perfis)
 - [Finanças e compliance](#financas-e-compliance)
@@ -35,7 +35,7 @@ Um [contrato](https://help.vtex.com/pt/docs/tutorials/contratos-b2b-pt) define o
 - Quais preços se aplicam (tabelas de preços).
 - Quais métodos de pagamento estão disponíveis.
 
-Os contratos são a base da experiência do comprador. Todas as [Organizational Units](#organizational-units) da empresa herdam as condições do contrato, garantindo consistência em toda a organização. A funcionalidade de [Scopes](#scopes) pode então controlar quais desses atributos cada unidade pode ver e utilizar.
+Os contratos são a base da experiência do comprador. Todas as [unidades organizacionais](#unidades-organizacionais) da empresa herdam as condições do contrato, garantindo consistência em toda a organização. A funcionalidade de [Scopes](#scopes) pode então controlar quais desses atributos cada unidade pode ver e utilizar.
 
 Para simplificar a gestão de contratos em escala, o [Agente de Gerenciamento de Contratos](https://help.vtex.com/pt/docs/tutorials/agente-de-gerenciamento-de-contratos) permite que operadores da loja atualizem contratos em massa usando instruções em linguagem natural, como adicionar coleções ou alterar métodos de pagamento em centenas de contratos de uma vez.
 
@@ -43,17 +43,17 @@ Para simplificar a gestão de contratos em escala, o [Agente de Gerenciamento de
 
 O **B2B Buyer Portal** permite que organizações compradoras repliquem sua estrutura interna na plataforma, para que cada departamento, filial ou subsidiária possa operar com suas próprias regras, compartilhando um único contrato.
 
-### Organizational Units
+### Unidades organizacionais
 
-As [Organizational Units](https://help.vtex.com/pt/docs/tutorials/organization-units-pt) representam as subdivisões de uma organização compradora, como departamentos, escritórios regionais ou subsidiárias. Elas seguem um modelo hierárquico em árvore. Uma unidade raiz representa a organização como um todo, e as unidades filhas refletem suas áreas internas.
+As [unidades organizacionais](https://help.vtex.com/pt/docs/tutorials/unidades-organizacionais) representam as subdivisões de uma organização compradora, como departamentos, escritórios regionais ou subsidiárias. Elas seguem um modelo hierárquico em árvore. Uma unidade raiz representa a organização como um todo, e as unidades filhas refletem suas áreas internas.
 
 Cada unidade pode ter configurações específicas de visibilidade de produtos, métodos de pagamento, endereços de entrega, campos contábeis e regras de aprovação de pedidos, permitindo que a loja se alinhe às políticas internas da empresa compradora sem precisar de múltiplos contratos ou contas. As configurações por unidade estão sempre sujeitas às condições do contrato.
 
-> ℹ️ Saiba mais sobre configurações em [Adicionar ou editar Organizational Units](https://help.vtex.com/pt/docs/tutorials/adicionar-ou-editar-organizational-units).
+> ℹ️ Saiba mais sobre configurações em [Adicionar ou editar unidades organizacionais](https://help.vtex.com/pt/docs/tutorials/adicionar-ou-editar-organizational-units).
 
 ### Scopes
 
-Os [Scopes](https://help.vtex.com/pt/docs/tutorials/visao-geral-de-scopes) controlam quais atributos da organização são visíveis e disponíveis para cada Organization Unit. Os administradores podem restringir o acesso a contratos, métodos de pagamento, cartões de crédito, coleções, endereços e campos contábeis por unidade, garantindo que os compradores vejam apenas o que é relevante para sua Organization Unit.
+Os [Scopes](https://help.vtex.com/pt/docs/tutorials/visao-geral-de-scopes) controlam quais atributos da organização são visíveis e disponíveis para cada unidade organizacional. Os administradores podem restringir o acesso a contratos, métodos de pagamento, cartões de crédito, coleções, endereços e campos contábeis por unidade, garantindo que os compradores vejam apenas o que é relevante para sua unidade organizacional.
 
 ### Membros e perfis
 
@@ -100,7 +100,7 @@ Essa camada de governança garante que a atividade de compras esteja em conformi
 
 Os [campos contábeis](https://help.vtex.com/pt/docs/tutorials/campos-contabeis) capturam informações de negócio adicionais durante o checkout, como centro de custo, número de PO, códigos de projeto ou classificações de despesas. Os campos podem ser aplicados nos níveis de pedido, item ou endereço e configurados como obrigatórios ou opcionais.
 
-As organizações também podem definir valores padrão por Organizational Unit para preencher automaticamente campos do checkout, reduzindo a entrada manual e garantindo consistência dos dados nas compras.
+As organizações também podem definir valores padrão por unidade organizacional para preencher automaticamente campos do checkout, reduzindo a entrada manual e garantindo consistência dos dados nas compras.
 
 > ℹ️ Saiba mais sobre configurações em [Adicionar ou editar campos contábeis](https://help.vtex.com/pt/docs/tutorials/adicionar-ou-editar-campos-contabeis).
 
@@ -117,7 +117,7 @@ Cartões de pagamento podem ser armazenados no nível do contrato (compartilhado
 A [Conta da organização](https://help.vtex.com/pt/docs/tutorials/conta-da-organizacao) é a interface de autoatendimento onde os administradores da organização compradora gerenciam todas as configurações mencionadas acima. Em uma única tela, os admins podem:
 
 - Visualizar e atualizar detalhes do contrato (perfil, endereços, métodos de pagamento, sortimento de produtos).
-- Gerenciar usuários, perfis e Organizational Units.
+- Gerenciar usuários, perfis e unidades organizacionais.
 - Configurar budgets, buying policies e campos contábeis.
 
 Essa interface centralizada permite que as organizações compradoras gerenciem suas operações de forma autônoma, sem depender do lojista para tarefas administrativas rotineiras.
@@ -132,6 +132,6 @@ Essa funcionalidade atende organizações que utilizam software de procurement c
 
 ## Saiba mais
 
-- [Adicionar ou editar Organizational Units](https://help.vtex.com/pt/docs/tutorials/adicionar-ou-editar-organizational-units)
+- [Adicionar ou editar unidades organizacionais](https://help.vtex.com/pt/docs/tutorials/adicionar-ou-editar-organizational-units)
 - [Adicionar usuários à organização compradora](https://help.vtex.com/pt/docs/tutorials/adicionar-usuarios-a-organizacao-compradora)
 - [B2B Buyer Portal integration overview](https://developers.vtex.com/docs/guides/b2b-buyer-portal-integration-overview) (documentação para desenvolvedores)

--- a/docs/pt/tutorials/b2b/b2b-buyer-portal/unidades-organizacionais.md
+++ b/docs/pt/tutorials/b2b/b2b-buyer-portal/unidades-organizacionais.md
@@ -69,7 +69,7 @@ As condições comerciais definidas no contrato são herdadas pelas unidades fil
 
 Para entender como contratos são configurados e gerenciados, consulte:
 
-* [Contratos B2B](https://help.vtex.com/pt/docs/tutorials/contratos-b2b)
+* [Contratos B2B](https://help.vtex.com/pt/docs/tutorials/contratos-b2b-pt)
 
 ## Configurações por unidade organizacional
 
@@ -87,7 +87,7 @@ Saiba mais na documentação a seguir:
 
 * [Buying Policies](https://help.vtex.com/pt/docs/tutorials/buying-policies)
 * [Visão geral de Budgets](https://help.vtex.com/pt/docs/tutorials/visao-geral-de-budgets)
-* [Campos customizáveis no checkout](https://help.vtex.com/pt/docs/tutorials/campos-customizaveis-do-checkout)
+* [Campos customizáveis no checkout](https://help.vtex.com/pt/docs/tutorials/campos-contabeis)
 
 ## Usuários de unidades organizacionais
 

--- a/docs/pt/tutorials/b2b/b2b-buyer-portal/unidades-organizacionais.md
+++ b/docs/pt/tutorials/b2b/b2b-buyer-portal/unidades-organizacionais.md
@@ -8,7 +8,7 @@ slugEN: organizational-units
 locale: pt
 ---
 
-> ⚠️ Esta funcionalidade está disponível apenas para lojas que usam B2B Buyer Portal, atualmente disponível para contas selecionadas.
+> ⚠️ Esta funcionalidade está disponível apenas para lojas que usam [B2B Buyer Portal](https://help.vtex.com/pt/docs/tutorials/b2b-buyer-portal-pt), atualmente disponível para contas selecionadas.
 
 Em operações B2B, o comprador é uma empresa e não um consumidor individual. Cada empresa é representada por uma organização compradora que mantém relacionamento comercial com a loja.
 

--- a/docs/pt/tutorials/b2b/organization-account/conta-da-organizacao.md
+++ b/docs/pt/tutorials/b2b/organization-account/conta-da-organizacao.md
@@ -49,7 +49,7 @@ A página principal da **Conta da Organização** é dividida em três áreas pr
 
 ### Informações do contrato
 
-A seção informações do contrato é indicada pelo nome da [unidade organizacional](https://help.vtex.com/pt/docs/tutorials/organization-units-pt) onde as configurações estão sendo gerenciadas.
+A seção informações do contrato é indicada pelo nome da [unidade organizacional](https://help.vtex.com/pt/docs/tutorials/unidades-organizacionais) onde as configurações estão sendo gerenciadas.
 
 Nessa área é possível acessar:
 
@@ -68,7 +68,7 @@ As opções incluem:
 
 - **Users** — gerenciamento dos [usuários da organização](https://help.vtex.com/pt/docs/tutorials/membros-da-organizacao-compradora).
 - **Roles** — definição de permissões e funções.
-- **Organizational Units** — criação e gerenciamento de [unidades organizacionais](https://help.vtex.com/pt/docs/tutorials/organization-units-pt).
+- **Organizational Units** — criação e gerenciamento de [unidades organizacionais](https://help.vtex.com/pt/docs/tutorials/unidades-organizacionais).
 
 ### Finance and Compliance
 
@@ -89,7 +89,7 @@ Ao clicar nesse botão, será exibido um menu com opções para criar diferentes
 - **Add address** — Adicionar um endereço.
 - **Add credit card** — Adicionar um cartão de crédito.
 - **Add user** — Adicionar um usuário à organização.
-- **Add organization unit** — Criar uma nova [unidade organizacional](https://help.vtex.com/pt/docs/tutorials/organization-units-pt).
+- **Add organization unit** — Criar uma nova [unidade organizacional](https://help.vtex.com/pt/docs/tutorials/unidades-organizacionais).
 - **Add budget** — Criar um [orçamento](https://help.vtex.com/pt/docs/tutorials/visao-geral-de-budgets).
 - **Add buying policy** — Criar uma [política de compra](https://help.vtex.com/pt/docs/tutorials/buying-policies).
 

--- a/docs/pt/tutorials/b2b/organization-account/conta-da-organizacao.md
+++ b/docs/pt/tutorials/b2b/organization-account/conta-da-organizacao.md
@@ -4,7 +4,7 @@ createdAt: '2025-03-09T10:00:00.000Z'
 updatedAt: '2025-03-26T10:00:00.000Z'
 contentType: tutorial
 productTeam: B2B
-slugEN: conta-da-organizacao
+slugEN: organization-account
 locale: pt
 ---
 

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -17147,8 +17147,8 @@
                   },
                   "slug": {
                     "en": "b2b-buyer-portal",
-                    "es": "",
-                    "pt": ""
+                    "es": "b2b-buyer-portal-es",
+                    "pt": "b2b-buyer-portal-pt"
                   },
                   "origin": "",
                   "type": "markdown",
@@ -17352,21 +17352,6 @@
                 },
                 {
                   "name": {
-                    "pt": "Conta da Organização",
-                    "en": "Conta da Organização",
-                    "es": "Conta da Organização"
-                  },
-                  "slug": {
-                    "pt": "conta-da-organizacao",
-                    "en": "",
-                    "es": ""
-                  },
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": {
                     "en": "Contract settings",
                     "es": "Configuraciones del contrato",
                     "pt": "Configurações do contrato"
@@ -17384,12 +17369,12 @@
                   "name": {
                     "en": "Organization account",
                     "es": "Cuenta de la organización",
-                    "pt": "Organization account"
+                    "pt": "Conta da Organização"
                   },
                   "slug": {
                     "en": "organization-account",
                     "es": "cuenta-de-la-organizacion",
-                    "pt": ""
+                    "pt": "conta-da-organizacao"
                   },
                   "origin": "",
                   "type": "markdown",


### PR DESCRIPTION
- add direct links to the B2B Buyer Portal overview from related EN, ES, and PT articles
- replace English terminology with localized Portuguese wording in the PT Buyer Portal overview
- fix the `slugEN` value for the PT organization account article
