### PR TITLE
Copy Crowdin word count to language subtasks

### DIFF
--- a/.github/workflows/localization-ticket.yml
+++ b/.github/workflows/localization-ticket.yml
@@ -874,10 +874,6 @@ jobs:
             fi
           }
 
-          merge_word_count_description() {
-            CURRENT="$1" COUNT="$2" python3 .github/scripts/crowdin_sync.py word-count
-          }
-
           is_language_subtask() {
             case "$1" in
               English*|Portuguese*|Spanish*) return 0 ;;
@@ -888,28 +884,12 @@ jobs:
           update_subtask_word_count() {
             local key="$1"
             local summary="$2"
-            local current_desc merged_desc custom_fields payload response
-
-            if [ -z "$CROWDIN_TOTAL_WORDS" ]; then
-              echo "Missing word count for ${summary} subtask ${key}" >&2
-              exit 1
-            fi
-
-            current_desc=$(curl -s \
-              -u "${LOC_JIRA_USER_EMAIL}:${LOC_JIRA_API_TOKEN}" \
-              "${LOC_JIRA_BASE_URL}/rest/api/2/issue/${key}?fields=description" \
-              | jq -r '.fields.description // ""')
-            merged_desc=$(merge_word_count_description "$current_desc" "$CROWDIN_TOTAL_WORDS")
-
-            custom_fields=$(jq -n \
-              --arg field "$LOC_JIRA_WORD_COUNT_FIELD" \
-              --argjson count "$CROWDIN_TOTAL_WORDS" \
-              '{($field): $count}')
+            local payload response
 
             payload=$(jq -n \
-              --arg description "$merged_desc" \
-              --argjson custom_fields "$custom_fields" \
-              '{fields: ({description: $description} + $custom_fields)}')
+              --arg field "$LOC_JIRA_WORD_COUNT_FIELD" \
+              --argjson count "$CROWDIN_TOTAL_WORDS" \
+              '{fields: {($field): $count}}')
 
             response=$(curl -s -o update-subtask-word-count-response.json -w "%{http_code}" \
               -X PUT \

--- a/.github/workflows/localization-ticket.yml
+++ b/.github/workflows/localization-ticket.yml
@@ -2,8 +2,8 @@
 # is added to a PR with new markdown content.
 #
 # Trigger: localization needed (high|medium|low) on PRs to main under docs/pt/**,
-# docs/en/**, or localization/**. Skips PRs with the "localization" label or l10n*
-# branches. Re-add the label after new commits if it was applied before content changed.
+# docs/en/**, or localization/**. Skips PRs with the "localization" label (case-insensitive)
+# or l10n* branches (case-insensitive). Re-add the label after new commits if it was applied before content changed.
 #
 # Content routing (mutually exclusive):
 #   docs/pt or localization/ → PT Crowdin project
@@ -50,23 +50,48 @@ on:
 jobs:
   create-jira-ticket:
     if: >
-      (github.event.label.name == 'localization needed (high)' ||
-       github.event.label.name == 'localization needed (medium)' ||
-       github.event.label.name == 'localization needed (low)') &&
-      !contains(github.event.pull_request.labels.*.name, 'localization') &&
-      !startsWith(github.event.pull_request.head.ref, 'l10n')
+      github.event.label.name == 'localization needed (high)' ||
+      github.event.label.name == 'localization needed (medium)' ||
+      github.event.label.name == 'localization needed (low)'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
 
     steps:
+      - name: Check PR eligibility
+        id: eligibility
+        run: |
+          HEAD_REF='${{ github.event.pull_request.head.ref }}'
+          HEAD_REF_LOWER=$(printf '%s' "$HEAD_REF" | tr '[:upper:]' '[:lower:]')
+
+          if [[ "$HEAD_REF_LOWER" == l10n* ]]; then
+            echo "Skipping: head branch starts with l10n (case-insensitive): ${HEAD_REF}"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          HAS_LOCALIZATION_LABEL=$(jq -r '
+            [.pull_request.labels[].name | ascii_downcase == "localization"] | any
+          ' "$GITHUB_EVENT_PATH")
+
+          if [ "$HAS_LOCALIZATION_LABEL" = "true" ]; then
+            echo "Skipping: PR has localization label (case-insensitive)"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "PR is eligible for localization automation"
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
+        if: steps.eligibility.outputs.should_run == 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Check for content additions
+        if: steps.eligibility.outputs.should_run == 'true'
         id: content_diff
         run: |
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
@@ -128,7 +153,9 @@ jobs:
 
       - name: Check production lock for existing tasks
         id: production_lock
-        if: steps.content_diff.outputs.has_additions == 'true'
+        if: >-
+          steps.eligibility.outputs.should_run == 'true' &&
+          steps.content_diff.outputs.has_additions == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           LOC_JIRA_BASE_URL: ${{ secrets.LOC_JIRA_BASE_URL }}
@@ -209,6 +236,7 @@ jobs:
       - name: Resolve or create Jira ticket
         id: parent_ticket
         if: >-
+          steps.eligibility.outputs.should_run == 'true' &&
           steps.content_diff.outputs.has_additions == 'true' &&
           steps.production_lock.outputs.updates_blocked != 'true'
         env:
@@ -402,6 +430,7 @@ jobs:
 
       - name: Link source Jira tasks from PR
         if: >-
+          steps.eligibility.outputs.should_run == 'true' &&
           steps.content_diff.outputs.has_additions == 'true' &&
           steps.production_lock.outputs.updates_blocked != 'true' &&
           steps.parent_ticket.outputs.parent_key != ''
@@ -503,6 +532,7 @@ jobs:
       - name: Upload touched files to Crowdin
         id: crowdin_upload
         if: >-
+          steps.eligibility.outputs.should_run == 'true' &&
           steps.content_diff.outputs.has_additions == 'true' &&
           steps.production_lock.outputs.updates_blocked != 'true' &&
           steps.parent_ticket.outputs.parent_key != ''
@@ -520,6 +550,7 @@ jobs:
 
       - name: Update parent task word count
         if: >-
+          steps.eligibility.outputs.should_run == 'true' &&
           steps.content_diff.outputs.has_additions == 'true' &&
           steps.production_lock.outputs.updates_blocked != 'true' &&
           steps.parent_ticket.outputs.parent_key != ''
@@ -567,6 +598,7 @@ jobs:
 
       - name: Comment on PR with Jira link
         if: >-
+          steps.eligibility.outputs.should_run == 'true' &&
           steps.content_diff.outputs.has_additions == 'true' &&
           steps.production_lock.outputs.updates_blocked != 'true' &&
           steps.parent_ticket.outputs.parent_key != ''
@@ -639,6 +671,7 @@ jobs:
 
       - name: Create localization subtasks
         if: >-
+          steps.eligibility.outputs.should_run == 'true' &&
           steps.content_diff.outputs.has_additions == 'true' &&
           steps.production_lock.outputs.updates_blocked != 'true' &&
           steps.parent_ticket.outputs.parent_key != ''

--- a/.github/workflows/localization-ticket.yml
+++ b/.github/workflows/localization-ticket.yml
@@ -17,8 +17,8 @@
 # Links source tasks found in the PR title, description, or branch to
 # the LOC parent with a `blocks` link.
 #
-# Crowdin: uploads PR-changed files via API, sets word count on the parent,
-# editor links on # language subtasks. Partial upload for existing files with
+# Crowdin: uploads PR-changed files via API, sets word count on the parent and
+# language subtasks, editor links on language subtasks. Partial upload for existing files with
 # changes in ≤5 blocks (not new files); full source file is attached as Crowdin
 # file context with START/END OF UPDATED SECTION markers.
 #
@@ -652,6 +652,7 @@ jobs:
           CONTENT_SOURCE: ${{ steps.content_diff.outputs.content_source }}
           CROWDIN_EN_EDITOR_LINKS: ${{ steps.crowdin_upload.outputs.en_editor_links }}
           CROWDIN_ES_EDITOR_LINKS: ${{ steps.crowdin_upload.outputs.es_editor_links }}
+          CROWDIN_TOTAL_WORDS: ${{ steps.crowdin_upload.outputs.total_words }}
         run: |
           if [ -z "$PARENT_DUE_DATE" ]; then
             echo "Parent due date is missing; cannot set subtask due dates." >&2
@@ -873,6 +874,59 @@ jobs:
             fi
           }
 
+          merge_word_count_description() {
+            CURRENT="$1" COUNT="$2" python3 .github/scripts/crowdin_sync.py word-count
+          }
+
+          is_language_subtask() {
+            case "$1" in
+              English*|Portuguese*|Spanish*) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
+          update_subtask_word_count() {
+            local key="$1"
+            local summary="$2"
+            local current_desc merged_desc custom_fields payload response
+
+            if [ -z "$CROWDIN_TOTAL_WORDS" ]; then
+              echo "Missing word count for ${summary} subtask ${key}" >&2
+              exit 1
+            fi
+
+            current_desc=$(curl -s \
+              -u "${LOC_JIRA_USER_EMAIL}:${LOC_JIRA_API_TOKEN}" \
+              "${LOC_JIRA_BASE_URL}/rest/api/2/issue/${key}?fields=description" \
+              | jq -r '.fields.description // ""')
+            merged_desc=$(merge_word_count_description "$current_desc" "$CROWDIN_TOTAL_WORDS")
+
+            custom_fields=$(jq -n \
+              --arg field "$LOC_JIRA_WORD_COUNT_FIELD" \
+              --argjson count "$CROWDIN_TOTAL_WORDS" \
+              '{($field): $count}')
+
+            payload=$(jq -n \
+              --arg description "$merged_desc" \
+              --argjson custom_fields "$custom_fields" \
+              '{fields: ({description: $description} + $custom_fields)}')
+
+            response=$(curl -s -o update-subtask-word-count-response.json -w "%{http_code}" \
+              -X PUT \
+              -H "Content-Type: application/json" \
+              -u "${LOC_JIRA_USER_EMAIL}:${LOC_JIRA_API_TOKEN}" \
+              -d "$payload" \
+              "${LOC_JIRA_BASE_URL}/rest/api/2/issue/${key}")
+
+            if [ "$response" -eq 204 ] || [ "$response" -eq 200 ]; then
+              echo "Updated word count for ${key} (${summary}): ${CROWDIN_TOTAL_WORDS}"
+            else
+              echo "Failed to update word count for ${key} (HTTP ${response})" >&2
+              cat update-subtask-word-count-response.json >&2
+              exit 1
+            fi
+          }
+
           rank_subtask_after() {
             local key="$1"
             local after_key="$2"
@@ -1013,4 +1067,12 @@ jobs:
                   "${SUBTASK_SUMMARIES[$i]}"
                 ;;
             esac
+          done
+
+          echo "Updating word count on language subtasks..."
+          for i in "${!SUBTASK_SUMMARIES[@]}"; do
+            summary="${SUBTASK_SUMMARIES[$i]}"
+            if is_language_subtask "$summary"; then
+              update_subtask_word_count "${ORDERED_KEYS[$i]}" "$summary"
+            fi
           done


### PR DESCRIPTION
## Summary
- After setting Word count on the LOC parent, copy the same `customfield_10253` value to English, Portuguese, and Spanish subtasks in the localization ticket workflow.