### PR TITLE
docs: Master Data announcement synopsis and tags for alphanumeric registration

### DIFF
--- a/docs/en/announcements/2026/april/2026-04-24-alphanumeric-company-registration-number-validation-support-in-master-data.md
+++ b/docs/en/announcements/2026/april/2026-04-24-alphanumeric-company-registration-number-validation-support-in-master-data.md
@@ -1,12 +1,15 @@
 ---
 title: 'Support for alphanumeric company registration number validation in Master Data v1'
-status: PUBLISHED
 createdAt: 2026-04-24T00:00:00.000Z
 updatedAt: 2026-04-24T00:00:00.000Z
 contentType: updates
 productTeam: Master Data
 slugEN: 2026-04-24-alphanumeric-company-registration-number-validation-support-in-master-data
 locale: en
+announcementSynopsisEN: 'Master Data v1 now validates alphanumeric company registration numbers on document fields, helping merchants prepare for the new Brazilian format ahead of July 2026.'
+tags:
+  - Improvement
+  - Master Data
 ---
 
 Starting July 2026, Brazil will adopt the new alphanumeric format for company registration numbers. To help merchants prepare, VTEX already supports the new format across all stores through native validation of the **document/company registration number** fields in Master Data v1.

--- a/docs/es/announcements/2026/abril/2026-04-24-soporte-validacion-numero-registro-persona-juridica-alfanumerico-en-master-data.md
+++ b/docs/es/announcements/2026/abril/2026-04-24-soporte-validacion-numero-registro-persona-juridica-alfanumerico-en-master-data.md
@@ -1,12 +1,15 @@
 ---
 title: 'Soporte para la validación de nro. de registro de persona jurídica alfanumérico en Master Data v1'
-status: PUBLISHED
 createdAt: 2026-04-24T00:00:00.000Z
 updatedAt: 2026-04-24T00:00:00.000Z
 contentType: updates
 productTeam: Master Data
 slugEN: 2026-04-24-alphanumeric-company-registration-number-validation-support-in-master-data
 locale: es
+announcementSynopsisES: 'Master Data v1 ahora valida números de registro de persona jurídica alfanuméricos en los campos fiscales, ayudando a los retailers a prepararse para el nuevo formato en Brasil antes de julio de 2026.'
+tags:
+  - Mejora
+  - Master Data
 ---
 
 A partir de julio de 2026 Brasil adoptará el nuevo formato alfanumérico de nro. de registro de persona jurídica. Para que los retailers puedan prepararse con anticipación, VTEX ya ofrece a todas las tiendas soporte para el nuevo formato en la validación nativa de los campos de tipo **nro. de id. fiscal/nro. de registro de persona jurídica** en Master Data v1.

--- a/docs/pt/announcements/2026/abril/2026-04-24-suporte-validacao-cnpj-alfanumerico-master-data.md
+++ b/docs/pt/announcements/2026/abril/2026-04-24-suporte-validacao-cnpj-alfanumerico-master-data.md
@@ -1,12 +1,15 @@
 ---
 title: 'Suporte à validação de CNPJ alfanumérico no Master Data v1'
-status: PUBLISHED
 createdAt: 2026-04-24T00:00:00.000Z
 updatedAt: 2026-04-24T00:00:00.000Z
 contentType: updates
 productTeam: Master Data
 slugEN: 2026-04-24-alphanumeric-company-registration-number-validation-support-in-master-data
 locale: pt
+announcementSynopsisPT: 'O Master Data v1 agora valida CNPJ alfanumérico nos campos de documento, ajudando os lojistas a se prepararem para o novo formato brasileiro antes de julho de 2026.'
+tags:
+  - Melhoria
+  - Master Data
 ---
 
 A partir de julho de 2026, o Brasil adotará o novo formato alfanumérico de CNPJ. Para que os lojistas possam se preparar com antecedência, a VTEX já oferece a todas as lojas suporte ao novo formato na validação nativa dos campos do tipo **CPF/CNPJ** no Master Data v1.


### PR DESCRIPTION
Updates frontmatter for the April 24, 2026 Master Data announcement about alphanumeric company registration validation across EN, ES, and PT.

## Changes

- Remove `status: PUBLISHED` from announcement frontmatter.
- Add locale-specific `announcementSynopsis*` fields (EN, ES, PT).
- Add `tags` (Improvement / Mejora / Melhoria and Master Data) per locale.
