### PR TITLE
EDU-18839: add GET_UNMASKED_PII audit event for Gift Card

### DIFF
--- a/docs/en/tutorials/security/platform-security-resources/events-available-in-audit.md
+++ b/docs/en/tutorials/security/platform-security-resources/events-available-in-audit.md
@@ -192,6 +192,7 @@ Below, you will find a list of the potential events available in [Audit](/en/doc
 | CREATE_GIFT_CARD_CANCELLATION | Gift card cancellation record. | Gift card ID. |
 | CREATE_GIFT_CARD_SETTLEMENT | Gift card settlement record. | Gift card ID. |
 | INSERT_GIFT_CARD_CREDITS | Added credit to gift card. | Gift card ID. |
+| GET_UNMASKED_PII | Viewed unmasked personally identifiable information (PII). | Gift card ID. |
 ## Checkout
 
 | Action | Event description | Event details |

--- a/docs/es/tutorials/seguridad/recursos-de-seguridad-de-la-plataforma/eventos-disponibles-en-audit.md
+++ b/docs/es/tutorials/seguridad/recursos-de-seguridad-de-la-plataforma/eventos-disponibles-en-audit.md
@@ -192,6 +192,7 @@ A continuación, verás la lista de posibles eventos disponibles en [Audit](/es/
 | CREATE_GIFT_CARD_CANCELLATION | Registrar la cancelación de las tarjetas de regalo. | ID de la tarjeta de regalo. |
 | CREATE_GIFT_CARD_SETTLEMENT | Registrar la liquidación de las tarjeta de regalo. | ID de la tarjeta de regalo. |
 | INSERT_GIFT_CARD_CREDITS | Insertar créditos en tarjeta de regalo. | ID de la tarjeta de regalo. |
+| GET_UNMASKED_PII | Visualización de información de identificación personal (PII) sin enmascarar. | ID de la tarjeta de regalo. |
 
 ## Checkout
 

--- a/docs/pt/tutorials/segurança/recursos-de-segurança-da-plataforma/eventos-disponiveis-no-audit.md
+++ b/docs/pt/tutorials/segurança/recursos-de-segurança-da-plataforma/eventos-disponiveis-no-audit.md
@@ -192,6 +192,7 @@ Confira a seguir a lista dos possíveis eventos disponíveis no [Audit](/pt/docs
 | CREATE_GIFT_CARD_CANCELLATION | Registro de cancelamento de vale-presente. | ID do vale-presente. |
 | CREATE_GIFT_CARD_SETTLEMENT | Registro de liquidação de vale-presente. | ID do vale-presente. |
 | INSERT_GIFT_CARD_CREDITS | Inserção de créditos em vale-presente. | ID do vale-presente. |
+| GET_UNMASKED_PII | Visualização de informações de identificação pessoal (PII) sem máscara. | ID do vale-presente. |
 
 ## Checkout
 


### PR DESCRIPTION
## Summary

Adds the new `GET_UNMASKED_PII` audit event to the Gift Card section of the [Events available in Audit](https://help.vtex.com/en/tutorial/events-available-in-audit--6r1Mzcu5NmkmmDLJlz9CCZ) article (EN, PT, ES).

This event tracks access to unmasked PII (personally identifiable information) in the Gift Card System.

Source: [vtex/admin-audit#267](https://github.com/vtex/admin-audit/pull/267) (still open at time of writing — hold publishing until it merges).

## Related Task

[EDU-18839](https://vtex-dev.atlassian.net/browse/EDU-18839)