### PR TITLE
feat: post Jira comment when Crowdin upload succeeds

### DIFF
--- a/.github/scripts/crowdin_sync.py
+++ b/.github/scripts/crowdin_sync.py
@@ -6,8 +6,9 @@ with Crowdin metadata (word count, editor links).
 Partial uploads require equivalent EN and/or ES files on main (matched by slugEN
 in frontmatter) plus block/word-count tiers on the PR diff. PT sources use a
 full upload when the PR adds new EN/ES translation files for the same slugEN,
-even if the PT diff is small. Rename-aware diffs follow git rename detection;
-git rename detection; numstat rename paths are normalized before processing.
+even if the PT diff is small. EN/ES-only PRs upload the matching PT source from
+main (890214) with locale imports from the PR. Rename-aware diffs follow git
+rename detection; numstat rename paths are normalized before processing.
 When multiple locale files share a slugEN, paths that already exist on main
 are preferred over PR-only additions. Duplicate slugEN values on main trigger
 a warning comment on the parent Jira task.
@@ -301,11 +302,15 @@ def build_crowdin_file_name(
 
 PT_SOURCE_PATH_PREFIXES = ("docs/pt/", "localization/")
 EN_SOURCE_PATH_PREFIXES = ("docs/en/",)
+ES_SOURCE_PATH_PREFIXES = ("docs/es/",)
+TRANSLATION_PATH_PREFIXES = EN_SOURCE_PATH_PREFIXES + ES_SOURCE_PATH_PREFIXES
 
 
 def is_eligible_path(relative_path: str) -> bool:
     path = relative_path.replace("\\", "/")
-    return path.startswith(PT_SOURCE_PATH_PREFIXES + EN_SOURCE_PATH_PREFIXES)
+    return path.startswith(
+        PT_SOURCE_PATH_PREFIXES + EN_SOURCE_PATH_PREFIXES + ES_SOURCE_PATH_PREFIXES
+    )
 
 
 def decode_git_path(path: str) -> str:
@@ -852,6 +857,60 @@ def resolve_equivalent_path(
     return find_equivalent_path_at_ref(slug_en, target_locale, base_sha)
 
 
+def is_translation_only_pr() -> bool:
+    return env("TRANSLATION_ONLY_PR").lower() in ("true", "1", "yes")
+
+
+def resolve_pt_sources_from_translation_changes(
+    translation_files: list[str],
+    *,
+    base_sha: str,
+    head_sha: str,
+) -> list[str]:
+    """Map changed EN/ES files to PT sources on main (deduped)."""
+    pt_paths: list[str] = []
+    seen: set[str] = set()
+
+    for path in sorted(translation_files):
+        normalized = path.replace("\\", "/")
+        if not normalized.startswith(TRANSLATION_PATH_PREFIXES):
+            continue
+
+        slug_en = get_slug_en_for_path(path, head_sha, base_sha)
+        if not slug_en:
+            print(
+                f"No slugEN for translation file {path}; "
+                "cannot resolve PT source on main",
+                file=sys.stderr,
+            )
+            continue
+
+        pt_path = find_locale_equivalent_by_slug(
+            base_sha,
+            "pt",
+            slug_en,
+            base_sha=base_sha,
+        )
+        if not pt_path or not git_file_exists(base_sha, pt_path):
+            print(
+                f"No PT source on main for slugEN {slug_en!r} "
+                f"(from {path})",
+                file=sys.stderr,
+            )
+            continue
+
+        if pt_path in seen:
+            continue
+        seen.add(pt_path)
+        pt_paths.append(pt_path)
+        print(
+            f"Translation-only PR: {path} -> PT source on main {pt_path}",
+            file=sys.stderr,
+        )
+
+    return pt_paths
+
+
 def has_new_translation_files_in_pr(
     source_path: str,
     *,
@@ -904,6 +963,8 @@ def import_translation_file(
     language_id: str,
     content: bytes,
     file_name: str,
+    *,
+    import_eq_suggestions: bool = False,
 ) -> str:
     storage_id = upload_storage_bytes(content, file_name)
     response = crowdin_request(
@@ -913,7 +974,7 @@ def import_translation_file(
             "storageId": storage_id,
             "fileId": file_id,
             "languageIds": [language_id],
-            "importEqSuggestions": False,
+            "importEqSuggestions": import_eq_suggestions,
             "autoApproveImported": False,
         },
     )
@@ -1296,14 +1357,18 @@ def resolve_upload_context(
     all_files: list[str],
 ) -> tuple[CrowdinUploadGroup, list[str]]:
     content_source = env("CONTENT_SOURCE")
+    base_sha = env("BASE_SHA")
+    head_sha = env("HEAD_SHA")
     pt_files = files_for_prefixes(all_files, PT_CROWDIN_GROUP.path_prefixes)
     en_files = files_for_prefixes(all_files, EN_CROWDIN_GROUP.path_prefixes)
+    es_files = files_for_prefixes(all_files, ES_SOURCE_PATH_PREFIXES)
+    translation_files = en_files + es_files
 
     if content_source == "pt" or (not content_source and pt_files):
-        if en_files:
+        if translation_files:
             print(
-                "PR touches PT source (docs/pt or localization/) and docs/en; "
-                "ignoring docs/en files",
+                "PR touches PT source (docs/pt or localization/) and "
+                "docs/en or docs/es; ignoring translation files",
                 file=sys.stderr,
             )
         active_files = pt_files or [
@@ -1312,6 +1377,21 @@ def resolve_upload_context(
             if path.replace("\\", "/").startswith(PT_CROWDIN_GROUP.path_prefixes)
         ]
         return PT_CROWDIN_GROUP, active_files
+
+    if is_translation_only_pr() or (not pt_files and translation_files):
+        if base_sha and head_sha:
+            pt_from_translations = resolve_pt_sources_from_translation_changes(
+                translation_files,
+                base_sha=base_sha,
+                head_sha=head_sha,
+            )
+            if pt_from_translations:
+                print(
+                    "Translation-only PR: uploading "
+                    f"{len(pt_from_translations)} PT source file(s) from main",
+                    file=sys.stderr,
+                )
+                return PT_CROWDIN_GROUP, pt_from_translations
 
     if content_source == "en" or en_files:
         return EN_CROWDIN_GROUP, en_files or [
@@ -1322,7 +1402,7 @@ def resolve_upload_context(
 
     raise RuntimeError(
         "Could not determine Crowdin upload mode (expected CONTENT_SOURCE=pt|en "
-        "or changed files under docs/pt, localization/, or docs/en)"
+        "or changed files under docs/pt, localization/, docs/en, or docs/es)"
     )
 
 
@@ -1429,6 +1509,22 @@ def upload_group_files(
                 f"[{group.name}] Imported {translation.repo_path} as "
                 f"{translation.language_id} translation for {crowdin_name} "
                 f"(from {translation.source_ref})",
+                file=sys.stderr,
+            )
+
+        if group.name == "pt":
+            source_language_id = str(project_data["sourceLanguage"]["id"])
+            self_import_id = import_translation_file(
+                project_id,
+                file_id,
+                source_language_id,
+                plan.content,
+                crowdin_name,
+                import_eq_suggestions=True,
+            )
+            print(
+                f"[{group.name}] Self-imported {source_language_id} source for "
+                f"{crowdin_name} (import {self_import_id})",
                 file=sys.stderr,
             )
 

--- a/.github/scripts/crowdin_sync.py
+++ b/.github/scripts/crowdin_sync.py
@@ -4,7 +4,9 @@ Upload PR-touched markdown files to Crowdin and update Jira descriptions
 with Crowdin metadata (word count, editor links).
 
 Partial uploads require equivalent EN and/or ES files on main (matched by slugEN
-in frontmatter) plus block/word-count tiers on the PR diff. Rename-aware diffs follow
+in frontmatter) plus block/word-count tiers on the PR diff. PT sources use a
+full upload when the PR adds new EN/ES translation files for the same slugEN,
+even if the PT diff is small. Rename-aware diffs follow git rename detection;
 git rename detection; numstat rename paths are normalized before processing.
 When multiple locale files share a slugEN, paths that already exist on main
 are preferred over PR-only additions. Duplicate slugEN values on main trigger
@@ -722,12 +724,7 @@ def pick_preferred_equivalent_path(
     return chosen
 
 
-def find_en_equivalent_by_slug(
-    ref: str,
-    slug_en: str,
-    *,
-    base_sha: str | None = None,
-) -> str | None:
+def find_all_en_equivalents_by_slug(ref: str, slug_en: str) -> list[str]:
     """EN files use slugEN as the filename (docs/en/**/{slugEN}.md)."""
     result = subprocess.run(
         ["git", "ls-tree", "-r", "--name-only", ref, "--", "docs/en/"],
@@ -736,15 +733,25 @@ def find_en_equivalent_by_slug(
         check=False,
     )
     if result.returncode != 0:
-        return None
+        return []
 
-    matches = [
-        path
-        for path in result.stdout.splitlines()
-        if path.endswith((".md", ".mdx")) and Path(path).stem == slug_en
-    ]
+    return sorted(
+        {
+            path
+            for path in result.stdout.splitlines()
+            if path.endswith((".md", ".mdx")) and Path(path).stem == slug_en
+        }
+    )
+
+
+def find_en_equivalent_by_slug(
+    ref: str,
+    slug_en: str,
+    *,
+    base_sha: str | None = None,
+) -> str | None:
     return pick_preferred_equivalent_path(
-        matches,
+        find_all_en_equivalents_by_slug(ref, slug_en),
         base_sha=base_sha,
         slug_en=slug_en,
         locale="en",
@@ -759,13 +766,11 @@ def normalize_git_grep_path(line: str, ref: str) -> str:
     return line
 
 
-def find_locale_equivalent_by_slug(
+def find_all_locale_equivalents_by_slug(
     ref: str,
     locale: str,
     slug_en: str,
-    *,
-    base_sha: str | None = None,
-) -> str | None:
+) -> list[str]:
     """PT/ES equivalents share slugEN in frontmatter but may use different filenames."""
     pattern = rf"^slugEN:\s*\"?{re.escape(slug_en)}\"?\s*$"
     matches: list[str] = []
@@ -793,8 +798,18 @@ def find_locale_equivalent_by_slug(
                 if line.strip().endswith((".md", ".mdx"))
             )
 
+    return sorted(set(matches))
+
+
+def find_locale_equivalent_by_slug(
+    ref: str,
+    locale: str,
+    slug_en: str,
+    *,
+    base_sha: str | None = None,
+) -> str | None:
     return pick_preferred_equivalent_path(
-        matches,
+        find_all_locale_equivalents_by_slug(ref, locale, slug_en),
         base_sha=base_sha,
         slug_en=slug_en,
         locale=locale,
@@ -835,6 +850,36 @@ def resolve_equivalent_path(
     if equivalent_path and git_file_exists(head_sha, equivalent_path):
         return equivalent_path
     return find_equivalent_path_at_ref(slug_en, target_locale, base_sha)
+
+
+def has_new_translation_files_in_pr(
+    source_path: str,
+    *,
+    base_sha: str,
+    head_sha: str,
+    group: CrowdinUploadGroup,
+) -> bool:
+    """True when the PR introduces EN/ES files for this PT source's slugEN."""
+    if group.name != "pt":
+        return False
+
+    slug_en = get_slug_en_for_path(source_path, head_sha, base_sha)
+    if not slug_en:
+        return False
+
+    locale_matches = {
+        "en": find_all_en_equivalents_by_slug(head_sha, slug_en),
+        "es": find_all_locale_equivalents_by_slug(head_sha, "es", slug_en),
+    }
+    for locale, paths in locale_matches.items():
+        for path in paths:
+            if git_file_exists(head_sha, path) and not git_file_exists(base_sha, path):
+                print(
+                    f"New {locale} translation in PR for slugEN {slug_en!r}: {path}",
+                    file=sys.stderr,
+                )
+                return True
+    return False
 
 
 def resolve_translation_content(
@@ -949,7 +994,10 @@ def should_upload_partial(
     *,
     new_file: bool,
     has_existing_translations_in_main: bool,
+    new_translations_in_pr: bool,
 ) -> bool:
+    if new_translations_in_pr:
+        return False
     if not has_existing_translations_in_main:
         return False
     if added_count == 0 or new_file:
@@ -1147,6 +1195,12 @@ def plan_upload(
         head_sha=head_sha,
         group=group,
     )
+    new_translations_in_pr = has_new_translation_files_in_pr(
+        relative_path,
+        base_sha=base_sha,
+        head_sha=head_sha,
+        group=group,
+    )
 
     if should_upload_partial(
         added_count,
@@ -1156,6 +1210,7 @@ def plan_upload(
         total_words,
         new_file=new_file,
         has_existing_translations_in_main=translations_in_main,
+        new_translations_in_pr=new_translations_in_pr,
     ):
         partial_text = format_partial_content(blocks)
         changed_line_numbers = {line_no for line_no, _ in additions}
@@ -1175,7 +1230,13 @@ def plan_upload(
             translation_imports=translation_imports,
         )
 
-    if not translations_in_main:
+    if new_translations_in_pr:
+        print(
+            f"Using full upload for {relative_path}: "
+            "PR adds new EN/ES translation files for this slugEN",
+            file=sys.stderr,
+        )
+    elif not translations_in_main:
         print(
             f"Using full upload for {relative_path}: "
             "no equivalent EN/ES files on main (matched by slugEN)",

--- a/.github/scripts/crowdin_sync.py
+++ b/.github/scripts/crowdin_sync.py
@@ -75,6 +75,11 @@ def normalize_language_id(language_id: str) -> str:
     return language_id.replace("_", "-").lower()
 
 
+def normalize_editor_code(code: str) -> str:
+    """Crowdin editor URL segments drop separators (en-US -> enus, pt-BR -> ptbr)."""
+    return code.replace("_", "").replace("-", "").lower()
+
+
 def resolve_project_language_id(project_data: dict, language_id: str) -> str:
     """Return the Crowdin project's canonical language ID for language_id."""
     target = normalize_language_id(language_id)
@@ -187,13 +192,13 @@ def fetch_project_data(project_id: str) -> dict:
 
 def language_editor_code(project_data: dict, language_id: str) -> str:
     target = normalize_language_id(language_id)
-    source = project_data.get("sourceLanguage") or {}
-    if normalize_language_id(str(source.get("id", ""))) == target:
-        return str(source["editorCode"])
     for language in project_data.get("targetLanguages") or []:
         if normalize_language_id(str(language.get("id", ""))) == target:
-            return str(language["editorCode"])
-    return language_id
+            return normalize_editor_code(str(language["editorCode"]))
+    source = project_data.get("sourceLanguage") or {}
+    if normalize_language_id(str(source.get("id", ""))) == target:
+        return normalize_editor_code(str(source["editorCode"]))
+    return normalize_editor_code(language_id)
 
 
 def editor_url(
@@ -202,7 +207,10 @@ def editor_url(
     source_editor_code: str,
     target_editor_code: str,
 ) -> str:
-    language_pair = f"{source_editor_code}-{target_editor_code}"
+    language_pair = (
+        f"{normalize_editor_code(source_editor_code)}-"
+        f"{normalize_editor_code(target_editor_code)}"
+    )
     return f"{crowdin_web_base()}/editor/{project_identifier}/{file_id}/{language_pair}"
 
 

--- a/.github/scripts/crowdin_sync.py
+++ b/.github/scripts/crowdin_sync.py
@@ -17,6 +17,7 @@ Commands:
   crowdin_sync.py              Upload touched files to Crowdin
   crowdin_sync.py word-count   Merge word count into a Jira description (CURRENT, COUNT)
   crowdin_sync.py crowdin-links  Merge editor links into a Jira description (CURRENT, LINKS)
+  crowdin_sync.py annotate-changed-files  Add (PARTIAL|FULL) to Changed files (CURRENT, CHANGED_FILES, FILES_JSON, BASE_SHA, HEAD_SHA)
 """
 
 from __future__ import annotations
@@ -1338,6 +1339,73 @@ def write_github_output(name: str, value: str) -> None:
         handle.write(f"{name}<<{delimiter}\n{value}\n{delimiter}\n")
 
 
+def build_upload_modes_for_changed_files(
+    changed_paths: list[str],
+    uploaded_files: list[dict],
+    *,
+    base_sha: str,
+    head_sha: str,
+) -> dict[str, str]:
+    path_to_mode: dict[str, str] = {}
+    slug_to_mode: dict[str, str] = {}
+
+    for record in uploaded_files:
+        mode = str(record.get("upload_mode", "full")).upper()
+        source_path = str(record.get("source_path", ""))
+        if source_path:
+            path_to_mode[source_path] = mode
+            slug_en = get_slug_en_for_path(source_path, head_sha, base_sha)
+            if slug_en:
+                slug_to_mode[slug_en] = mode
+
+    modes: dict[str, str] = {}
+    for path in changed_paths:
+        if path in path_to_mode:
+            modes[path] = path_to_mode[path]
+            continue
+        slug_en = get_slug_en_for_path(path, head_sha, base_sha)
+        if slug_en and slug_en in slug_to_mode:
+            modes[path] = slug_to_mode[slug_en]
+            continue
+        modes[path] = "FULL"
+    return modes
+
+
+def format_annotated_changed_files_section(
+    changed_paths: list[str],
+    upload_modes: dict[str, str],
+) -> str:
+    if not changed_paths:
+        return "* No MD/MDX files changed"
+    lines = [
+        f"* {path} **({upload_modes.get(path, 'FULL')})**"
+        for path in changed_paths
+    ]
+    return "\n".join(lines)
+
+
+def merge_changed_files_description(current: str, changed_files_section: str) -> str:
+    block = f"h3. Changed files\n\n{changed_files_section.rstrip()}"
+    pattern = r"^h3\. Changed files\n\n[\s\S]*?(?=\nh3\. PR Description\b)"
+    if re.search(pattern, current, flags=re.MULTILINE):
+        return re.sub(
+            pattern,
+            block + "\n\n",
+            current.rstrip(),
+            count=1,
+            flags=re.MULTILINE,
+        )
+    if "h3. PR Description" in current:
+        return current.replace(
+            "h3. PR Description",
+            f"{block}\n\nh3. PR Description",
+            1,
+        )
+    if current.strip():
+        return f"{current.rstrip()}\n\n{block}\n"
+    return f"{block}\n"
+
+
 def merge_word_count_description(current: str, count: str) -> str:
     row = f"|Word count|{count}|"
     if re.search(r"^\|Word count\|", current, flags=re.MULTILINE):
@@ -1639,12 +1707,36 @@ def main() -> int:
             os.environ.get("LINKS", ""),
         ))
         return 0
+    if command == "annotate-changed-files":
+        current = os.environ.get("CURRENT", "")
+        changed_paths = [
+            line.strip()
+            for line in os.environ.get("CHANGED_FILES", "").splitlines()
+            if line.strip()
+        ]
+        uploaded_files = json.loads(os.environ.get("FILES_JSON", "[]"))
+        base_sha = env("BASE_SHA")
+        head_sha = env("HEAD_SHA")
+        if not base_sha or not head_sha:
+            raise RuntimeError("BASE_SHA and HEAD_SHA are required")
+        upload_modes = build_upload_modes_for_changed_files(
+            changed_paths,
+            uploaded_files,
+            base_sha=base_sha,
+            head_sha=head_sha,
+        )
+        section = format_annotated_changed_files_section(
+            changed_paths,
+            upload_modes,
+        )
+        print(merge_changed_files_description(current, section))
+        return 0
     if command == "upload":
         return upload_files()
 
     print(
         f"Unknown command: {command} "
-        "(expected upload, word-count, or crowdin-links)",
+        "(expected upload, word-count, crowdin-links, or annotate-changed-files)",
         file=sys.stderr,
     )
     return 1

--- a/.github/scripts/crowdin_sync.py
+++ b/.github/scripts/crowdin_sync.py
@@ -348,7 +348,16 @@ def changed_files() -> list[str]:
     seen: set[str] = set()
     files: list[str] = []
     for line in raw.splitlines():
-        path = normalize_changed_path(line.strip())
+        stripped = line.strip()
+        if "{" in stripped and "=>" not in stripped:
+            print(
+                "[crowdin_sync] Skipping truncated rename path "
+                "(ensure CHANGED_FILES uses awk -F'\\t'): "
+                f"{stripped}",
+                file=sys.stderr,
+            )
+            continue
+        path = normalize_changed_path(stripped)
         if (
             path
             and path.endswith((".md", ".mdx"))

--- a/.github/scripts/jira_helpers.sh
+++ b/.github/scripts/jira_helpers.sh
@@ -2,6 +2,8 @@
 # Source after setting LOC_JIRA_BASE_URL, LOC_JIRA_USER_EMAIL, LOC_JIRA_API_TOKEN,
 # LOC_JIRA_PROJECT_KEY, PR_NUMBER, GITHUB_REPOSITORY, PR_REF, PR_LABEL, and GH_TOKEN.
 
+CROWDIN_UPLOAD_SUCCESS_COMMENT=$'AUTOMATIC CROWDIN UPLOAD SUCCESSFUL\n\nThe Jira ticket and subtasks were created or updated, the files were uploaded to Crowdin, and the word count and Crowdin editor links were added or updated.'
+
 # Post a plain-text comment on a Jira issue. Returns 0 on HTTP 201.
 jira_post_comment() {
   local issue_key="$1"

--- a/.github/workflows/localization-ticket.yml
+++ b/.github/workflows/localization-ticket.yml
@@ -23,7 +23,8 @@
 # Crowdin: uploads PR-changed files via API, sets word count on the parent and
 # language subtasks, editor links on language subtasks. If the Crowdin upload
 # fails, Jira/subtask creation still runs; word count and editor links are skipped
-# and a comment is posted on the parent task. Partial upload only when equivalent
+# and a comment is posted on the parent task. On success, a success comment is
+# posted after subtasks and word count / editor links are updated. Partial upload only when equivalent
 # EN and/or ES files already exist on main (matched by slugEN in frontmatter)
 # and the PT diff meets partial block/word-count tiers; otherwise full source. Existing or
 # PR-added locale files with the same slugEN are imported as Crowdin translations
@@ -1157,3 +1158,23 @@ jobs:
           else
             echo "Skipping Crowdin editor links and subtask word counts (Crowdin upload failed or was skipped)"
           fi
+
+      - name: Comment on parent task for Crowdin upload success
+        if: >-
+          steps.eligibility.outputs.should_run == 'true' &&
+          steps.content_diff.outputs.has_additions == 'true' &&
+          steps.content_diff.outputs.has_eligible_files == 'true' &&
+          steps.production_lock.outputs.updates_blocked != 'true' &&
+          steps.parent_ticket.outputs.parent_key != '' &&
+          steps.crowdin_upload.outputs.upload_succeeded == 'true'
+        env:
+          LOC_JIRA_BASE_URL: ${{ secrets.LOC_JIRA_BASE_URL }}
+          LOC_JIRA_USER_EMAIL: ${{ secrets.LOC_JIRA_USER_EMAIL }}
+          LOC_JIRA_API_TOKEN: ${{ secrets.LOC_JIRA_API_TOKEN }}
+          PARENT_KEY: ${{ steps.parent_ticket.outputs.parent_key }}
+        run: |
+          # shellcheck source=.github/scripts/jira_helpers.sh
+          source .github/scripts/jira_helpers.sh
+
+          jira_post_comment "$PARENT_KEY" "$CROWDIN_UPLOAD_SUCCESS_COMMENT"
+          echo "Posted Crowdin upload success comment on ${PARENT_KEY}"

--- a/.github/workflows/localization-ticket.yml
+++ b/.github/workflows/localization-ticket.yml
@@ -136,7 +136,7 @@ jobs:
             CHANGED_FILES=$(git -c core.quotepath=false diff --numstat -M \
               "$DIFF_RANGE" \
               -- docs/pt/ localization/ \
-              | awk '$1 > 0 {print $3}' \
+              | awk -F'\t' '$1 > 0 {print $3}' \
               | sed 's/^"//;s/"$//' \
               | grep -E '\.(md|mdx)$' \
               | sort || true)
@@ -148,7 +148,7 @@ jobs:
             CHANGED_FILES=$(git -c core.quotepath=false diff --numstat -M \
               "$DIFF_RANGE" \
               -- docs/en/ \
-              | awk '$1 > 0 {print $3}' \
+              | awk -F'\t' '$1 > 0 {print $3}' \
               | sed 's/^"//;s/"$//' \
               | grep -E '\.(md|mdx)$' \
               | sort || true)

--- a/.github/workflows/localization-ticket.yml
+++ b/.github/workflows/localization-ticket.yml
@@ -636,16 +636,25 @@ jobs:
           LOC_JIRA_API_TOKEN: ${{ secrets.LOC_JIRA_API_TOKEN }}
           PARENT_KEY: ${{ steps.parent_ticket.outputs.parent_key }}
           CROWDIN_TOTAL_WORDS: ${{ steps.crowdin_upload.outputs.total_words }}
+          FILES_JSON: ${{ steps.crowdin_upload.outputs.files_json }}
+          CHANGED_FILES: ${{ steps.content_diff.outputs.changed_files }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           merge_word_count_description() {
             CURRENT="$1" COUNT="$2" python3 .github/scripts/crowdin_sync.py word-count
+          }
+
+          annotate_changed_files_description() {
+            CURRENT="$1" python3 .github/scripts/crowdin_sync.py annotate-changed-files
           }
 
           current_desc=$(curl -s \
             -u "${LOC_JIRA_USER_EMAIL}:${LOC_JIRA_API_TOKEN}" \
             "${LOC_JIRA_BASE_URL}/rest/api/2/issue/${PARENT_KEY}?fields=description" \
             | jq -r '.fields.description // ""')
-          merged_desc=$(merge_word_count_description "$current_desc" "$CROWDIN_TOTAL_WORDS")
+          merged_desc=$(annotate_changed_files_description "$current_desc")
+          merged_desc=$(merge_word_count_description "$merged_desc" "$CROWDIN_TOTAL_WORDS")
 
           custom_fields=$(jq -n \
             --arg field "$LOC_JIRA_WORD_COUNT_FIELD" \

--- a/.github/workflows/localization-ticket.yml
+++ b/.github/workflows/localization-ticket.yml
@@ -120,12 +120,19 @@ jobs:
             -- docs/en/ \
             | awk '{sum += $1} END {print sum+0}')
 
+          INSERTIONS_ES=$(git -c core.quotepath=false diff --numstat \
+            "$DIFF_RANGE" \
+            -- docs/es/ \
+            | awk '{sum += $1} END {print sum+0}')
+
           HAS_PT=false
           HAS_EN=false
+          HAS_ES=false
           if [ "$INSERTIONS_PT" -gt 0 ]; then HAS_PT=true; fi
           if [ "$INSERTIONS_EN" -gt 0 ]; then HAS_EN=true; fi
+          if [ "$INSERTIONS_ES" -gt 0 ]; then HAS_ES=true; fi
 
-          if [ "$HAS_PT" = true ] || [ "$HAS_EN" = true ]; then
+          if [ "$HAS_PT" = true ] || [ "$HAS_EN" = true ] || [ "$HAS_ES" = true ]; then
             echo "has_additions=true" >> $GITHUB_OUTPUT
           else
             echo "has_additions=false" >> $GITHUB_OUTPUT
@@ -133,6 +140,7 @@ jobs:
 
           if [ "$HAS_PT" = true ]; then
             echo "content_source=pt" >> $GITHUB_OUTPUT
+            echo "translation_only_pr=false" >> $GITHUB_OUTPUT
             CHANGED_FILES=$(git -c core.quotepath=false diff --numstat -M \
               "$DIFF_RANGE" \
               -- docs/pt/ localization/ \
@@ -140,20 +148,35 @@ jobs:
               | sed 's/^"//;s/"$//' \
               | grep -E '\.(md|mdx)$' \
               | sort || true)
-            if [ "$HAS_EN" = true ]; then
-              echo "PR touches PT source (docs/pt or localization/) and docs/en; ignoring docs/en files"
+            if [ "$HAS_EN" = true ] || [ "$HAS_ES" = true ]; then
+              echo "PR touches PT source (docs/pt or localization/) and docs/en or docs/es; ignoring translation files"
             fi
-          elif [ "$HAS_EN" = true ]; then
-            echo "content_source=en" >> $GITHUB_OUTPUT
-            CHANGED_FILES=$(git -c core.quotepath=false diff --numstat -M \
-              "$DIFF_RANGE" \
-              -- docs/en/ \
-              | awk -F'\t' '$1 > 0 {print $3}' \
-              | sed 's/^"//;s/"$//' \
-              | grep -E '\.(md|mdx)$' \
-              | sort || true)
+          elif [ "$HAS_EN" = true ] || [ "$HAS_ES" = true ]; then
+            echo "content_source=pt" >> $GITHUB_OUTPUT
+            echo "translation_only_pr=true" >> $GITHUB_OUTPUT
+            CHANGED_FILES=$(
+              {
+                if [ "$HAS_EN" = true ]; then
+                  git -c core.quotepath=false diff --numstat -M \
+                    "$DIFF_RANGE" \
+                    -- docs/en/ \
+                    | awk -F'\t' '$1 > 0 {print $3}'
+                fi
+                if [ "$HAS_ES" = true ]; then
+                  git -c core.quotepath=false diff --numstat -M \
+                    "$DIFF_RANGE" \
+                    -- docs/es/ \
+                    | awk -F'\t' '$1 > 0 {print $3}'
+                fi
+              } \
+                | sed 's/^"//;s/"$//' \
+                | grep -E '\.(md|mdx)$' \
+                | sort -u || true
+            )
+            echo "Translation-only PR (docs/en or docs/es); Crowdin will upload matching PT source from main"
           else
             echo "content_source=" >> $GITHUB_OUTPUT
+            echo "translation_only_pr=false" >> $GITHUB_OUTPUT
             CHANGED_FILES=""
           fi
 
@@ -552,6 +575,7 @@ jobs:
           LOC_JIRA_USER_EMAIL: ${{ secrets.LOC_JIRA_USER_EMAIL }}
           LOC_JIRA_API_TOKEN: ${{ secrets.LOC_JIRA_API_TOKEN }}
           CONTENT_SOURCE: ${{ steps.content_diff.outputs.content_source }}
+          TRANSLATION_ONLY_PR: ${{ steps.content_diff.outputs.translation_only_pr }}
           CHANGED_FILES: ${{ steps.content_diff.outputs.changed_files }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -46068,21 +46068,6 @@
             },
             {
               "name": {
-                "es": "Error en el campo de cantidad máxima de la misma SKU en la Cesta",
-                "pt": "Erro no campo de quantidade máxima da mesma SKU no carrinho",
-                "en": "Error en el campo de cantidad máxima de la misma SKU en la Cesta"
-              },
-              "slug": {
-                "es": "error-en-el-campo-de-cantidad-maxima-de-la-misma-sku-en-la-cesta",
-                "pt": "erro-no-campo-de-quantidade-maxima-da-mesma-sku-no-carrinho",
-                "en": ""
-              },
-              "origin": "",
-              "type": "markdown",
-              "children": []
-            },
-            {
-              "name": {
                 "en": "Error when changing delivery type when seller has recursion",
                 "es": "Error al cambiar el tipo de entrega cuando el vendedor tiene recursividad",
                 "pt": "Erro ao mudar o tipo de entrega quando o vendedor tem recorrência"
@@ -46324,12 +46309,12 @@
             {
               "name": {
                 "en": "Interacting with the payment component while is still in a loading state sends the wrong payment option",
-                "es": "Si se interactúa con el componente de pago mientras aún se está cargando, se envía una opción de pago incorrecta",
+                "es": "Interactuar con el componente de pago mientras aún se encuentra en estado de carga envía la opción de pago incorrecta.",
                 "pt": "Interagir com o componente de pagamento enquanto ele ainda está em estado de carregamento envia a opção de pagamento incorreta."
               },
               "slug": {
                 "en": "interacting-with-the-payment-component-while-is-still-in-a-loading-state-sends-the-wrong-payment-option",
-                "es": "si-se-interactua-con-el-componente-de-pago-mientras-aun-se-esta-cargando-se-envia-una-opcion-de-pago-incorrecta",
+                "es": "interactuar-con-el-componente-de-pago-mientras-aun-se-encuentra-en-estado-de-carga-envia-la-opcion-de-pago-incorrecta",
                 "pt": "interagir-com-o-componente-de-pagamento-enquanto-ele-ainda-esta-em-estado-de-carregamento-envia-a-opcao-de-pagamento-incorreta"
               },
               "origin": "",
@@ -59901,12 +59886,12 @@
             {
               "name": {
                 "en": "Bin sent does not match an associated Card brand",
-                "es": "La papelera enviada no coincide con una marca de tarjeta asociada",
+                "es": "El BIN enviado no coincide con una marca de tarjeta asociada.",
                 "pt": "O endereço enviado não corresponde a nenhuma bandeira de cartão associada."
               },
               "slug": {
                 "en": "bin-sent-does-not-match-an-associated-card-brand",
-                "es": "la-papelera-enviada-no-coincide-con-una-marca-de-tarjeta-asociada",
+                "es": "el-bin-enviado-no-coincide-con-una-marca-de-tarjeta-asociada",
                 "pt": "o-endereco-enviado-nao-corresponde-a-nenhuma-bandeira-de-cartao-associada"
               },
               "origin": "",
@@ -62646,12 +62631,12 @@
             {
               "name": {
                 "en": "The Cielo 3DS2 app is returning an \"approved\" status even in scenarios when the authentication has failed.",
-                "es": "La aplicación Cielo 3DS2 muestra el estado «aprobado» incluso en casos en los que la autenticación ha fallado.",
+                "es": "La aplicación Cielo 3DS2 devuelve un estado de \"aprobado\" incluso en situaciones en las que la autenticación ha fallado.",
                 "pt": "O aplicativo Cielo 3DS2 está retornando o status \"aprovado\" mesmo em cenários nos quais a autenticação falhou."
               },
               "slug": {
                 "en": "the-cielo-3ds2-app-is-returning-an-approved-status-even-in-scenarios-when-the-authentication-has-failed",
-                "es": "la-aplicacion-cielo-3ds2-muestra-el-estado-aprobado-incluso-en-casos-en-los-que-la-autenticacion-ha-fallado",
+                "es": "la-aplicacion-cielo-3ds2-devuelve-un-estado-de-aprobado-incluso-en-situaciones-en-las-que-la-autenticacion-ha-fallado",
                 "pt": "o-aplicativo-cielo-3ds2-esta-retornando-o-status-aprovado-mesmo-em-cenarios-nos-quais-a-autenticacao-falhou"
               },
               "origin": "",

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -46068,14 +46068,14 @@
             },
             {
               "name": {
-                "en": "Error in the maximum quantity field of the same SKU in the Cart",
-                "es": "Error en el campo de cantidad máxima del mismo SKU en el carrito.",
-                "pt": "Erro no campo de quantidade máxima do mesmo SKU no carrinho."
+                "es": "Error en el campo de cantidad máxima de la misma SKU en la Cesta",
+                "pt": "Erro no campo de quantidade máxima da mesma SKU no carrinho",
+                "en": "Error en el campo de cantidad máxima de la misma SKU en la Cesta"
               },
               "slug": {
-                "en": "error-in-the-maximum-quantity-field-of-the-same-sku-in-the-cart",
-                "es": "error-en-el-campo-de-cantidad-maxima-del-mismo-sku-en-el-carrito",
-                "pt": "erro-no-campo-de-quantidade-maxima-do-mesmo-sku-no-carrinho"
+                "es": "error-en-el-campo-de-cantidad-maxima-de-la-misma-sku-en-la-cesta",
+                "pt": "erro-no-campo-de-quantidade-maxima-da-mesma-sku-no-carrinho",
+                "en": ""
               },
               "origin": "",
               "type": "markdown",
@@ -47246,6 +47246,21 @@
                 "en": "pickups-inherited-between-whitelabel-sellers-are-treated-as-differentindependent-pickups-on-the-purchase-flow",
                 "es": "las-recogidas-heredadas-entre-vendedores-de-marca-blanca-se-tratan-como-recogidas-diferentesindependientes-en-el-flujo-de-compra",
                 "pt": "as-pickups-herdadas-entre-os-vendedores-whitelabel-sao-tratadas-como-pickups-diferentesindependentes-no-fluxo-de-compra"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
+                "en": "Place Order APIs don't respect the maximum quantity of the same SKU in the cart configuration",
+                "es": "Las API para realizar pedidos no respetan la cantidad máxima del mismo SKU en la configuración del carrito.",
+                "pt": "As APIs de \"Finalizar Pedido\" não respeitam a quantidade máxima do mesmo SKU na configuração do carrinho."
+              },
+              "slug": {
+                "en": "place-order-apis-dont-respect-the-maximum-quantity-of-the-same-sku-in-the-cart-configuration",
+                "es": "las-api-para-realizar-pedidos-no-respetan-la-cantidad-maxima-del-mismo-sku-en-la-configuracion-del-carrito",
+                "pt": "as-apis-de-finalizar-pedido-nao-respeitam-a-quantidade-maxima-do-mesmo-sku-na-configuracao-do-carrinho"
               },
               "origin": "",
               "type": "markdown",
@@ -54905,6 +54920,21 @@
                 "en": "warehouse-prioritization-is-not-deterministic-during-shipping-simulation",
                 "es": "la-priorizacion-de-almacenes-no-es-determinista-durante-la-simulacion-de-envio",
                 "pt": "a-priorizacao-do-armazem-nao-e-deterministica-durante-a-simulacao-de-expedicao"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
+                "en": "Wrong warehouse assigned to item added via ChangeOrderV2 (FFM/SOS ShippingEnricher ignores Logistics’ DeliveryIds)",
+                "es": "Se asignó un almacén incorrecto al artículo agregado mediante ChangeOrderV2 (FFM/SOS ShippingEnricher ignora los DeliveryIds de Logística).",
+                "pt": "Armazém incorreto atribuído ao item adicionado via ChangeOrderV2 (FFM/SOS ShippingEnricher ignora os DeliveryIds da Logística)"
+              },
+              "slug": {
+                "en": "wrong-warehouse-assigned-to-item-added-via-changeorderv2-ffmsos-shippingenricher-ignores-logistics-deliveryids",
+                "es": "se-asigno-un-almacen-incorrecto-al-articulo-agregado-mediante-changeorderv2-ffmsos-shippingenricher-ignora-los-deliveryids-de-logistica",
+                "pt": "armazem-incorreto-atribuido-ao-item-adicionado-via-changeorderv2-ffmsos-shippingenricher-ignora-os-deliveryids-da-logistica"
               },
               "origin": "",
               "type": "markdown",


### PR DESCRIPTION
## Summary

- Post **AUTOMATIC CROWDIN UPLOAD SUCCESSFUL** on the parent LOC task after upload, word count, and editor links are updated.
- Fix Crowdin editor URL segments (`ptbr-en`, `ptbr-esmx`) and parse git rename paths from tab-separated numstat.
- Force full PT upload when a PR adds new EN/ES files for the same slugEN.
- Handle EN/ES-only PRs: upload matching PT source from main, import EN/ES from the PR, self-import pt-BR.
- Annotate parent **Changed files** with **(PARTIAL)** or **(FULL)** after upload.