### PR TITLE
fix(announcements): correct audit events tag to Improvement

### DIFF
--- a/docs/en/announcements/2026/june/2026-06-10-new-events-available-in-audit.md
+++ b/docs/en/announcements/2026/june/2026-06-10-new-events-available-in-audit.md
@@ -8,7 +8,7 @@ slugEN: 2026-06-10-new-events-available-in-audit
 locale: en
 announcementSynopsisEN: 'We''ve expanded the Audit event list with new records for the VTEX ID, Master Data, Orders, and Gift Cards applications, providing greater visibility into sensitive operations in your store.'
 tags:
-  - New
+  - Improvement
   - Audit
 ---
 

--- a/docs/es/announcements/2026/junio/2026-06-10-nuevos-eventos-disponibles-en-audit.md
+++ b/docs/es/announcements/2026/junio/2026-06-10-nuevos-eventos-disponibles-en-audit.md
@@ -8,7 +8,7 @@ slugEN: 2026-06-10-new-events-available-in-audit
 locale: es
 announcementSynopsisES: 'Ampliamos la lista de eventos de Audit con nuevos registros para las aplicaciones VTEX ID, Master Data, Pedidos y Tarjeta de regalo, ofreciendo más visibilidad sobre operaciones sensibles en tu tienda.'
 tags:
-  - Nuevo
+  - Mejora
   - Audit
 ---
 

--- a/docs/pt/announcements/2026/junho/2026-06-10-novos-eventos-disponiveis-no-audit.md
+++ b/docs/pt/announcements/2026/junho/2026-06-10-novos-eventos-disponiveis-no-audit.md
@@ -8,7 +8,7 @@ slugEN: 2026-06-10-new-events-available-in-audit
 locale: pt
 announcementSynopsisPT: 'Ampliamos a lista de eventos do Audit com novos registros para as aplicações VTEX ID, Master Data, Pedidos e Vale-presente, oferecendo mais visibilidade sobre operações sensíveis na sua loja.'
 tags:
-  - Novo
+  - Melhoria
   - Audit
 ---
 


### PR DESCRIPTION

Corrects the tag on the "New events available in Audit" announcement across all three locales.
