### PR TITLE
docs: redirect references from deprecated buyer organization members article

### DIFF
--- a/docs/en/tutorials/b2b/b2b-buyer-portal/b2b-buyer-portal.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/b2b-buyer-portal.md
@@ -57,7 +57,7 @@ Each unit can have specific settings for product visibility, payment methods, sh
 
 ### Members and roles
 
-[Members](https://help.vtex.com/docs/tutorials/buyer-organization-members) of a buyer organization are assigned storefront roles that define what they can view and do in the store. Examples of predefined roles include:
+[Members](https://help.vtex.com/docs/tutorials/adding-users-to-buyer-organizations) of a buyer organization are assigned storefront roles that define what they can view and do in the store. Examples of predefined roles include:
 
 - **Buyer:** Places orders.
 - **Order Approver:** Approves or rejects orders in approval workflows.
@@ -65,7 +65,7 @@ Each unit can have specific settings for product visibility, payment methods, sh
 - **Budget Manager:** Creates and manages budgets and allocations.
 - **Buying Policy Manager:** Configures purchase approval rules.
 
-These and other available roles can be combined to meet each user's responsibilities, creating a granular permissions model for complex organizational structures. For the full list, see [Buyer organization members](https://help.vtex.com/docs/tutorials/buyer-organization-members).
+These and other available roles can be combined to meet each user's responsibilities, creating a granular permissions model for complex organizational structures. For the full list, see [Adding users to buyer organizations](https://help.vtex.com/docs/tutorials/adding-users-to-buyer-organizations).
 
 ## Finance and compliance
 

--- a/docs/en/tutorials/b2b/b2b-buyer-portal/organizational-units.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/organizational-units.md
@@ -100,7 +100,7 @@ A user's scope of action within an organizational unit in a B2B store is defined
 - **Organizational units**, which determine the group the user belongs to.
 - **Storefront roles**, which define the user's role in the organization by gathering certain permissions to perform actions in the storefront.
 
-Learn more in [Buyer organization members](https://help.vtex.com/en/docs/tutorials/buyer-organization-members).
+Learn more in [Adding users to buyer organizations](https://help.vtex.com/en/docs/tutorials/adding-users-to-buyer-organizations).
 
 ## Shopping experience
 

--- a/docs/en/tutorials/b2b/b2b-buyer-portal/scopes-overview.md
+++ b/docs/en/tutorials/b2b/b2b-buyer-portal/scopes-overview.md
@@ -39,4 +39,4 @@ The restrictions that can be imposed on **Organizational Units** are related to:
 
 To view and manage the scope of an organizational unit, the user's [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-roles) profile must have the `View_Organization_Unit` and `Edit_Organization_Unit` resources.
 
-> ℹ️ For more information, see the article [Buyer organization members](https://help.vtex.com/en/docs/tutorials/buyer-organization-members).
+> ℹ️ For more information, see the article [Adding users to buyer organizations](https://help.vtex.com/en/docs/tutorials/adding-users-to-buyer-organizations).

--- a/docs/en/tutorials/b2b/organization-account/organization-account.md
+++ b/docs/en/tutorials/b2b/organization-account/organization-account.md
@@ -66,7 +66,7 @@ The **Organization** section allows you to manage the organizational structure o
 
 The options include:
 
-- **Users** — Manage [organization users](https://help.vtex.com/en/docs/tutorials/buyer-organization-members).
+- **Users** — Manage [organization users](https://help.vtex.com/en/docs/tutorials/adding-users-to-buyer-organizations).
 - **Roles** — Define permissions and roles.
 - **Organizational units** — Create and manage [organizational units](https://help.vtex.com/en/docs/tutorials/organizational-units).
 

--- a/docs/es/tutorials/b2b/b2b-buyer-portal/b2b-buyer-portal-es.md
+++ b/docs/es/tutorials/b2b/b2b-buyer-portal/b2b-buyer-portal-es.md
@@ -57,7 +57,7 @@ Cada unidad puede tener configuraciones específicas de visibilidad de productos
 
 ### Miembros y roles
 
-A los [miembros](https://help.vtex.com/es/docs/tutorials/miembros-de-la-organizacion-compradora) de una organización compradora se les asignan roles del storefront que definen las secciones que pueden ver y las acciones que pueden realizar en la tienda. Algunos roles predefinidos son:
+A los [miembros](https://help.vtex.com/es/docs/tutorials/agregar-usuarios-a-la-organizacion-compradora) de una organización compradora se les asignan roles del storefront que definen las secciones que pueden ver y las acciones que pueden realizar en la tienda. Algunos roles predefinidos son:
 
 - **Buyer:** realiza pedidos.
 - **Order Approver:** aprueba o rechaza pedidos en flujos de aprobación.
@@ -65,7 +65,7 @@ A los [miembros](https://help.vtex.com/es/docs/tutorials/miembros-de-la-organiza
 - **Budget Manager:** crea y gestiona presupuestos y asignaciones.
 - **Buying Policy Manager:** configura reglas de aprobación de compras.
 
-Los roles pueden combinarse para atender las responsabilidades de cada usuario, creando un modelo de permisos granulares para estructuras organizativas complejas. Para ver la lista completa, consulta [Miembros de la organización compradora](https://help.vtex.com/es/docs/tutorials/miembros-de-la-organizacion-compradora).
+Los roles pueden combinarse para atender las responsabilidades de cada usuario, creando un modelo de permisos granulares para estructuras organizativas complejas. Para ver la lista completa, consulta [Agregar usuarios a la organización compradora](https://help.vtex.com/es/docs/tutorials/agregar-usuarios-a-la-organizacion-compradora).
 
 ## Finanzas y compliance
 

--- a/docs/es/tutorials/b2b/b2b-buyer-portal/unidades-organizativas.md
+++ b/docs/es/tutorials/b2b/b2b-buyer-portal/unidades-organizativas.md
@@ -100,7 +100,7 @@ El ámbito de actuación de un usuario miembro de una unidad organizativa en una
 - **Unidades organizativas**, que determinan el grupo al que pertenece el usuario.
 - **Roles del storefront**, que definen el papel del usuario en la organización reuniendo determinados permisos para realizar acciones en el storefront.
 
-Más información en [Miembros de la organización compradora](https://help.vtex.com/es/docs/tutorials/miembros-de-la-organizacion-compradora).
+Más información en [Agregar usuarios a la organización compradora](https://help.vtex.com/es/docs/tutorials/agregar-usuarios-a-la-organizacion-compradora).
 
 ## Experiencia de compra
 

--- a/docs/es/tutorials/b2b/b2b-buyer-portal/vision-general-de-scopes.md
+++ b/docs/es/tutorials/b2b/b2b-buyer-portal/vision-general-de-scopes.md
@@ -39,4 +39,4 @@ Las restricciones que se pueden imponer a las **unidades organizativas** están 
 
 Para ver y gestionar el scope de una unidad organizativa, el rol de [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-roles) del usuario debe tener los recursos `View_Organization_Unit` y `Edit_Organization_Unit`.
 
-> ℹ️ Para más información, consulta el artículo [Miembros de la organización compradora](https://help.vtex.com/es/docs/tutorials/miembros-de-la-organizacion-compradora).
+> ℹ️ Para más información, consulta el artículo [Agregar usuarios a la organización compradora](https://help.vtex.com/es/docs/tutorials/agregar-usuarios-a-la-organizacion-compradora).

--- a/docs/es/tutorials/b2b/organization-account/cuenta-de-la-organizacion.md
+++ b/docs/es/tutorials/b2b/organization-account/cuenta-de-la-organizacion.md
@@ -66,7 +66,7 @@ La sección **Organización** permite gestionar la estructura organizativa de la
 
 Las opciones incluyen:
 
-- **Usuarios** — gestión de los [usuarios de la organización](https://help.vtex.com/es/docs/tutorials/miembros-de-la-organizacion-compradora).
+- **Usuarios** — gestión de los [usuarios de la organización](https://help.vtex.com/es/docs/tutorials/agregar-usuarios-a-la-organizacion-compradora).
 - **Roles** — definición de permisos y funciones.
 - **Unidades organizativas** — creación y gestión de [unidades organizativas](https://help.vtex.com/es/docs/tutorials/unidades-organizativas).
 

--- a/docs/pt/tutorials/b2b/b2b-buyer-portal/b2b-buyer-portal-pt.md
+++ b/docs/pt/tutorials/b2b/b2b-buyer-portal/b2b-buyer-portal-pt.md
@@ -57,7 +57,7 @@ Os [Scopes](https://help.vtex.com/pt/docs/tutorials/visao-geral-de-scopes) contr
 
 ### Membros e perfis
 
-Os [membros](https://help.vtex.com/pt/docs/tutorials/membros-da-organizacao-compradora) de uma organização compradora recebem perfis de acesso do storefront que definem o que podem ver e fazer na loja. Exemplos de perfis predefinidos incluem:
+Os [membros](https://help.vtex.com/pt/docs/tutorials/adicionar-usuarios-a-organizacao-compradora) de uma organização compradora recebem perfis de acesso do storefront que definem o que podem ver e fazer na loja. Exemplos de perfis predefinidos incluem:
 
 - **Buyer:** realiza pedidos.
 - **Order Approver:** aprova ou rejeita pedidos em fluxos de aprovação.
@@ -65,7 +65,7 @@ Os [membros](https://help.vtex.com/pt/docs/tutorials/membros-da-organizacao-comp
 - **Budget Manager:** cria e gerencia budgets e alocações.
 - **Buying Policy Manager:** configura regras de aprovação de compras.
 
-Esses e outros perfis disponíveis podem ser combinados para atender às responsabilidades de cada usuário, criando um modelo de permissões granular para estruturas organizacionais complexas. Para a lista completa, consulte [Membros da organização compradora](https://help.vtex.com/pt/docs/tutorials/membros-da-organizacao-compradora).
+Esses e outros perfis disponíveis podem ser combinados para atender às responsabilidades de cada usuário, criando um modelo de permissões granular para estruturas organizacionais complexas. Para a lista completa, consulte [Adicionar usuários à organização compradora](https://help.vtex.com/pt/docs/tutorials/adicionar-usuarios-a-organizacao-compradora).
 
 ## Finanças e compliance
 

--- a/docs/pt/tutorials/b2b/b2b-buyer-portal/unidades-organizacionais.md
+++ b/docs/pt/tutorials/b2b/b2b-buyer-portal/unidades-organizacionais.md
@@ -100,7 +100,7 @@ O escopo de atuação do usuário membro de uma unidade organizacional em uma lo
 * **Unidades organizacionais**, que determinam o grupo em que o usuário está contido.
 * **Perfis de acesso do storefront**, que definem o papel do usuário na organização reunindo determinadas permissões para realizar ações na frente de loja.
 
-Saiba mais em [Membros da organização compradora](https://help.vtex.com/pt/docs/tutorials/membros-da-organizacao-compradora).
+Saiba mais em [Adicionar usuários à organização compradora](https://help.vtex.com/pt/docs/tutorials/adicionar-usuarios-a-organizacao-compradora).
 
 ## Experiência de compra
 

--- a/docs/pt/tutorials/b2b/b2b-buyer-portal/visao-geral-de-scopes.md
+++ b/docs/pt/tutorials/b2b/b2b-buyer-portal/visao-geral-de-scopes.md
@@ -39,4 +39,4 @@ As restrições que podem ser impostas a **Organizational Units** estão relacio
 
 Para visualizar e gerenciar o scope de uma organizational unit, o perfil de [Storefront Roles](https://developers.vtex.com/docs/guides/storefront-roles) do usuário deve ter os recursos `View_Organization_Unit` e `Edit_Organization_Unit`.
 
-> ℹ️ Para mais informações, veja o artigo [Membros da organização compradora](https://help.vtex.com/pt/docs/tutorials/membros-da-organizacao-compradora).
+> ℹ️ Para mais informações, veja o artigo [Adicionar usuários à organização compradora](https://help.vtex.com/pt/docs/tutorials/adicionar-usuarios-a-organizacao-compradora).

--- a/docs/pt/tutorials/b2b/organization-account/conta-da-organizacao.md
+++ b/docs/pt/tutorials/b2b/organization-account/conta-da-organizacao.md
@@ -66,7 +66,7 @@ A seção **Organization** permite gerenciar a estrutura organizacional da empre
 
 As opções incluem:
 
-- **Users** — gerenciamento dos [usuários da organização](https://help.vtex.com/pt/docs/tutorials/membros-da-organizacao-compradora).
+- **Users** — gerenciamento dos [usuários da organização](https://help.vtex.com/pt/docs/tutorials/adicionar-usuarios-a-organizacao-compradora).
 - **Roles** — definição de permissões e funções.
 - **Organizational Units** — criação e gerenciamento de [unidades organizacionais](https://help.vtex.com/pt/docs/tutorials/unidades-organizacionais).
 


### PR DESCRIPTION
Updates references to the deprecated "Buyer organization members" article so they point to the new consolidated article, "Adding users to buyer organizations", across all three locales (en, es, pt).

## Changes

- Replaced the old slug `buyer-organization-members` (and its localized variants `miembros-de-la-organizacion-compradora` and `membros-da-organizacao-compradora`) with the new slug `adding-users-to-buyer-organizations` (and its localized variants).
- Updated link text from the old article title to the new article title where the link text was the literal title.
- Preserved contextual link text (e.g., "Members", "organization users") and only updated the slug, to keep sentence flow intact.
- Preserved existing URL prefixes (`/docs/`, `/en/docs/`, `/es/docs/`, `/pt/docs/`) as they were.
