### PR TITLE
docs(announcements): add June audit events announcement and update month ordering

### DIFF
--- a/docs/en/announcements/2026/april/metadata.json
+++ b/docs/en/announcements/2026/april/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-april",
   "name": "April",
   "slug": "2026-april",
-  "order": 2
+  "order": 3
 }

--- a/docs/en/announcements/2026/february/metadata.json
+++ b/docs/en/announcements/2026/february/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-february",
   "name": "February",
   "slug": "2026-february",
-  "order": 4
+  "order": 5
 }

--- a/docs/en/announcements/2026/january/metadata.json
+++ b/docs/en/announcements/2026/january/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-january",
   "name": "January",
   "slug": "2026-january",
-  "order": 5
+  "order": 6
 }

--- a/docs/en/announcements/2026/june/2026-06-10-new-events-available-in-audit.md
+++ b/docs/en/announcements/2026/june/2026-06-10-new-events-available-in-audit.md
@@ -1,10 +1,10 @@
 ---
 title: 'New events available in Audit'
-createdAt: 2026-05-12T00:00:00.000Z
-updatedAt: 2026-05-12T00:00:00.000Z
+createdAt: 2026-06-10T00:00:00.000Z
+updatedAt: 2026-06-10T00:00:00.000Z
 contentType: updates
 productTeam: Storage
-slugEN: 2026-05-12-new-events-available-in-audit
+slugEN: 2026-06-10-new-events-available-in-audit
 locale: en
 announcementSynopsisEN: 'We''ve expanded the Audit event list with new records for the VTEX ID, Master Data, Orders, and Gift Cards applications, providing greater visibility into sensitive operations in your store.'
 tags:

--- a/docs/en/announcements/2026/june/metadata.json
+++ b/docs/en/announcements/2026/june/metadata.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-june",
+  "name": "June",
+  "slug": "2026-june",
+  "order": 1
+}

--- a/docs/en/announcements/2026/march/metadata.json
+++ b/docs/en/announcements/2026/march/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-march",
   "name": "March",
   "slug": "2026-march",
-  "order": 3
+  "order": 4
 }

--- a/docs/en/announcements/2026/may/metadata.json
+++ b/docs/en/announcements/2026/may/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-may",
   "name": "May",
   "slug": "2026-may",
-  "order": 1
+  "order": 2
 }

--- a/docs/es/announcements/2026/abril/metadata.json
+++ b/docs/es/announcements/2026/abril/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-abril",
   "name": "Abril",
   "slug": "2026-abril",
-  "order": 2
+  "order": 3
 }

--- a/docs/es/announcements/2026/enero/metadata.json
+++ b/docs/es/announcements/2026/enero/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-january",
   "name": "Enero",
   "slug": "2026-enero",
-  "order": 5
+  "order": 6
 }

--- a/docs/es/announcements/2026/febrero/metadata.json
+++ b/docs/es/announcements/2026/febrero/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-february",
   "name": "Febrero",
   "slug": "2026-febrero",
-  "order": 4
+  "order": 5
 }

--- a/docs/es/announcements/2026/junio/2026-06-10-nuevos-eventos-disponibles-en-audit.md
+++ b/docs/es/announcements/2026/junio/2026-06-10-nuevos-eventos-disponibles-en-audit.md
@@ -1,10 +1,10 @@
 ---
 title: 'Nuevos eventos disponibles en Audit'
-createdAt: 2026-05-12T00:00:00.000Z
-updatedAt: 2026-05-12T00:00:00.000Z
+createdAt: 2026-06-10T00:00:00.000Z
+updatedAt: 2026-06-10T00:00:00.000Z
 contentType: updates
 productTeam: Storage
-slugEN: 2026-05-12-new-events-available-in-audit
+slugEN: 2026-06-10-new-events-available-in-audit
 locale: es
 announcementSynopsisES: 'Ampliamos la lista de eventos de Audit con nuevos registros para las aplicaciones VTEX ID, Master Data, Pedidos y Tarjeta de regalo, ofreciendo más visibilidad sobre operaciones sensibles en tu tienda.'
 tags:

--- a/docs/es/announcements/2026/junio/metadata.json
+++ b/docs/es/announcements/2026/junio/metadata.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-junio",
+  "name": "Junio",
+  "slug": "2026-junio",
+  "order": 1
+}

--- a/docs/es/announcements/2026/marzo/metadata.json
+++ b/docs/es/announcements/2026/marzo/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-march",
   "name": "Marzo",
   "slug": "2026-marzo",
-  "order": 3
+  "order": 4
 }

--- a/docs/es/announcements/2026/mayo/metadata.json
+++ b/docs/es/announcements/2026/mayo/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-mayo",
   "name": "Mayo",
   "slug": "2026-mayo",
