### PR TITLE
EDU-18944: add mixed date window behavior for VTEX Ads metrics

### DIFF
--- a/docs/pt/tutorials/retail-media/metricas-e-atribuicao-do-vtex-ads.md
+++ b/docs/pt/tutorials/retail-media/metricas-e-atribuicao-do-vtex-ads.md
@@ -159,6 +159,20 @@ As métricas Halo medem o impacto indireto do anúncio em vendas de outros produ
 | **Receita Halo** | Receita de produtos não anunciados comprados no mesmo pedido influenciado pelo anúncio. | -       |
 | **Itens Halo**   | Quantidade de itens Halo vendidos.                                                      | -       |
 
+## Comportamento em janelas de data mistas
+
+A metodologia de atribuição dos produtos patrocinados (Sponsored Products) mudou em 1º de julho de 2026 e passou a incluir conversões por visualização, além das conversões por clique. Além disso, para todos os formatos, a taxa de conversão passou a usar as **visualizações** no denominador, em vez dos cliques usados anteriormente.
+
+Por isso, métricas como ROAS, taxa de conversão, conversões e receita atribuída são calculadas de forma diferente antes e depois dessa data.
+
+Quando o período selecionado cruza 1º de julho de 2026, o cálculo consolidado adota a nova metodologia em todo o intervalo. Nesses casos, o gráfico exibe um aviso visual na data da mudança.
+
+Para obter resultados consistentes, selecione o período de análise de acordo com a metodologia desejada:
+
+- **Desempenho histórico:** selecione períodos inteiramente anteriores a 1º de julho de 2026.
+- **Nova metodologia:** selecione períodos inteiramente a partir de 1º de julho de 2026.
+
+> ⚠️ Em janelas de análise que contêm 1º de julho de 2026, a taxa de conversão é calculada com a nova metodologia em todo o intervalo. As métricas com quebra por clique (**Conversões (clique)**, **Taxa de conversão por clique** e **ROAS por clique**) estão disponíveis apenas a partir de 1º de julho de 2026.
 
 ## Disponibilidade e acesso aos dados
 

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -38887,6 +38887,21 @@
                   "origin": "",
                   "type": "markdown",
                   "children": []
+                },
+                {
+                  "name": {
+                    "en": "Analytics: Support metrics",
+                    "es": "Analytics: Métricas de atención",
+                    "pt": "Analytics: Métricas de atendimento"
+                  },
+                  "slug": {
+                    "en": "analytics-support-metrics",
+                    "es": "analytics-metricas-de-atencion",
+                    "pt": "analytics-metricas-de-atendimento"
+                  },
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
                 }
               ]
             },
@@ -38894,12 +38909,12 @@
               "name": {
                 "en": "Analytics",
                 "es": "Analytics",
-                "pt": "Analytics: Métricas de atendimento"
+                "pt": "Analytics"
               },
               "slug": {
                 "en": "vtex-cx-platform-analytics",
                 "es": "vtex-cx-platform-analytics",
-                "pt": "analytics-metricas-de-atendimento"
+                "pt": ""
               },
               "origin": "",
               "type": "markdown",
@@ -39862,6 +39877,21 @@
                 "en": "incorrect-values-in-quotes-on-items-with-unity-multiplier-configuration",
                 "es": "valores-incorrectos-en-las-comillas-de-los-articulos-con-configuracion-de-multiplicador-unitario",
                 "pt": "valores-incorretos-em-cotacoes-de-itens-com-configuracao-de-multiplicador-de-unidade"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
+                "en": "Item quantity duplicated when trying to edit quotes qith items split by promotions",
+                "es": "Se duplica la cantidad de artículos al intentar editar cotizaciones con artículos divididos por promociones.",
+                "pt": "A quantidade de itens foi duplicada ao tentar editar orçamentos com itens divididos por promoções."
+              },
+              "slug": {
+                "en": "item-quantity-duplicated-when-trying-to-edit-quotes-qith-items-split-by-promotions",
+                "es": "se-duplica-la-cantidad-de-articulos-al-intentar-editar-cotizaciones-con-articulos-divididos-por-promociones",
+                "pt": "a-quantidade-de-itens-foi-duplicada-ao-tentar-editar-orcamentos-com-itens-divididos-por-promocoes"
               },
               "origin": "",
               "type": "markdown",


### PR DESCRIPTION
Adds a new section to the VTEX Ads metrics tutorial explaining how attribution and conversion metrics behave when the selected date range crosses July 1, 2026.

## Changes

- Added section "Comportamento em janelas de data mistas" to the metrics and attribution tutorial
- Documents the methodology change (view-through conversions, views in conversion rate denominator)
- Explains consolidated calculation behavior and visual warning in charts
- Provides guidance for selecting consistent analysis periods

## Related Task

[EDU-18944](https://vtex-dev.atlassian.net/browse/EDU-18944)
