### PR TITLE
update: clarify localization placeholder workflow in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Welcome to the [VTEX Help Center](https://help.vtex.com/) content repository!
       - [Adding a download file to the article](#adding-a-download-file-to-the-article)
     - [Updating a published article](#updating-a-published-article)
     - [Localization workflow](#localization-workflow)
+      - [Placeholder for EN and ES files](#placeholder-for-en-and-es-files)
+      - [Triggering the localization task](#triggering-the-localization-task)
       - [Linking the EDU task](#linking-the-edu-task)
       - [When the automation runs](#when-the-automation-runs)
         - [Exclusions](#exclusions)
@@ -352,11 +354,12 @@ Follow the steps below to create a new article in the Help Center:
    >
 3. [Add images](#adding-images) to the article, if necessary.
 4. Fill in the [front matter](#filling-in-front-matter-information) of the article.
-5. Submit your PR for review on GitHub.
-6. Send the PR link in the `#education-prs` Slack channel for review by another technical writer.
-7. After review, register the PR link in the `Document Link` field of the JIRA task and request the translation of the content, moving the card status to `Translating`.
-8. Once the translations are complete, check the contents of the two files created by the localization team in the folders corresponding to each locale (EN and ES) of the repository. If the article in the PT version contains images, repeat this [procedure](#adding-images) to insert them into the EN and ES versions.
-9. Approve the PR and apply the merge to publish the article.
+5. Create placeholder files for the EN and ES versions in their respective locale folders. Each placeholder should contain only the front matter (no body content) — this signals to the Localization team which files need to be translated and where to upload the translations.
+6. Submit your PR for review on GitHub.
+7. Send the PR link in the `#education-prs` Slack channel for review by another technical writer.
+8. After review, add the appropriate `localization needed` label to trigger the localization workflow. See [Localization workflow](#localization-workflow) for details.
+9. Once the translations are complete, check the contents of the files updated by the localization team in the EN and ES folders. If the article in the PT version contains images, repeat this [procedure](#adding-images) to insert them into the EN and ES versions.
+10. Approve the PR and apply the merge to publish the article.
 
 > ℹ️ The [help-center-content](https://github.com/vtexdocs/help-center-content) repository is synched to the `helpcenter` repository, so new articles are automatically updated in the Help Center portal's navigation sidebar.
 
@@ -425,13 +428,22 @@ To update the content of an article that is already published on the Help Center
 
 1. Open a branch in the [help-portal-content](https://github.com/vtexdocs/help-center-content) repository.
 2. Access and update the **PT version** of the desired file in the repository.
-3. Access and update the files in the EN and ES versions with the same information (in Portuguese) inserted in the PT file.
+3. In the corresponding EN and ES files, update the `updatedAt` field to match the date set in the PT version. This acts as a placeholder that signals to the Localization team which files need to be translated. See [an example of this pattern](https://github.com/vtexdocs/help-center-content/pull/865/changes).
 4. Submit your PR for review.
-5. Register the PR link in the `Document Link` field of the JIRA task and request the translation of the content (EN and ES versions), moving the card status to `Translating`.
+5. Add the appropriate `localization needed` label to trigger the localization workflow. See [Localization workflow](#localization-workflow) for details.
 6. After the translation is complete, check the content translated by the localization team in the EN and ES version files.
 7. Approve the PR and apply the merge to publish the article.
 
 ### Localization workflow
+
+#### Placeholder for EN and ES files
+
+For both new articles and updates to existing ones, you must add a placeholder for the EN and ES files before opening a PR. This tells the Localization team exactly which files need to be translated and where to upload the translations.
+
+- **New articles**: create the EN and ES files with only the front matter (no body content).
+- **Updates to existing articles**: update the `updatedAt` field in the EN and ES files to match the date set in the PT version. See [an example of this pattern](https://github.com/vtexdocs/help-center-content/pull/865/changes).
+
+#### Triggering the localization task
 
 A GitHub Actions workflow automatically opens a Localization JIRA task when a PR is labeled `localization needed`.
 When a PR is ready for localization, add **one** of these labels:


### PR DESCRIPTION
### Summary

Updates README.md to document the placeholder requirement for EN and ES files in localization PRs.

- Publishing a new article: EN/ES placeholder files should contain only front matter (no body content)
- Updating a published article: existing EN/ES files should have their `updatedAt` updated to match the PT version
- Localization workflow section: adds a "Placeholder for EN and ES files" subsection explaining both cases, with a link to a reference PR
- Table of contents updated to reflect new subsections

---

### Type of change

* [ ] **New content** — Adds new documentation.
* [ ] **Content update** — Improves existing documentation (clarity, structure, examples, accuracy).
* [ ] **Bug fix** — Fixes markdown issues.
* [ ] **Editorial fix** — Spelling, grammar, or minor copy edits that don’t change meaning.
* [ ] **Content removal** — Deletes deprecated or obsolete content.

---

### Checklist

* [ ] The content follows the VTEX Style Guide.
* [ ] Markdown renders correctly (headings, lists, tables, callouts).
* [ ] Links, images, code blocks, and examples are valid.
* [ ] Terminology, product names, and API references are consistent.
* [ ] Frontmatter (title, description, tags, slug) is correct
* [ ] Files follow the expected folder structure and naming conventions.

---

### AI review instructions

This repository supports automated AI reviews for Markdown files in the `docs/pt` folder.

To run reviews on this PR, add at least one of the following labels:

* `AI style review`: evaluates tone and adherence to VTEX style guidelines.
* `AI grammar review`: identifies grammar and spelling issues.

Once at least one label is added, the review(s) will run automatically.

After the review is completed, the corresponding label will be removed and the label `AI reviewed` will be added to the PR.

> [!NOTE]
> To rerun a review, remove and add the desired label again.
