### PR TITLE
EDU-18425: fix(b2b-orders) update outdated URL and missing space in warning note

### DIFF
--- a/docs/en/tutorials/orders/understanding-b2b-orders.md
+++ b/docs/en/tutorials/orders/understanding-b2b-orders.md
@@ -27,7 +27,7 @@ This self-service experience is possible, thanks to API integration with the ERP
 - **ERP order number:** identification number of the order placed through the store ERP.
 - **My order:** identification number associated with the customer who made the purchase.
 
-> ⚠️ This app is only available for stores developed using [VTEX IO](https://vtex.com/br-pt/store-framework/). Before proceeding, you need to [install and configure B2B orders](https://developers.vtex.com/docs/apps/vtex.b2b-orders-history) on your store.
+> ⚠️ This app is only available for stores developed using [Store Framework](https://help.vtex.com/en/docs/tracks/frontend#store-framework). Before proceeding, you need to [install and configure B2B orders](https://developers.vtex.com/docs/apps/vtex.b2b-orders-history) on your store.
 
 ## Context
 

--- a/docs/en/tutorials/orders/understanding-b2b-orders.md
+++ b/docs/en/tutorials/orders/understanding-b2b-orders.md
@@ -27,7 +27,7 @@ This self-service experience is possible, thanks to API integration with the ERP
 - **ERP order number:** identification number of the order placed through the store ERP.
 - **My order:** identification number associated with the customer who made the purchase.
 
-> ⚠️ This app is only available for stores developed using [VTEX IO](https://vtex.com/br-pt/store-framework/).Before proceeding, you need to [install and configure B2B orders](https://developers.vtex.com/vtex-developer-docs/docs/querying-b2b-order-statuses) on your store.
+> ⚠️ This app is only available for stores developed using [VTEX IO](https://vtex.com/br-pt/store-framework/). Before proceeding, you need to [install and configure B2B orders](https://developers.vtex.com/docs/apps/vtex.b2b-orders-history) on your store.
 
 ## Context
 

--- a/docs/es/tutorials/pedidos/entendiendo-pedidos-b2b.md
+++ b/docs/es/tutorials/pedidos/entendiendo-pedidos-b2b.md
@@ -27,7 +27,7 @@ Esa experiencia de autoservicio es posible gracias a una integración vía API c
 - **ERP order number:** número de identificación del pedido en el ERP de la tienda.
 - **My order:** número de identificación asociado al cliente que efectuó la compra.
 
-> ⚠️ Esta app solo está disponible para las tiendas desarrolladas con [VTEX IO](https://vtex.com/br-pt/store-framework/).Antes de continuar, necesita [instalar y configurar Pedidos B2B](https://developers.vtex.com/vtex-developer-docs/docs/querying-b2b-order-statuses) en su tienda.
+> ⚠️ Esta app solo está disponible para las tiendas desarrolladas con [VTEX IO](https://vtex.com/br-pt/store-framework/). Antes de continuar, necesita [instalar y configurar Pedidos B2B](https://developers.vtex.com/docs/apps/vtex.b2b-orders-history) en su tienda.
 
 ## Contexto
 

--- a/docs/es/tutorials/pedidos/entendiendo-pedidos-b2b.md
+++ b/docs/es/tutorials/pedidos/entendiendo-pedidos-b2b.md
@@ -27,7 +27,7 @@ Esa experiencia de autoservicio es posible gracias a una integración vía API c
 - **ERP order number:** número de identificación del pedido en el ERP de la tienda.
 - **My order:** número de identificación asociado al cliente que efectuó la compra.
 
-> ⚠️ Esta app solo está disponible para las tiendas desarrolladas con [VTEX IO](https://vtex.com/br-pt/store-framework/). Antes de continuar, necesita [instalar y configurar Pedidos B2B](https://developers.vtex.com/docs/apps/vtex.b2b-orders-history) en su tienda.
+> ⚠️ Esta app solo está disponible para las tiendas desarrolladas con [Store Framework](https://help.vtex.com/es/docs/tracks/frontend#store-framework). Antes de continuar, necesita [instalar y configurar Pedidos B2B](https://developers.vtex.com/docs/apps/vtex.b2b-orders-history) en su tienda.
 
 ## Contexto
 

--- a/docs/pt/tutorials/pedidos/entendendo-pedidos-b2b.md
+++ b/docs/pt/tutorials/pedidos/entendendo-pedidos-b2b.md
@@ -27,7 +27,7 @@ Essa experiência de autosserviço é possível graças a uma integração via A
 - **ERP order number:** número identificador do pedido realizado por meio do ERP da loja.
 - **My order:** número identificador associado ao cliente que efetuou a compra.
 
-> ⚠️ Esta app só está disponível para lojas desenvolvidas usando [VTEX IO](https://vtex.com/br-pt/store-framework/).Antes de prosseguir, é preciso [instalar e configurar Pedidos B2B](https://developers.vtex.com/vtex-developer-docs/docs/querying-b2b-order-statuses) na sua loja.
+> ⚠️ Esta app só está disponível para lojas desenvolvidas usando [VTEX IO](https://vtex.com/br-pt/store-framework/). Antes de prosseguir, é preciso [instalar e configurar Pedidos B2B](https://developers.vtex.com/docs/apps/vtex.b2b-orders-history) na sua loja.
 
 ## Contexto
 

--- a/docs/pt/tutorials/pedidos/entendendo-pedidos-b2b.md
+++ b/docs/pt/tutorials/pedidos/entendendo-pedidos-b2b.md
@@ -27,7 +27,7 @@ Essa experiência de autosserviço é possível graças a uma integração via A
 - **ERP order number:** número identificador do pedido realizado por meio do ERP da loja.
 - **My order:** número identificador associado ao cliente que efetuou a compra.
 
-> ⚠️ Esta app só está disponível para lojas desenvolvidas usando [VTEX IO](https://vtex.com/br-pt/store-framework/). Antes de prosseguir, é preciso [instalar e configurar Pedidos B2B](https://developers.vtex.com/docs/apps/vtex.b2b-orders-history) na sua loja.
+> ⚠️ Esta app só está disponível para lojas desenvolvidas usando [Store Framework](https://help.vtex.com/pt/docs/tracks/frontend#store-framework). Antes de prosseguir, é preciso [instalar e configurar Pedidos B2B](https://developers.vtex.com/docs/apps/vtex.b2b-orders-history) na sua loja.
 
 ## Contexto
 


### PR DESCRIPTION
Updated outdated developer documentation URL and fixed a missing space in the warning note across the B2B orders article in all three locales (EN, ES, PT).

## Related Task

[EDU-18425](https://vtex-dev.atlassian.net/browse/EDU-18425)