-  "order": 1
+  "order": 2
 }

--- a/docs/pt/announcements/2026/abril/metadata.json
+++ b/docs/pt/announcements/2026/abril/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-abril",
   "name": "Abril",
   "slug": "2026-abril",
-  "order": 2
+  "order": 3
 }

--- a/docs/pt/announcements/2026/fevereiro/metadata.json
+++ b/docs/pt/announcements/2026/fevereiro/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-february",
   "name": "Fevereiro",
   "slug": "2026-fevereiro",
-  "order": 4
+  "order": 5
 }

--- a/docs/pt/announcements/2026/janeiro/metadata.json
+++ b/docs/pt/announcements/2026/janeiro/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-january",
   "name": "Janeiro",
   "slug": "2026-janeiro",
-  "order": 5
+  "order": 6
 }

--- a/docs/pt/announcements/2026/junho/2026-06-10-novos-eventos-disponiveis-no-audit.md
+++ b/docs/pt/announcements/2026/junho/2026-06-10-novos-eventos-disponiveis-no-audit.md
@@ -1,10 +1,10 @@
 ---
 title: 'Novos eventos disponíveis no Audit'
-createdAt: 2026-05-12T00:00:00.000Z
-updatedAt: 2026-05-12T00:00:00.000Z
+createdAt: 2026-06-10T00:00:00.000Z
+updatedAt: 2026-06-10T00:00:00.000Z
 contentType: updates
 productTeam: Storage
-slugEN: 2026-05-12-new-events-available-in-audit
+slugEN: 2026-06-10-new-events-available-in-audit
 locale: pt
 announcementSynopsisPT: 'Ampliamos a lista de eventos do Audit com novos registros para as aplicações VTEX ID, Master Data, Pedidos e Vale-presente, oferecendo mais visibilidade sobre operações sensíveis na sua loja.'
 tags:

--- a/docs/pt/announcements/2026/junho/metadata.json
+++ b/docs/pt/announcements/2026/junho/metadata.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-junho",
+  "name": "Junho",
+  "slug": "2026-junho",
+  "order": 1
+}

--- a/docs/pt/announcements/2026/maio/metadata.json
+++ b/docs/pt/announcements/2026/maio/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-maio",
   "name": "Maio",
   "slug": "2026-maio",
-  "order": 1
+  "order": 2
 }

--- a/docs/pt/announcements/2026/março/metadata.json
+++ b/docs/pt/announcements/2026/março/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-march",
   "name": "Março",
   "slug": "2026-março",
-  "order": 3
+  "order": 4
 }

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -25,6 +25,37 @@
           "children": [
             {
               "name": {
+                "en": "June",
+                "es": "Junio",
+                "pt": "Junho"
+              },
+              "slug": {
+                "en": "2026-june",
+                "es": "2026-junio",
+                "pt": "2026-junho"
+              },
+              "origin": "",
+              "type": "category",
+              "children": [
+                {
+                  "name": {
+                    "en": "New events available in Audit",
+                    "es": "Nuevos eventos disponibles en Audit",
+                    "pt": "Novos eventos disponíveis no Audit"
+                  },
+                  "slug": {
+                    "en": "2026-06-10-new-events-available-in-audit",
+                    "es": "2026-06-10-nuevos-eventos-disponibles-en-audit",
+                    "pt": "2026-06-10-novos-eventos-disponiveis-no-audit"
+                  },
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                }
+              ]
+            },
+            {
+              "name": {
                 "en": "May",
                 "es": "Mayo",
                 "pt": "Maio"
@@ -276,37 +307,6 @@
                     "en": "2026-01-08-new-audit-event-export",
                     "es": "2026-01-08-nueva-audit-exportacion-eventos",
                     "pt": "2026-01-08-nova-exportacao-eventos-audit"
-                  },
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "name": {
-                "en": "May",
-                "es": "Mayo",
-                "pt": "Maio"
-              },
-              "slug": {
-                "en": "may",
-                "es": "mayo",
-                "pt": "maio"
-              },
-              "origin": "",
-              "type": "category",
-              "children": [
-                {
-                  "name": {
-                    "en": "New events available in Audit",
-                    "es": "Nuevos eventos disponibles en Audit",
-                    "pt": "Novos eventos disponíveis no Audit"
-                  },
-                  "slug": {
-                    "en": "2026-05-12-new-events-available-in-audit",
-                    "es": "2026-05-12-nuevos-eventos-disponibles-en-audit",
-                    "pt": "2026-05-12-novos-eventos-disponiveis-no-audit"
                   },
                   "origin": "",
                   "type": "markdown",


### PR DESCRIPTION
Move the audit events announcement from May to June, updating all localized versions (EN, ES, PT) and adjusting month ordering across all 2026 metadata files.
