### PR TITLE
Fix link locale validation for PR-only slugs

### DIFF
--- a/.github/workflows/check-link-locale.yml
+++ b/.github/workflows/check-link-locale.yml
@@ -16,6 +16,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Generate navigation for current PR contents
+        env:
+          REQUEST_TIMEOUT: "60000"
+        run: |
+          set -e
+          mkdir -p public
+          npx --yes --package="github:vtexdocs/vtexhelp-nav-cli#main" --package=axios --package=dotenv \
+            vtex-nav gen --content-dir . --output public/navigation.json || \
+          npx --yes --package="git+https://github.com/vtexdocs/vtexhelp-nav-cli.git#main" --package=axios --package=dotenv \
+            vtex-nav gen --content-dir . --output public/navigation.json
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -27,4 +41,5 @@ jobs:
       - name: Run link locale and slug check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NAVIGATION_FILE: public/navigation.json
         run: python .github/scripts/check_link_locale.py


### PR DESCRIPTION
﻿## Bug

`check-link-locale` validated links against `public/navigation.json` fetched from the `main` branch. When a pull request introduced a new localized article or slug that existed only in the PR branch, the check could report a false positive because `main` did not know about that slug yet.

## Solution

Update the workflow to generate `public/navigation.json` from the current pull request contents before running the Python checker, and pass that file through `NAVIGATION_FILE`. This makes the validation use the same branch state under review instead of stale data from `main`.

## Test

We validated the fix in a temporary test PR by creating new EN/PT articles and linking to a PT slug that existed only on the PR branch. With this workflow change in place, `Generate navigation on PR` and `check-link-locale` both passed, confirming that the check now resolves PR-only slugs correctly. The temporary validation files were removed from this clean PR.

- Test: [PR 655](https://github.com/vtexdocs/help-center-content/pull/655)
- [Successful check](https://github.com/vtexdocs/help-center-content/actions/runs/24104766716/job/70325087388)
