### PR TITLE
docs: add CloudFront incompatibility warning to reverse proxy article

### DIFF
--- a/docs/en/tutorials/infrastructure/cdn-service/insert-reverse-proxy-in-front-of-vtex-services.md
+++ b/docs/en/tutorials/infrastructure/cdn-service/insert-reverse-proxy-in-front-of-vtex-services.md
@@ -17,6 +17,8 @@ subcategoryId: 2Za4fjGfxYOo6oqykukgyy
 
 > ❗ This guide addresses a practice that is **not recommended** for most stores and should only be applied in extreme cases. Implementing a reverse proxy replaces all perimeter services (CDN) managed and optimized by VTEX. This means that the store will be responsible for effective site provisioning, including configuring, monitoring, and managing aspects such as header passing, cookies, and caching. VTEX doesn't provide support or documentation for this specific configuration and is not responsible for any issues that may arise. VTEX is not responsible for problems with this system, whether related to our CDN, WAF service, or any other resource in front of our servers. We will not have visibility into the operation, and therefore, the solution is **not** covered under our SLA agreements.
 
+> ❗ This configuration is **not compatible with Amazon CloudFront**. As of January 2025, stores using CloudFront as their CDN cannot use a reverse proxy in front of VTEX services. Attempting this configuration with CloudFront may cause navigation failures and site downtime.
+
 To point your own CDN to the VTEX CDN, you need to insert a reverse proxy in front of VTEX services. The traffic flow follows this path:
 
 1. Store: Point of origin of traffic.

--- a/docs/es/tutorials/infraestructura/cdn-service/insertar-proxy-inverso-frente-a-los-servicios-vtex.md
+++ b/docs/es/tutorials/infraestructura/cdn-service/insertar-proxy-inverso-frente-a-los-servicios-vtex.md
@@ -17,6 +17,8 @@ subcategoryId: 2Za4fjGfxYOo6oqykukgyy
 
 > ❗ Esta guía aborda una práctica **no recomendada** para la mayoría de las tiendas y que solo debe aplicarse en casos excepcionales. Implementar un proxy inverso significa sustituir todos los servicios perimetrales (CDN) gestionados y optimizados por VTEX. Esto significa que la tienda será responsable por mantener efectivamente el sitio web, incluyendo configuración, monitoreo y gestión de aspectos como el paso de encabezados, cookies y la caché. VTEX no ofrece soporte o documentación para esas configuraciones específicas y no se hace responsable por los problemas que puedan surgir. VTEX no se hace responsable por problemas en ese sistema, ya sea en una CDN propia, un servicio de WAF u otro recurso que esté delante de nuestros servidores. No tenemos visibilidad de la operación y, por lo tanto, la solución **no** entra en nuestros acuerdos de SLA.
 
+> ❗ Esta configuración **no es compatible con Amazon CloudFront**. A partir de enero de 2025, las tiendas que usan CloudFront como CDN no pueden utilizar un proxy inverso delante de los servicios de VTEX. Intentar esta configuración con CloudFront puede causar fallos de navegación e indisponibilidad del sitio.
+
 Para apuntar tu propia CDN a la CDN de VTEX, debes insertar un proxy inverso delante de los servicios de VTEX. El flujo de tráfico seguirá el orden a continuación:
 
 1. Tienda: punto de origen del tráfico.

--- a/docs/pt/tutorials/infraestrutura/cdn-service/inserir-proxy-reverso-em-frente-aos-servicos-da-vtex.md
+++ b/docs/pt/tutorials/infraestrutura/cdn-service/inserir-proxy-reverso-em-frente-aos-servicos-da-vtex.md
@@ -17,6 +17,8 @@ subcategoryId: 2Za4fjGfxYOo6oqykukgyy
 
 > ❗  Este guia aborda uma prática **não recomendada** para a maioria das lojas e é aplicável somente a casos de extrema exceção.   Implementar um proxy reverso significa substituir todos os serviços de borda (CDN) gerenciados e otimizados pela VTEX. Isso implica que a loja será responsável pelo fornecimento efetivo do site, incluindo configurações, monitoramento e gerenciamento de aspectos como repasse de cabeçalhos, cookies e cache. A VTEX não oferece suporte ou documentação para essas configurações específicas e não se responsabiliza por problemas que possam surgir.   A VTEX não se responsabiliza por problemas nesse sistema, seja um CDN próprio, serviço de WAF ou outro recurso que fique à frente dos nossos servidores. Não teremos visibilidade da operação, e, portanto, a solução **não** se enquadra em nossos acordos de SLA. 
 
