### PR TITLE
[test] Validate link locale checks against PR-generated navigation

### DIFF
--- a/.github/workflows/check-link-locale.yml
+++ b/.github/workflows/check-link-locale.yml
@@ -16,6 +16,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Generate navigation for current PR contents
+        env:
+          REQUEST_TIMEOUT: "60000"
+        run: |
+          set -e
+          mkdir -p public
+          npx --yes --package="github:vtexdocs/vtexhelp-nav-cli#main" --package=axios --package=dotenv \
+            vtex-nav gen --content-dir . --output public/navigation.json || \
+          npx --yes --package="git+https://github.com/vtexdocs/vtexhelp-nav-cli.git#main" --package=axios --package=dotenv \
+            vtex-nav gen --content-dir . --output public/navigation.json
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -27,4 +41,5 @@ jobs:
       - name: Run link locale and slug check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NAVIGATION_FILE: public/navigation.json
         run: python .github/scripts/check_link_locale.py

--- a/docs/en/tutorials/b2b/b2b-buyer-portal/temp-link-check-e2e.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/temp-link-check-e2e.md
@@ -1,0 +1,11 @@
+---
+title: 'Temporary article for link check validation'
+createdAt: '2026-04-07T12:00:00.000Z'
+updatedAt: '2026-04-07T12:00:00.000Z'
+contentType: tutorial
+productTeam: B2B
+slugEN: temp-link-check-e2e
+locale: en
+---
+
+This temporary article exists to validate the link locale workflow against navigation generated from the pull request.

--- a/docs/pt/tutorials/b2b/b2b-buyer-portal/temp-link-check-e2e-pt.md
+++ b/docs/pt/tutorials/b2b/b2b-buyer-portal/temp-link-check-e2e-pt.md
@@ -1,0 +1,13 @@
+---
+title: 'Artigo temporario para validacao do check de links'
+createdAt: '2026-04-07T12:00:00.000Z'
+updatedAt: '2026-04-07T12:00:00.000Z'
+contentType: tutorial
+productTeam: B2B
+slugEN: temp-link-check-e2e
+locale: pt
+---
+
+Este artigo temporario existe para validar o workflow de verificacao de links com a navegacao gerada a partir do pull request.
+
+Link de teste: [artigo temporario](https://help.vtex.com/pt/docs/tutorials/temp-link-check-e2e-pt).

--- a/docs/pt/tutorials/b2b/organization-account/adicionar-ou-editar-unidades-organizacionais.md
+++ b/docs/pt/tutorials/b2b/organization-account/adicionar-ou-editar-unidades-organizacionais.md
@@ -12,6 +12,7 @@ locale: pt
 
 **Unidades organizacionais** são unidades organizacionais que permitem às empresas gerenciar sua estrutura interna de forma hierarquizada, com orçamento próprio, fluxos internos de aprovação, autonomia de compra e outros níveis de subdivisão. Dessa forma, a plataforma permite que uma única empresa B2B opere com múltiplas estruturas internas, mantendo consistência contratual e controle operacional.
 
+
 Este artigo orienta sobre o gerenciamento de unidades organizacionais e está dividido nas seguintes seções:
 
 * [Adicionar unidade organizacional](#adicionar-unidade-organizacional)

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -17258,6 +17258,21 @@
                   "origin": "",
                   "type": "markdown",
                   "children": []
+                },
+                {
+                  "name": {
+                    "en": "Temporary article for link check validation",
+                    "pt": "Artigo temporario para validacao do check de links",
+                    "es": "Temporary article for link check validation"
+                  },
+                  "slug": {
+                    "en": "temp-link-check-e2e",
+                    "pt": "temp-link-check-e2e-pt",
+                    "es": ""
+                  },
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
                 }
               ]
             },


### PR DESCRIPTION
*[TEST ONLY]*

Use navigation generated from the pull request contents when running the link locale check.

## Changes

- add a Node.js setup step to the link-check workflow
- generate `public/navigation.json` before running `check_link_locale.py`
- pass `NAVIGATION_FILE=public/navigation.json` so the checker validates against PR state instead of `main`

## Why

The previous workflow always read `main` branch navigation data, which caused false positives for newly added localized slugs that were valid in the PR but not yet present on `main`.
