### PR TITLE
EDU-18941: docs(pt): clarify Master Data v1 entity deletion does not remove documents

### DIFF
--- a/docs/en/tutorials/master-data/master-data-basics/data-entity.md
+++ b/docs/en/tutorials/master-data/master-data-basics/data-entity.md
@@ -3,7 +3,7 @@ title: 'Data entity'
 id: tutorials_1265
 status: PUBLISHED
 createdAt: 2017-04-27T21:56:57.118Z
-updatedAt: 2024-10-23T23:39:13.110Z
+updatedAt: 2026-07-08T18:37:00.000Z
 publishedAt: 2024-10-23T23:39:13.110Z
 firstPublishedAt: 2017-04-27T23:03:49.803Z
 contentType: tutorial
@@ -26,6 +26,8 @@ With these concepts in mind, you can set up several data control scenarios in Ma
 > ℹ️ Data entities created by your operation are considered custom entities and are subject to a monthly charge. Learn more in [Custom data entities](/docs/tutorials/master-data).
 
 > ⚠️ This article outlines the Master Data v1 operation. You should evaluate which Master Data version meets your needs or is in use in your operation. Learn more: <ul> <li>[Master Data version features](/en/docs/tutorials/master-data#available-versions)</li> <li>[Master Data v2](https://developers.vtex.com/docs/guides/master-data-v2-basics)</li> </ul>
+
+> ⚠️ Deleting a data entity through the Master Data v1 interface does not remove the documents (records) already stored. The billed volume remains unchanged until the records are removed via the API. To delete documents and reduce billing, see the [Deleting documents in Master Data v1](https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1) guide on the Developers Portal.
 
 ## Data types
 

--- a/docs/en/tutorials/master-data/master-data-basics/master-data.md
+++ b/docs/en/tutorials/master-data/master-data-basics/master-data.md
@@ -1,7 +1,7 @@
 ---
 title: 'Master Data'
 createdAt: 2018-04-02T19:01:38.026Z
-updatedAt: 2026-07-07T19:39:00.000Z
+updatedAt: 2026-07-08T18:37:00.000Z
 contentType: tutorial
 productTeam: Master Data
 slugEN: master-data
@@ -334,6 +334,12 @@ Measurement and billing follow a monthly cycle:
 
 
 > ℹ️ To view billing details, learn how to [download VTEX invoices](/en/docs/tutorials/how-to-download-the-vtex-invoices).
+
+### Delete entity vs. delete documents
+
+When trying to reduce the volume counted in the monthly billing snapshot, it is important to distinguish deleting the **data entity** (structure in VTEX Admin) from deleting **documents** (stored records).
+
+> ⚠️ Deleting a custom data entity through the Master Data v1 interface removes the entity definition, but does not delete the documents (records) already stored. The billed volume remains unchanged until the records are removed via the API. To delete documents and reduce billing, see the [Deleting documents in Master Data v1](https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1) guide on the Developers Portal.
 
 ## Applications
 

--- a/docs/es/tutorials/master-data/conceptos-básicos-de-master-data/entidade-de-datos.md
+++ b/docs/es/tutorials/master-data/conceptos-básicos-de-master-data/entidade-de-datos.md
@@ -3,7 +3,7 @@ title: 'Entidad de datos'
 id: tutorials_1265
 status: PUBLISHED
 createdAt: 2017-04-27T21:56:57.118Z
-updatedAt: 2024-10-23T23:39:13.110Z
+updatedAt: 2026-07-08T18:37:00.000Z
 publishedAt: 2024-10-23T23:39:13.110Z
 firstPublishedAt: 2017-04-27T23:03:49.803Z
 contentType: tutorial
@@ -26,6 +26,8 @@ Estos conceptos permiten configurar los más diversos escenarios de control de d
 > ℹ️ Las entidades de datos creadas por tu operación se consideran entidades personalizadas y están sujetas a una facturación mensual. Más información en [Entidades de datos personalizadas](/es/docs/tutorials/master-data).
 
 > ⚠️ Este artículo describe el funcionamiento de Master Data v1. Es importante evaluar la versión de Master Data que satisface las necesidades de tu operación o que ya está en uso. Más información: <ul> <li>[Características de las versiones de Master Data](/es/docs/tutorials/master-data#versiones-disponibles)</li> <li>[Master Data v2](https://developers.vtex.com/docs/guides/master-data-v2-basics)</li> </ul>
+
+> ⚠️ Eliminar una entidad de datos a través de la interfaz de Master Data v1 no elimina los documentos (registros) ya almacenados. El volumen facturado permanece sin cambios hasta que los registros se eliminen mediante la API. Para eliminar documentos y reducir la facturación, consulta la guía [Deleting documents in Master Data v1](https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1) en el portal de desarrolladores.
 
 ## Tipos de datos
 

--- a/docs/es/tutorials/master-data/conceptos-básicos-de-master-data/master-data-es.md
+++ b/docs/es/tutorials/master-data/conceptos-básicos-de-master-data/master-data-es.md
@@ -1,7 +1,7 @@
 ---
 title: 'Master Data'
 createdAt: 2018-04-02T19:01:38.026Z
-updatedAt: 2026-07-07T19:39:00.000Z
+updatedAt: 2026-07-08T18:37:00.000Z
 contentType: tutorial
 productTeam: Master Data
 slugEN: master-data
@@ -333,6 +333,12 @@ Tanto la medición como la facturación siguen un ciclo mensual:
 - Hasta el día 30 de cada mes, VTEX calcula los valores correspondientes al uso de Master Data y los créditos aplicables para la próxima factura.
 
 > ℹ️ Para saber más sobre detalles de las facturas, consulta cómo [descargar las facturas de VTEX](/es/docs/tutorials/como-descargar-las-facturas-de-vtex).
+
+### Eliminar entidad vs. eliminar documentos
+
+Al intentar reducir el volumen contabilizado en el snapshot mensual de facturación, es importante distinguir la eliminación de la **entidad de datos** (estructura en Admin VTEX) de la eliminación de los **documentos** (registros almacenados).
+
+> ⚠️ Eliminar una entidad de datos personalizada a través de la interfaz de Master Data v1 elimina la definición de la entidad, pero no elimina los documentos (registros) ya almacenados. El volumen facturado permanece sin cambios hasta que los registros se eliminen mediante la API. Para eliminar documentos y reducir la facturación, consulta la guía [Deleting documents in Master Data v1](https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1) en el portal de desarrolladores.
 
 ## Aplicaciones
 

--- a/docs/pt/tutorials/master-data/conceitos-básicos-do-master-data/entidade-de-dados.md
+++ b/docs/pt/tutorials/master-data/conceitos-básicos-do-master-data/entidade-de-dados.md
@@ -3,7 +3,7 @@ title: 'Entidade de dados'
 id: tutorials_1265
 status: PUBLISHED
 createdAt: 2017-04-27T21:56:57.118Z
-updatedAt: 2026-05-20T20:09:00.000Z
+updatedAt: 2026-07-08T18:37:00.000Z
 publishedAt: 2024-10-23T23:39:13.110Z
 firstPublishedAt: 2017-04-27T23:03:49.803Z
 contentType: tutorial
@@ -26,6 +26,8 @@ Com esses conceitos, é possível configurar os mais diversos cenários de contr
 > ℹ️ Entidades de dados criadas pela sua operação são consideradas entidades personalizadas e estão sujeitas a cobrança mensal. Saiba mais em [Entidades de dados personalizadas](/pt/docs/tutorials/master-data#entidades-de-dados-personalizadas).
 
 > ⚠️ Este artigo diz respeito ao funcionamento do Master Data v1. É importante avaliar qual versão do Master Data atende as necessidades ou está em uso na sua operação. Saiba mais: <ul> <li>[Características das versões do Master Data](/pt/docs/tutorials/master-data#versoes-disponiveis)</li> <li>[Master Data v2](https://developers.vtex.com/docs/guides/master-data-v2-basics)</li> </ul>
+
+> ⚠️ Excluir uma entidade de dados pela interface do Master Data v1 **não** remove os documentos (registros) já armazenados. O volume faturado permanece inalterado até que os registros sejam removidos pela API. Para excluir documentos e reduzir a cobrança, consulte o guia [Deleting documents in Master Data v1](https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1) no portal de desenvolvedores.
 
 ## Tipos de dados
 

--- a/docs/pt/tutorials/master-data/conceitos-básicos-do-master-data/master-data-pt.md
+++ b/docs/pt/tutorials/master-data/conceitos-básicos-do-master-data/master-data-pt.md
@@ -1,7 +1,7 @@
 ---
 title: 'Master Data'
 createdAt: 2018-04-02T19:01:38.026Z
-updatedAt: 2026-07-07T19:39:00.000Z
+updatedAt: 2026-07-08T18:37:00.000Z
 contentType: tutorial
 productTeam: Master Data
 slugEN: master-data
@@ -332,6 +332,12 @@ A medição e a cobrança seguem um ciclo mensal:
 - Até o dia 30 de cada mês, a VTEX calcula os valores referentes ao uso do Master Data e os créditos aplicáveis para a próxima fatura.
 
 > ℹ️ Para consultar o detalhamento de cobranças, veja como [fazer o download das faturas da VTEX](/pt/docs/tutorials/como-fazer-download-faturas-da-vtex).
+
+### Excluir entidade x excluir documentos
+
+Ao tentar reduzir o volume contabilizado no snapshot mensal de cobrança, é importante distinguir a exclusão da **entidade de dados** (estrutura no Admin VTEX) da exclusão dos **documentos** (registros armazenados).
+
+> ⚠️ Excluir uma entidade de dados personalizada pela interface do Master Data v1 remove a definição da entidade, mas **não** exclui os documentos (registros) já armazenados. O volume faturado permanece inalterado até que os registros sejam removidos pela API. Para excluir documentos e reduzir a cobrança, consulte o guia [Deleting documents in Master Data v1](https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1) no portal de desenvolvedores.
 
 ## Casos de uso
 

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -52839,6 +52839,21 @@
             },
             {
               "name": {
+                "en": "Intelligent Search Facets hides selected parent facet in multiselect drill-down",
+                "es": "La función de búsqueda inteligente oculta la faceta principal seleccionada en la exploración en profundidad de selección múltiple.",
+                "pt": "A pesquisa inteligente de facetas oculta a faceta principal selecionada na seleção múltipla com detalhamento."
+              },
+              "slug": {
+                "en": "intelligent-search-facets-hides-selected-parent-facet-in-multiselect-drilldown",
+                "es": "la-funcion-de-busqueda-inteligente-oculta-la-faceta-principal-seleccionada-en-la-exploracion-en-profundidad-de-seleccion-multiple",
+                "pt": "a-pesquisa-inteligente-de-facetas-oculta-a-faceta-principal-selecionada-na-selecao-multipla-com-detalhamento"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
                 "en": "Intelligent Search language settings not in sync with store configurations",
                 "es": "La configuración de idioma de la búsqueda inteligente no está sincronizada con la configuración de la tienda",
                 "pt": "As configurações de idioma da Pesquisa Inteligente não estão sincronizadas com as configurações da loja"


### PR DESCRIPTION
Add warnings in PT Master Data tutorials clarifying that deleting a data entity via the Admin interface does not remove stored documents or reduce billing volume in Master Data v1.

## Changes

- Added warning callout to `entidade-de-dados.md` explaining that entity deletion does not remove records
- Added "Excluir entidade x excluir documentos" section to `master-data-pt.md` under the billing section
- Both callouts link to the Developers Portal guide for deleting documents via API

## Related Task

[EDU-18941](https://vtex-dev.atlassian.net/browse/EDU-18941)
