### PR TITLE
docs: expand UserLogin and UserLogout event details in Audit article

### DIFF
--- a/docs/en/tutorials/security/platform-security-resources/events-available-in-audit.md
+++ b/docs/en/tutorials/security/platform-security-resources/events-available-in-audit.md
@@ -242,8 +242,8 @@ Below, you will find a list of the potential events available in [Audit](/en/doc
 |---|---|---|
 | PasswordCreated | Creation of a first-time password in the store or the VTEX Admin | User ID. |
 | PasswordUpdated | Change of store or VTEX Admin password by the user. | User ID. |
-| UserLogin | User login to the VTEX Admin. | User ID. |
-| UserLogout | User logout from the VTEX Admin. | User ID. |
+| UserLogin | User login to the VTEX Admin. | User ID, user login, IP address, audience, whether the user is an admin, identity provider, whether MFA was used, host, X-Forwarded-For header, user agent, and referer. |
+| UserLogout | User logout from the VTEX Admin. | User ID, user login, audience, whether the user is an admin, host, X-Forwarded-For header, user agent, and referer. |
 | IdentityProviderChanged | Identity provider configuration change. For example: Creating a customized OAuth integration and changing information in an existing OAuth configuration. | Identity provider. |
 
 ## Master Data

--- a/docs/es/tutorials/seguridad/recursos-de-seguridad-de-la-plataforma/eventos-disponibles-en-audit.md
+++ b/docs/es/tutorials/seguridad/recursos-de-seguridad-de-la-plataforma/eventos-disponibles-en-audit.md
@@ -243,8 +243,8 @@ A continuación, verás la lista de posibles eventos disponibles en [Audit](/es/
 |---|---|---|
 | PasswordCreated | El usuario registra una contraseña por primera vez en la tienda o en el Admin VTEX. | ID de usuario. |
 | PasswordUpdated | El usuario cambia su contraseña de la tienda o del Admin VTEX. | ID de usuario. |
-| UserLogin | Inicio de sesión del usuario en el Admin VTEX. | ID de usuario. |
-| UserLogout | Cierre de sesión del usuario en el Admin VTEX. | ID de usuario. |
+| UserLogin | Inicio de sesión del usuario en el Admin VTEX. | ID de usuario, login de usuario, dirección IP, audience, si el usuario es administrador, proveedor de identidad, si se utilizó MFA, host, encabezado X-Forwarded-For, agente de usuario y referer. |
+| UserLogout | Cierre de sesión del usuario en el Admin VTEX. | ID de usuario, login de usuario, audience, si el usuario es administrador, host, encabezado X-Forwarded-For, agente de usuario y referer. |
 | IdentityProviderChanged | Cambios en la configuración del proveedor de identidad. Por ejemplo, cuando se crea una integración OAuth personalizada, o se modifica la información de una configuración OAuth existente. | Proveedor de identidad. |
 
 ## Master Data

--- a/docs/pt/tutorials/segurança/recursos-de-segurança-da-plataforma/eventos-disponiveis-no-audit.md
+++ b/docs/pt/tutorials/segurança/recursos-de-segurança-da-plataforma/eventos-disponiveis-no-audit.md
@@ -243,8 +243,8 @@ Confira a seguir a lista dos possíveis eventos disponíveis no [Audit](/pt/docs
 |---|---|---|
 | PasswordCreated | Usuário registra uma senha pela primeira vez na loja ou no Admin VTEX. | ID do usuário. |
 | PasswordUpdated | Usuário altera sua senha da loja ou do Admin VTEX. | ID do usuário. |
-| UserLogin | Login do usuário no Admin VTEX. | ID do usuário. |
-| UserLogout | Logout do usuário do Admin VTEX. | ID do usuário. |
+| UserLogin | Login do usuário no Admin VTEX. | ID do usuário, login do usuário, endereço IP, audience, se o usuário é administrador, provedor de identidade, se MFA foi utilizado, host, cabeçalho X-Forwarded-For, agente de usuário e referer. |
+| UserLogout | Logout do usuário do Admin VTEX. | ID do usuário, login do usuário, audience, se o usuário é administrador, host, cabeçalho X-Forwarded-For, agente de usuário e referer. |
 | IdentityProviderChanged | Mudança de configurações de provedor de identidade. Por exemplo: criação de integração OAuth customizada, alteração de informações em configuração de OAuth existente, entre outros. | Provedor de identidade. |
 
 ## Master Data

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -52190,6 +52190,21 @@
             },
             {
               "name": {
+                "en": "Indexing History page shows high volume of products with indexing delay",
+                "es": "La página «Historial de indexación» muestra un gran volumen de productos con retrasos en la indexación",
+                "pt": "A página \"Histórico de indexação\" mostra um grande volume de produtos com atraso na indexação"
+              },
+              "slug": {
+                "en": "indexing-history-page-shows-high-volume-of-products-with-indexing-delay",
+                "es": "la-pagina-historial-de-indexacion-muestra-un-gran-volumen-de-productos-con-retrasos-en-la-indexacion",
+                "pt": "a-pagina-historico-de-indexacao-mostra-um-grande-volume-de-produtos-com-atraso-na-indexacao"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
                 "en": "Intelligent Search Banner update via Image URL does not work correctly",
                 "es": "La actualización del banner de búsqueda inteligente mediante la URL de la imagen no funciona correctamente",
                 "pt": "A atualização do banner de pesquisa inteligente por meio do URL da imagem não funciona corretamente"
@@ -52573,21 +52588,6 @@
                 "en": "product-image-sorting-doesnt-respect-the-catalog-order",
                 "es": "la-ordenacion-de-las-imagenes-de-los-productos-no-respeta-el-orden-del-catalogo",
                 "pt": "a-classificacao-da-imagem-do-produto-nao-respeita-a-ordem-do-catalogo"
-              },
-              "origin": "",
-              "type": "markdown",
-              "children": []
-            },
-            {
-              "name": {
-                "en": "Product indexing may show a high delay in Indexing History",
-                "es": "La indexación de productos puede mostrar un retraso considerable en el historial de indexación",
-                "pt": "A indexação de produtos pode apresentar um grande atraso no Histórico de indexação"
-              },
-              "slug": {
-                "en": "product-indexing-may-show-a-high-delay-in-indexing-history",
-                "es": "la-indexacion-de-productos-puede-mostrar-un-retraso-considerable-en-el-historial-de-indexacion",
-                "pt": "a-indexacao-de-produtos-pode-apresentar-um-grande-atraso-no-historico-de-indexacao"
               },
               "origin": "",
               "type": "markdown",


### PR DESCRIPTION
Updated the event details for `UserLogin` and `UserLogout` in the VTEX ID section of the "Events available in Audit" article across all three locales (EN, ES, PT).
