### PR TITLE
EDU-18606: Add Storefront Custom Resource and Role actions to License Manager

### DIFF
--- a/docs/en/tutorials/security/platform-security-resources/events-available-in-audit.md
+++ b/docs/en/tutorials/security/platform-security-resources/events-available-in-audit.md
@@ -230,6 +230,11 @@ Below, you will find a list of the potential events available in [Audit](/en/doc
 | Resource Access Denied | Resource access denied. | Resource key and user ID to which access was denied. |
 | Create New AppToken | Creation of application key. | Application key created. |
 | Create Sponsor Invite | Creation of a sponsor user invitation. | ID of invited user. |
+| Create Storefront Custom Resource | Creation of a storefront custom resource. | Storefront custom resource created. |
+| Delete Storefront Custom Resource | Deletion of a storefront custom resource. | Storefront custom resource deleted. |
+| Create Storefront Custom Role | Creation of a storefront custom role. | Storefront custom role created. |
+| Delete Storefront Custom Role | Deletion of a storefront custom role. | Storefront custom role deleted. |
+| Update Storefront Custom Role | Update of a storefront custom role. | Storefront custom role updated. |
 
 ## VTEX ID
 

--- a/docs/es/tutorials/seguridad/recursos-de-seguridad-de-la-plataforma/eventos-disponibles-en-audit.md
+++ b/docs/es/tutorials/seguridad/recursos-de-seguridad-de-la-plataforma/eventos-disponibles-en-audit.md
@@ -231,6 +231,11 @@ A continuación, verás la lista de posibles eventos disponibles en [Audit](/es/
 | Resource Access Denied | Acceso al recurso denegado. | Clave del recurso e ID del usuario al que se le denegó. |
 | Create New AppToken | Creación de clave de aplicación. | Clave de aplicación creada. |
 | Create Sponsor Invite | Crear invitación para usuario titular. | ID del usuario que recibirá la invitación. |
+| Create Storefront Custom Resource | Creación de recurso personalizado de frente de tienda. | Recurso personalizado de frente de tienda creado. |
+| Delete Storefront Custom Resource | Eliminación de recurso personalizado de frente de tienda. | Recurso personalizado de frente de tienda eliminado. |
+| Create Storefront Custom Role | Creación de role personalizado de frente de tienda. | Role personalizado de frente de tienda creado. |
+| Delete Storefront Custom Role | Eliminación de role personalizado de frente de tienda. | Role personalizado de frente de tienda eliminado. |
+| Update Storefront Custom Role | Actualización de role personalizado de frente de tienda. | Role personalizado de frente de tienda actualizado. |
 
 ## VTEX ID
 

--- a/docs/pt/tutorials/segurança/recursos-de-segurança-da-plataforma/eventos-disponiveis-no-audit.md
+++ b/docs/pt/tutorials/segurança/recursos-de-segurança-da-plataforma/eventos-disponiveis-no-audit.md
@@ -231,6 +231,11 @@ Confira a seguir a lista dos possíveis eventos disponíveis no [Audit](/pt/docs
 | Resource Access Denied | Acesso a recurso negado. | Chave do recurso e ID do usuário ao qual foi negado. |
 | Create New AppToken | Criação de chave de aplicação. | Chave de aplicação criada. |
 | Create Sponsor Invite | Criação de convite para usuário titular. | ID do usuário convidado. |
+| Create Storefront Custom Resource | Criação de recurso customizado de frente de loja. | Recurso customizado de frente de loja criado. |
+| Delete Storefront Custom Resource | Exclusão de recurso customizado de frente de loja. | Recurso customizado de frente de loja excluído. |
+| Create Storefront Custom Role | Criação de role customizada de frente de loja. | Role customizada de frente de loja criada. |
+| Delete Storefront Custom Role | Exclusão de role customizada de frente de loja. | Role customizada de frente de loja excluída. |
+| Update Storefront Custom Role | Atualização de role customizada de frente de loja. | Role customizada de frente de loja atualizada. |
 
 ## VTEX ID
 

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -66,6 +66,21 @@
                   "origin": "",
                   "type": "markdown",
                   "children": []
+                },
+                {
+                  "name": {
+                    "en": "New events available in Audit",
+                    "es": "Nuevos eventos disponibles en Audit",
+                    "pt": "Novos eventos disponíveis no Audit"
+                  },
+                  "slug": {
+                    "en": "2026-05-12-new-events-available-in-audit",
+                    "es": "2026-05-12-nuevos-eventos-disponibles-en-audit",
+                    "pt": "2026-05-12-novos-eventos-disponiveis-no-audit"
+                  },
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
                 }
               ]
             },
@@ -276,37 +291,6 @@
                     "en": "2026-01-08-new-audit-event-export",
                     "es": "2026-01-08-nueva-audit-exportacion-eventos",
                     "pt": "2026-01-08-nova-exportacao-eventos-audit"
-                  },
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "name": {
-                "en": "May",
-                "es": "Mayo",
-                "pt": "Maio"
-              },
-              "slug": {
-                "en": "may",
-                "es": "mayo",
-                "pt": "maio"
-              },
-              "origin": "",
-              "type": "category",
-              "children": [
-                {
-                  "name": {
-                    "en": "New events available in Audit",
-                    "es": "Nuevos eventos disponibles en Audit",
-                    "pt": "Novos eventos disponíveis no Audit"
-                  },
-                  "slug": {
-                    "en": "2026-05-12-new-events-available-in-audit",
-                    "es": "2026-05-12-nuevos-eventos-disponibles-en-audit",
-                    "pt": "2026-05-12-novos-eventos-disponiveis-no-audit"
                   },
                   "origin": "",
                   "type": "markdown",


### PR DESCRIPTION
## Summary
- Adds five new License Manager audit events for storefront custom resource and role CRUD operations.
- Updates EN, PT, and ES versions of the Events available in Audit article.

## Related Task
[EDU-18606](https://vtex-dev.atlassian.net/browse/EDU-18606)

## References
- Audit PR: https://github.com/vtex/admin-audit/pull/264
- Slack thread: https://vtex.slack.com/archives/C016C3P1J2Y/p1780496106493889
