### PR TITLE
fix(retail-media): correct broken YAML frontmatter delimiter

### DIFF
--- a/docs/pt/tutorials/retail-media/metricas-e-atribuicao-do-vtex-ads.md
+++ b/docs/pt/tutorials/retail-media/metricas-e-atribuicao-do-vtex-ads.md
@@ -1,14 +1,12 @@
 ---
-
-## title: 'Métricas e atribuição do VTEX Ads'
-
+title: 'Métricas e atribuição do VTEX Ads'
 createdAt: '2026-07-01T10:00:00.000Z'
 updatedAt: '2026-07-01T10:00:00.000Z'
 contentType: tutorial
 productTeam: Others
 slugEN: vtex-ads-metrics-and-attribution
 locale: pt
-
+---
 O [VTEX Ads](/pt/docs/tracks/retail-media) oferece um conjunto de métricas para ajudar anunciantes, publishers e agências de marketing a medir o desempenho das campanhas e o retorno sobre o investimento em publicidade. As métricas estão disponíveis em todos os dashboards do VTEX Ads como **cards de métricas** no topo de cada tela e como **colunas** nas tabelas correspondentes.
 
 Este artigo descreve as métricas disponíveis e o modelo de atribuição que determina como a plataforma credita conversões aos anúncios.

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -38940,12 +38940,12 @@
               "name": {
                 "en": "VTEX Ads metrics and attribution",
                 "es": "Métricas y atribución de VTEX Ads",
-                "pt": "VTEX Ads metrics and attribution"
+                "pt": "Métricas e atribuição do VTEX Ads"
               },
               "slug": {
                 "en": "vtex-ads-metrics-and-attribution",
                 "es": "metricas-y-atribucion-de-vtex-ads",
-                "pt": ""
+                "pt": "metricas-e-atribuicao-do-vtex-ads"
               },
               "origin": "",
               "type": "markdown",
@@ -68985,6 +68985,21 @@
           "origin": "",
           "type": "category",
           "children": [
+            {
+              "name": {
+                "en": "Dafiti Installment interest incorrectly increases item sellingPrice in Dafiti orders",
+                "es": "Dafiti El interés de las cuotas aumenta incorrectamente el precio de venta del artículo en los pedidos de Dafiti.",
+                "pt": "Dafiti O cálculo de juros parcelados aumenta incorretamente o preço de venda dos itens em pedidos da Dafiti."
+              },
+              "slug": {
+                "en": "dafiti-installment-interest-incorrectly-increases-item-sellingprice-in-dafiti-orders",
+                "es": "dafiti-el-interes-de-las-cuotas-aumenta-incorrectamente-el-precio-de-venta-del-articulo-en-los-pedidos-de-dafiti",
+                "pt": "dafiti-o-calculo-de-juros-parcelados-aumenta-incorretamente-o-preco-de-venda-dos-itens-em-pedidos-da-dafiti"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
             {
               "name": {
                 "en": "Magazine Luiza - Main Image not respected",


### PR DESCRIPTION
Fixes a broken YAML frontmatter block in the "Métricas e atribuição do VTEX Ads" tutorial that was causing the frontmatter to render incorrectly.