+> ❗ Esta configuração **não é compatível com o Amazon CloudFront**. A partir de janeiro de 2025, lojas que utilizam o CloudFront como CDN não conseguem usar proxy reverso à frente dos serviços da VTEX. Tentar essa configuração com o CloudFront pode causar falhas de navegação e indisponibilidade do site.
+
 Para apontar sua própria CDN para a CDN da VTEX, é necessário inserir um proxy reverso em frente aos serviços da VTEX. Neste cenário, o fluxo de tráfego passa a seguir este caminho: 
 
 1. Loja: O ponto de origem do tráfego.  

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -40798,6 +40798,21 @@
             },
             {
               "name": {
+                "en": "Catalog Kit Insertion Allows Circular Reference",
+                "es": "La inserción del kit de catálogo permite una referencia circular.",
+                "pt": "A inserção do kit de catálogo permite referência circular."
+              },
+              "slug": {
+                "en": "catalog-kit-insertion-allows-circular-reference",
+                "es": "la-insercion-del-kit-de-catalogo-permite-una-referencia-circular",
+                "pt": "a-insercao-do-kit-de-catalogo-permite-referencia-circular"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
                 "en": "Catalog Myvtex Iframe HTML Select Breaking for Chrome 108",
                 "es": "Catálogo Myvtex Iframe HTML: selección de «Breaking» para Chrome 108",
                 "pt": "Catálogo Myvtex Iframe HTML Select Breaking para o Chrome 108"
@@ -42959,13 +42974,13 @@
             {
               "name": {
                 "en": "Publish button intermittently unresponsive in Seller Portal product creation/update",
-                "es": "El botón «Publicar» no responde de forma intermitente al crear o actualizar productos en el Portal del vendedor",
-                "pt": "O botão “Publicar” não responde ocasionalmente durante a criação/atualização de produtos no Portal do Vendedor"
+                "es": "El botón de publicación no responde de forma intermitente en la creación/actualización de productos en el Portal del vendedor.",
+                "pt": "O botão \"Publicar\" apresenta falhas intermitentes na criação/atualização de produtos no Seller Portal."
               },
               "slug": {
                 "en": "publish-button-intermittently-unresponsive-in-seller-portal-product-creationupdate",
-                "es": "el-boton-publicar-no-responde-de-forma-intermitente-al-crear-o-actualizar-productos-en-el-portal-del-vendedor",
-                "pt": "o-botao-publicar-nao-responde-ocasionalmente-durante-a-criacaoatualizacao-de-produtos-no-portal-do-vendedor"
+                "es": "el-boton-de-publicacion-no-responde-de-forma-intermitente-en-la-creacionactualizacion-de-productos-en-el-portal-del-vendedor",
+                "pt": "o-botao-publicar-apresenta-falhas-intermitentes-na-criacaoatualizacao-de-produtos-no-seller-portal"
               },
               "origin": "",
               "type": "markdown",
@@ -43281,6 +43296,21 @@
                 "en": "sku-insert-file-api-is-not-responding-with-the-text-property",
                 "es": "la-api-de-insercion-de-archivos-de-sku-no-responde-con-la-propiedad-texto",
                 "pt": "a-api-sku-insert-file-nao-esta-respondendo-com-a-propriedade-text"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
+                "en": "SKU Insert FIle API may generate duplicate images if it fails",
+                "es": "La API de inserción de archivos SKU puede generar imágenes duplicadas si falla.",
+                "pt": "A API de Inserção de Arquivos SKU pode gerar imagens duplicadas se falhar."
+              },
+              "slug": {
+                "en": "sku-insert-file-api-may-generate-duplicate-images-if-it-fails",
+                "es": "la-api-de-insercion-de-archivos-sku-puede-generar-imagenes-duplicadas-si-falla",
+                "pt": "a-api-de-insercao-de-arquivos-sku-pode-gerar-imagens-duplicadas-se-falhar"
               },
               "origin": "",
               "type": "markdown",
@@ -44746,7 +44776,7 @@
             {
               "name": {
                 "en": "Carts created from order replacement do not receive promotions correctly",
-                "es": "Los carritos creados a partir de la sustitución de un pedido no reciben las promociones correctamente",
+                "es": "Los carritos creados a partir de la sustitución de un pedido no reciben las promociones correctamente.",
                 "pt": "Os carrinhos criados a partir da substituição de pedidos não recebem as promoções corretamente"
               },
               "slug": {
@@ -50584,12 +50614,12 @@
             {
               "name": {
                 "en": "Netshoes - Main Image not respected",
-                "es": "Imagen principal no respetada",
+                "es": "Netshoes - Imagen principal no respetada",
                 "pt": "Netshoes - Imagem principal não respeitada"
               },
               "slug": {
                 "en": "netshoes-main-image-not-respected",
-                "es": "imagen-principal-no-respetada",
+                "es": "netshoes-imagen-principal-no-respetada",
                 "pt": "netshoes-imagem-principal-nao-respeitada"
               },
               "origin": "",
@@ -50719,13 +50749,13 @@
             {
               "name": {
                 "en": "Shopee Catalog Sync Blocked Due to Excess Variation Attributes",
-                "es": "Shopee Sincronización de catálogo bloqueada por exceso de atributos de variación",
-                "pt": "Shopee Sincronização de catálogo bloqueada devido ao excesso de atributos de variação"
+                "es": "Sincronización del catálogo bloqueada debido a un exceso de atributos de variación.",
+                "pt": "Sincronização do catálogo bloqueada devido ao excesso de atributos de variação."
               },
               "slug": {
                 "en": "shopee-catalog-sync-blocked-due-to-excess-variation-attributes",
-                "es": "shopee-sincronizacion-de-catalogo-bloqueada-por-exceso-de-atributos-de-variacion",
-                "pt": "shopee-sincronizacao-de-catalogo-bloqueada-devido-ao-excesso-de-atributos-de-variacao"
+                "es": "sincronizacion-del-catalogo-bloqueada-debido-a-un-exceso-de-atributos-de-variacion",
+                "pt": "sincronizacao-do-catalogo-bloqueada-devido-ao-excesso-de-atributos-de-variacao"
               },
               "origin": "",
               "type": "markdown",
@@ -68706,6 +68736,68 @@
                 "en": "order-not-notified-carrier-leaves-label-barcode-incomplete",
                 "es": "el-transportista-no-ha-sido-informado-del-pedido-y-ha-dejado-el-codigo-de-barras-de-la-etiqueta-incompleto",
                 "pt": "encomenda-nao-notificada-a-transportadora-deixa-o-codigo-de-barras-da-etiqueta-incompleto"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            }
+          ]
+        },
+        {
+          "name": {
+            "en": "Marketplace in",
+            "es": "Marketplace in",
+            "pt": "Marketplace in"
+          },
+          "slug": {
+            "en": "marketplace-in",
+            "es": "marketplace-in",
+            "pt": "marketplace-in"
+          },
+          "origin": "",
+          "type": "category",
+          "children": [
+            {
+              "name": {
+                "en": "Shopee Order code: 001 / Invalid Email",
+                "es": "Shopee Código de pedido: 001 / Correo electrónico no válido",
+                "pt": "Shopee Código do pedido: 001 / E-mail inválido"
+              },
+              "slug": {
+                "en": "shopee-order-code-001-invalid-email",
+                "es": "shopee-codigo-de-pedido-001-correo-electronico-no-valido",
+                "pt": "shopee-codigo-do-pedido-001-email-invalido"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            }
+          ]
+        },
+        {
+          "name": {
+            "en": "Marketplace out",
+            "es": "Marketplace out",
+            "pt": "Marketplace out"
+          },
+          "slug": {
+            "en": "marketplace-out",
+            "es": "marketplace-out",
+            "pt": "marketplace-out"
+          },
+          "origin": "",
+          "type": "category",
+          "children": [
+            {
+              "name": {
+                "en": "Magazine Luiza - Main Image not respected",
+                "es": "Magazine Luiza - Imagen principal no respetada",
+                "pt": "Magazine Luiza - Imagem principal não respeitada"
+              },
+              "slug": {
+                "en": "magazine-luiza-main-image-not-respected",
+                "es": "magazine-luiza-imagen-principal-no-respetada",
+                "pt": "magazine-luiza-imagem-principal-nao-respeitada"
               },
               "origin": "",
               "type": "markdown",


### PR DESCRIPTION
[EDU-18826](https://vtex-dev.atlassian.net/browse/EDU-18826)

Adds a warning callout to the reverse proxy article (PT, EN, ES) noting that this configuration is incompatible with Amazon CloudFront since January 2025. This was a breaking change that went undocumented, leading to customer incidents when they tried to use the setup with CloudFront.