### PR TITLE
feat: replace License Manager resources iframes with DataTable component

### DIFF
--- a/data-tables/license-manager-internal-resources.json
+++ b/data-tables/license-manager-internal-resources.json
@@ -5,215 +5,215 @@
       "category": "Product",
       "resource": "Export Job",
       "key": "ExportJob",
-      "resourceId": 2124114,
-      "productId": 55
+      "resourceId": "2124114",
+      "productId": "55"
     },
     {
       "product": "Availability Notify",
       "category": "Notification Requests",
       "resource": "Download Notification Requests",
       "key": "downloadNotificationRequests",
-      "resourceId": 2156515,
-      "productId": 136
+      "resourceId": "2156515",
+      "productId": "136"
     },
     {
       "product": "B2B",
       "category": "Import",
       "resource": "B2BBulkImport",
       "key": "B2BBulkImport",
-      "resourceId": 1954299,
-      "productId": 105
+      "resourceId": "1954299",
+      "productId": "105"
     },
     {
       "product": "B2B",
       "category": "Import",
       "resource": "BulkImportTest",
       "key": "BulkImportTest",
-      "resourceId": 1957237,
-      "productId": 105
+      "resourceId": "1957237",
+      "productId": "105"
     },
     {
       "product": "B2B",
       "category": "B2B General",
       "resource": "B2BBulkExport",
       "key": "B2BBulkExport",
-      "resourceId": 2045795,
-      "productId": 105
+      "resourceId": "2045795",
+      "productId": "105"
     },
     {
       "product": "Billing",
       "category": "Company",
       "resource": "Add Account",
       "key": "add_accountname",
-      "resourceId": 134736,
-      "productId": 43
+      "resourceId": "134736",
+      "productId": "43"
     },
     {
       "product": "Billing",
       "category": "Company",
       "resource": "Delete Account",
       "key": "delete_accountname",
-      "resourceId": 134737,
-      "productId": 43
+      "resourceId": "134737",
+      "productId": "43"
     },
     {
       "product": "Billing",
       "category": "Invoice",
       "resource": "Recalculate Invoice",
       "key": "generate_invoice_overdue",
-      "resourceId": 139181,
-      "productId": 43
+      "resourceId": "139181",
+      "productId": "43"
     },
     {
       "product": "Billing",
       "category": "Dashboard",
       "resource": "Get Dashboard Charges",
       "key": "get_unscrewed_dashboard_charges",
-      "resourceId": 142913,
-      "productId": 43
+      "resourceId": "142913",
+      "productId": "43"
     },
     {
       "product": "Billing",
       "category": "Reseller",
       "resource": "List Active Commissions",
       "key": "list_active_commissions",
-      "resourceId": 1569483,
-      "productId": 43
+      "resourceId": "1569483",
+      "productId": "43"
     },
     {
       "product": "Billing",
       "category": "Reseller",
       "resource": "List Commissions History",
       "key": "list_commissions_history",
-      "resourceId": 1569484,
-      "productId": 43
+      "resourceId": "1569484",
+      "productId": "43"
     },
     {
       "product": "Billing",
       "category": "Reseller",
       "resource": "Get Commission Totalizers",
       "key": "get_commissions_totalizers",
-      "resourceId": 1569485,
-      "productId": 43
+      "resourceId": "1569485",
+      "productId": "43"
     },
     {
       "product": "Billing",
       "category": "Commands",
       "resource": "Inflation Report Command",
       "key": "inflationreport",
-      "resourceId": 1928420,
-      "productId": 43
+      "resourceId": "1928420",
+      "productId": "43"
     },
     {
       "product": "Billing",
       "category": "Contracts",
       "resource": "Mark Contract as Reviewed",
       "key": "mark-contract-as-reviewed",
-      "resourceId": 1929752,
-      "productId": 43
+      "resourceId": "1929752",
+      "productId": "43"
     },
     {
       "product": "Billing",
       "category": "Contracts",
       "resource": "Save contracts with changes to financial values",
       "key": "put_contract_financial_values",
-      "resourceId": 1933312,
-      "productId": 43
+      "resourceId": "1933312",
+      "productId": "43"
     },
     {
       "product": "Billing",
       "category": "Invoice",
       "resource": "List Invoice Due Date Change Requests",
       "key": "list-invoice-due-date-change-requests",
-      "resourceId": 1951668,
-      "productId": 43
+      "resourceId": "1951668",
+      "productId": "43"
     },
     {
       "product": "Billing",
       "category": "Invoice",
       "resource": "Put Invoice Due Date Change Requests",
       "key": "put-invoice-due-date-change-requests",
-      "resourceId": 1951669,
-      "productId": 43
+      "resourceId": "1951669",
+      "productId": "43"
     },
     {
       "product": "Billing",
       "category": "Invoice",
       "resource": "Review Invoice Due Date Change Requests",
       "key": "review-invoice-due-date-change-requests",
-      "resourceId": 1951677,
-      "productId": 43
+      "resourceId": "1951677",
+      "productId": "43"
     },
     {
       "product": "Billing",
       "category": "Company",
       "resource": "Create Child Account",
       "key": "create_child_account",
-      "resourceId": 2078353,
-      "productId": 43
+      "resourceId": "2078353",
+      "productId": "43"
     },
     {
       "product": "Billing",
       "category": "Invoice",
       "resource": "Update boleto overdue date",
       "key": "boleto_overdue_date",
-      "resourceId": 2102653,
-      "productId": 43
+      "resourceId": "2102653",
+      "productId": "43"
     },
     {
       "product": "CDN API",
       "category": "CDN API Internal",
       "resource": "Update WafControl Config",
       "key": "UpdateWafControlConfig",
-      "resourceId": 2142571,
-      "productId": 108
+      "resourceId": "2142571",
+      "productId": "108"
     },
     {
       "product": "CDN API",
       "category": "CDN API Internal",
       "resource": "View WafControl Config",
       "key": "ViewWafControlConfig",
-      "resourceId": 2142572,
-      "productId": 108
+      "resourceId": "2142572",
+      "productId": "108"
     },
     {
       "product": "Catalog",
       "category": "Marketing",
       "resource": "Experts",
       "key": "Especialista.aspx",
-      "resourceId": 925,
-      "productId": 2
+      "resourceId": "925",
+      "productId": "2"
     },
     {
       "product": "Catalog",
       "category": "Marketing",
       "resource": "Expert Management",
       "key": "EspecialistaForm.aspx",
-      "resourceId": 926,
-      "productId": 2
+      "resourceId": "926",
+      "productId": "2"
     },
     {
       "product": "Catalog",
       "category": "Commercial",
       "resource": "Experts opinions",
       "key": "EspecialistaOpiniao.aspx",
-      "resourceId": 927,
-      "productId": 2
+      "resourceId": "927",
+      "productId": "2"
     },
     {
       "product": "Catalog",
       "category": "Content",
       "resource": "Instant Publish",
       "key": "instant-publish",
-      "resourceId": 1044980,
-      "productId": 2
+      "resourceId": "1044980",
+      "productId": "2"
     },
     {
       "product": "CatalogV2",
       "category": "Management",
       "resource": "Product Write",
       "key": "product-write",
-      "resourceId": 1132306,
+      "resourceId": "1132306",
       "productId": ""
     },
     {
@@ -221,7 +221,7 @@
       "category": "Management",
       "resource": "Product Read",
       "key": "product-read",
-      "resourceId": 1132321,
+      "resourceId": "1132321",
       "productId": ""
     },
     {
@@ -229,7 +229,7 @@
       "category": "Management",
       "resource": "Category Write",
       "key": "category-write",
-      "resourceId": 1132322,
+      "resourceId": "1132322",
       "productId": ""
     },
     {
@@ -237,7 +237,7 @@
       "category": "Management",
       "resource": "Category Read",
       "key": "category-read",
-      "resourceId": 1132323,
+      "resourceId": "1132323",
       "productId": ""
     },
     {
@@ -245,7 +245,7 @@
       "category": "Management",
       "resource": "Brand Write",
       "key": "brand-write",
-      "resourceId": 1132324,
+      "resourceId": "1132324",
       "productId": ""
     },
     {
@@ -253,7 +253,7 @@
       "category": "Management",
       "resource": "Brand Read",
       "key": "brand-read",
-      "resourceId": 1132325,
+      "resourceId": "1132325",
       "productId": ""
     },
     {
@@ -261,7 +261,7 @@
       "category": "Management",
       "resource": "Save Image",
       "key": "image-write",
-      "resourceId": 1330546,
+      "resourceId": "1330546",
       "productId": ""
     },
     {
@@ -269,911 +269,911 @@
       "category": "CheckoutResources",
       "resource": "Order Cancellation",
       "key": "CancelaPedidos",
-      "resourceId": 1357,
-      "productId": 5
+      "resourceId": "1357",
+      "productId": "5"
     },
     {
       "product": "Checkout",
       "category": "CheckoutResources",
       "resource": "Save card token to user profile",
       "key": "SaveCardTokenToUserProfile",
-      "resourceId": 721440,
-      "productId": 5
+      "resourceId": "721440",
+      "productId": "5"
     },
     {
       "product": "Checkout",
       "category": "CheckoutResources",
       "resource": "RecaptchaAllowlist",
       "key": "RecaptchaAllowlist",
-      "resourceId": 1936124,
-      "productId": 5
+      "resourceId": "1936124",
+      "productId": "5"
     },
     {
       "product": "Checkout",
       "category": "CheckoutResources",
       "resource": "Lock an OrderForm",
       "key": "CanLockOrderForm",
-      "resourceId": 2154439,
-      "productId": 5
+      "resourceId": "2154439",
+      "productId": "5"
     },
     {
       "product": "Commerce Content",
       "category": "Branch",
       "resource": "Save to main branch",
       "key": "SaveToMainBranch",
-      "resourceId": 2086248,
-      "productId": 115
+      "resourceId": "2086248",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
       "category": "Entry",
       "resource": "Delete entry",
       "key": "DeleteEntry",
-      "resourceId": 2086249,
-      "productId": 115
+      "resourceId": "2086249",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
       "category": "Branch",
       "resource": "Remove from main branch",
       "key": "RemoveFromMainBranch",
-      "resourceId": 2086250,
-      "productId": 115
+      "resourceId": "2086250",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
       "category": "Branch",
       "resource": "Merge branch",
       "key": "MergeBranch",
-      "resourceId": 2086251,
-      "productId": 115
+      "resourceId": "2086251",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
       "category": "Media Gallery",
       "resource": "Upload Image",
       "key": "UploadImage",
-      "resourceId": 2114634,
-      "productId": 115
+      "resourceId": "2114634",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
       "category": "Branch",
       "resource": "Delete Branch",
       "key": "DeleteBranch",
-      "resourceId": 2153203,
-      "productId": 115
+      "resourceId": "2153203",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
       "category": "Branch",
       "resource": "Create Branch",
       "key": "CreateBranch",
-      "resourceId": 2153204,
-      "productId": 115
+      "resourceId": "2153204",
+      "productId": "115"
     },
     {
       "product": "Conditions Evaluator",
       "category": "Conditions",
       "resource": "Read conditions",
       "key": "read_conditions",
-      "resourceId": 446093,
-      "productId": 69
+      "resourceId": "446093",
+      "productId": "69"
     },
     {
       "product": "Conditions Evaluator",
       "category": "Conditions",
       "resource": "Modify conditions",
       "key": "modify_conditions",
-      "resourceId": 446094,
-      "productId": 69
+      "resourceId": "446094",
+      "productId": "69"
     },
     {
       "product": "Conversation Tracker",
       "category": "Email",
       "resource": "End Conversation",
       "key": "Finalizar_Conversa",
-      "resourceId": 1137,
-      "productId": 20
+      "resourceId": "1137",
+      "productId": "20"
     },
     {
       "product": "Conversation Tracker",
       "category": "Email",
       "resource": "Extend Conversation",
       "key": "Prorrogar_Conversa",
-      "resourceId": 1138,
-      "productId": 20
+      "resourceId": "1138",
+      "productId": "20"
     },
     {
       "product": "Conversation Tracker",
       "category": "Internal",
       "resource": "ConversationTracker-InternalApi",
       "key": "ConversationTrackerInternalApi",
-      "resourceId": 2006418,
-      "productId": 20
+      "resourceId": "2006418",
+      "productId": "20"
     },
     {
       "product": "Conversation Tracker",
       "category": "Email",
       "resource": "ConversationTracker Email Mapping",
       "key": "ConversationTracker-EmailMapping",
-      "resourceId": 2123571,
-      "productId": 20
+      "resourceId": "2123571",
+      "productId": "20"
     },
     {
       "product": "Credit Control",
       "category": "Purchase Conditions",
       "resource": "Read Cross Profile Purchase Conditions",
       "key": "read_cross_profile_purchase_conditions",
-      "resourceId": 2128450,
-      "productId": 58
+      "resourceId": "2128450",
+      "productId": "58"
     },
     {
       "product": "Customer Management",
       "category": "Contract",
       "resource": "View Contracts",
       "key": "ViewContracts",
-      "resourceId": 2106494,
-      "productId": 130
+      "resourceId": "2106494",
+      "productId": "130"
     },
     {
       "product": "Customer Management",
       "category": "Contract",
       "resource": "Edit Contracts",
       "key": "EditContracts",
-      "resourceId": 2106495,
-      "productId": 130
+      "resourceId": "2106495",
+      "productId": "130"
     },
     {
       "product": "Dandelion",
       "category": "Export Functions",
       "resource": "Export Resource",
       "key": "dandelion-export",
-      "resourceId": 1014315,
-      "productId": 85
+      "resourceId": "1014315",
+      "productId": "85"
     },
     {
       "product": "Dandelion",
       "category": "Import Functions",
       "resource": "Import Resource",
       "key": "dandelion-import",
-      "resourceId": 1014380,
-      "productId": 85
+      "resourceId": "1014380",
+      "productId": "85"
     },
     {
       "product": "Data Vault",
       "category": "Internal",
       "resource": "Tokenize",
       "key": "Tokenize",
-      "resourceId": 2128438,
-      "productId": 133
+      "resourceId": "2128438",
+      "productId": "133"
     },
     {
       "product": "Data Vault",
       "category": "Internal",
       "resource": "Detokenize",
       "key": "Detokenize",
-      "resourceId": 2128439,
-      "productId": 133
+      "resourceId": "2128439",
+      "productId": "133"
     },
     {
       "product": "Data Vault",
       "category": "Internal",
       "resource": "Fingerprint",
       "key": "Fingerprint",
-      "resourceId": 2128440,
-      "productId": 133
+      "resourceId": "2128440",
+      "productId": "133"
     },
     {
       "product": "Data Vault",
       "category": "Internal",
       "resource": "User Rights Delete",
       "key": "DataVaultUserRightsDelete",
-      "resourceId": 2128441,
-      "productId": 133
+      "resourceId": "2128441",
+      "productId": "133"
     },
     {
       "product": "Data Vault",
       "category": "Internal",
       "resource": "User Rights Retrieve",
       "key": "DataVaultUserRightsRetrieve",
-      "resourceId": 2128442,
-      "productId": 133
+      "resourceId": "2128442",
+      "productId": "133"
     },
     {
       "product": "Delivery Promises",
       "category": "ProductAvailability",
       "resource": "Notify Product Availability Change",
       "key": "NotifyProductAvailabilityChange",
-      "resourceId": 2032871,
-      "productId": 111
+      "resourceId": "2032871",
+      "productId": "111"
     },
     {
       "product": "Delivery Promises",
       "category": "ProductAvailability",
       "resource": "Delivery Promises ReprocessItem",
       "key": "DeliveryPromisesReprocessItem",
-      "resourceId": 2118039,
-      "productId": 111
+      "resourceId": "2118039",
+      "productId": "111"
     },
     {
       "product": "FastStore",
       "category": "Secrets",
       "resource": "View Secrets",
       "key": "ViewSecrets",
-      "resourceId": 2100329,
-      "productId": 129
+      "resourceId": "2100329",
+      "productId": "129"
     },
     {
       "product": "FastStore",
       "category": "Secrets",
       "resource": "Edit Secrets",
       "key": "EditSecrets",
-      "resourceId": 2100330,
-      "productId": 129
+      "resourceId": "2100330",
+      "productId": "129"
     },
     {
       "product": "Fraud Prevention",
       "category": "Transaction Attempts",
       "resource": "View transaction attempts",
       "key": "ViewTransactionAttempts",
-      "resourceId": 2134012,
-      "productId": 127
+      "resourceId": "2134012",
+      "productId": "127"
     },
     {
       "product": "Fraud Prevention",
       "category": "Transaction Attempts",
       "resource": "Edit transaction attempt action settings",
       "key": "EditTransactionAttemptActionSettings",
-      "resourceId": 2134013,
-      "productId": 127
+      "resourceId": "2134013",
+      "productId": "127"
     },
     {
       "product": "Fraud Prevention",
       "category": "Transaction Attempts",
       "resource": "Edit transaction attempt score settings",
       "key": "EditTransactionAttemptScoreSettings",
-      "resourceId": 2134014,
-      "productId": 127
+      "resourceId": "2134014",
+      "productId": "127"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Get applications",
       "key": "Get_Applications",
-      "resourceId": 1066,
-      "productId": 1
+      "resourceId": "1066",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Find user by email",
       "key": "Get_User_By_Identifier",
-      "resourceId": 1070,
-      "productId": 1
+      "resourceId": "1070",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "View users with account access",
       "key": "Get_Users_By_Account",
-      "resourceId": 1071,
-      "productId": 1
+      "resourceId": "1071",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "View all admin users",
       "key": "Get_Users_By_IsAdmin",
-      "resourceId": 1072,
-      "productId": 1
+      "resourceId": "1072",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Button linking user to role",
       "key": "Create_Role_User",
-      "resourceId": 1073,
-      "productId": 1
+      "resourceId": "1073",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Get resource by key",
       "key": "Get_Resource_By_Key",
-      "resourceId": 1082,
-      "productId": 1
+      "resourceId": "1082",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Link user to role",
       "key": "Associate_Login_To_Role",
-      "resourceId": 1084,
-      "productId": 1
+      "resourceId": "1084",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Unlink user from role",
       "key": "Disassociate_Login_To_Role",
-      "resourceId": 1085,
-      "productId": 1
+      "resourceId": "1085",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "View accounts a user has access to",
       "key": "Get_Licensed_Accounts_From_ProductId",
-      "resourceId": 1093,
-      "productId": 1
+      "resourceId": "1093",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Delete access profile",
       "key": "Role:Delete",
-      "resourceId": 1131,
-      "productId": 1
+      "resourceId": "1131",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Get admin status",
       "key": "Get_Admin_Status",
-      "resourceId": 1180,
-      "productId": 1
+      "resourceId": "1180",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Get accounts",
       "key": "Get_Accounts_Paged",
-      "resourceId": 1181,
-      "productId": 1
+      "resourceId": "1181",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Set/Unset production status from account",
       "key": "Remove_Account_From_Production",
-      "resourceId": 113305,
-      "productId": 1
+      "resourceId": "113305",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "View API Keys",
       "key": "View_ApiKeys",
-      "resourceId": 1991888,
-      "productId": 1
+      "resourceId": "1991888",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Internal access control",
       "resource": "Block Cascading User",
       "key": "BlockUser",
-      "resourceId": 2004075,
-      "productId": 1
+      "resourceId": "2004075",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "View Storefront User Permissions",
       "key": "View_Storefront_User_Permissions",
-      "resourceId": 2082433,
-      "productId": 1
+      "resourceId": "2082433",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Edit Storefront User Permissions",
       "key": "Edit_Storefront_User_Permissions",
-      "resourceId": 2082434,
-      "productId": 1
+      "resourceId": "2082434",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Get paged products",
       "key": "Get_Products_Paged",
-      "resourceId": 1187,
-      "productId": 1
+      "resourceId": "1187",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Save license",
       "key": "Save_License",
-      "resourceId": 1198,
-      "productId": 1
+      "resourceId": "1198",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Link license to account",
       "key": "Save_License_In_Account",
-      "resourceId": 1058,
-      "productId": 1
+      "resourceId": "1058",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Set account domain",
       "key": "Set_Domain",
-      "resourceId": 1060,
-      "productId": 1
+      "resourceId": "1060",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Check if provisioned",
       "key": "Check_in_Provisioning",
-      "resourceId": 1062,
-      "productId": 1
+      "resourceId": "1062",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Get all accounts",
       "key": "Get_All_Accounts",
-      "resourceId": 1065,
-      "productId": 1
+      "resourceId": "1065",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Find product url",
       "key": "Get_Product_Endpoint",
-      "resourceId": 1068,
-      "productId": 1
+      "resourceId": "1068",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Save resource",
       "key": "Save_Resource",
-      "resourceId": 1080,
-      "productId": 1
+      "resourceId": "1080",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Remove resource by key",
       "key": "Remove_Resource_By_Key",
-      "resourceId": 1081,
-      "productId": 1
+      "resourceId": "1081",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Account list",
       "key": "Account:List",
-      "resourceId": 1098,
-      "productId": 1
+      "resourceId": "1098",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Create account",
       "key": "Account:Add",
-      "resourceId": 1099,
-      "productId": 1
+      "resourceId": "1099",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Edit account",
       "key": "Account:Edit",
-      "resourceId": 1100,
-      "productId": 1
+      "resourceId": "1100",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Delete account",
       "key": "Account:Delete",
-      "resourceId": 1101,
-      "productId": 1
+      "resourceId": "1101",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "Ui - Product list",
       "key": "Product:List",
-      "resourceId": 1102,
-      "productId": 1
+      "resourceId": "1102",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Create product",
       "key": "Product:Add",
-      "resourceId": 1103,
-      "productId": 1
+      "resourceId": "1103",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Edit product",
       "key": "Product:Edit",
-      "resourceId": 1104,
-      "productId": 1
+      "resourceId": "1104",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Delete product",
       "key": "Product:Delete",
-      "resourceId": 1105,
-      "productId": 1
+      "resourceId": "1105",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - List of licenses",
       "key": "License:List",
-      "resourceId": 1106,
-      "productId": 1
+      "resourceId": "1106",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Create license",
       "key": "License:Add",
-      "resourceId": 1107,
-      "productId": 1
+      "resourceId": "1107",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Edit license",
       "key": "License:Edit",
-      "resourceId": 1108,
-      "productId": 1
+      "resourceId": "1108",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Delete license",
       "key": "License:Delete",
-      "resourceId": 1109,
-      "productId": 1
+      "resourceId": "1109",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Link product to license",
       "key": "License:AssociateProducts",
-      "resourceId": 1110,
-      "productId": 1
+      "resourceId": "1110",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Unlink product from license",
       "key": "License:DisassociateProducts",
-      "resourceId": 1111,
-      "productId": 1
+      "resourceId": "1111",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Users list",
       "key": "User:List",
-      "resourceId": 1116,
-      "productId": 1
+      "resourceId": "1116",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Create user",
       "key": "User:Add",
-      "resourceId": 1117,
-      "productId": 1
+      "resourceId": "1117",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Edit user",
       "key": "User:Edit",
-      "resourceId": 1118,
-      "productId": 1
+      "resourceId": "1118",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Delete User",
       "key": "User:Delete",
-      "resourceId": 1119,
-      "productId": 1
+      "resourceId": "1119",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Create resource category",
       "key": "ResourceCategory:Add",
-      "resourceId": 1125,
-      "productId": 1
+      "resourceId": "1125",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Role list",
       "key": "Role:List",
-      "resourceId": 1128,
-      "productId": 1
+      "resourceId": "1128",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Create Role",
       "key": "Role:Add",
-      "resourceId": 1129,
-      "productId": 1
+      "resourceId": "1129",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Edit role",
       "key": "Role:Edit",
-      "resourceId": 1130,
-      "productId": 1
+      "resourceId": "1130",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Link user to role",
       "key": "Role:AssociateUser",
-      "resourceId": 1133,
-      "productId": 1
+      "resourceId": "1133",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Unlink user from role",
       "key": "Role:DisassociateUser",
-      "resourceId": 1134,
-      "productId": 1
+      "resourceId": "1134",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Link resource to role",
       "key": "Role:AssociateResource",
-      "resourceId": 1135,
-      "productId": 1
+      "resourceId": "1135",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "UI - Unlink resource from role",
       "key": "Role:DisassociateResource",
-      "resourceId": 1136,
-      "productId": 1
+      "resourceId": "1136",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Add resource",
       "key": "Create_Resource",
-      "resourceId": 1176,
-      "productId": 1
+      "resourceId": "1176",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "Remove account",
       "key": "Delete_Account",
-      "resourceId": 1182,
-      "productId": 1
+      "resourceId": "1182",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Add product",
       "key": "Create_Product",
-      "resourceId": 1186,
-      "productId": 1
+      "resourceId": "1186",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "Remove license",
       "key": "Delete_License",
-      "resourceId": 1199,
-      "productId": 1
+      "resourceId": "1199",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "Get account provision status",
       "key": "Get_Products_In_Provisioning",
-      "resourceId": 1200,
-      "productId": 1
+      "resourceId": "1200",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Update application token",
       "key": "Update_Token",
-      "resourceId": 1208,
-      "productId": 1
+      "resourceId": "1208",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Get product",
       "key": "Get_Product",
-      "resourceId": 1618,
-      "productId": 1
+      "resourceId": "1618",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Turn on/off account",
       "key": "Inactivate_Account",
-      "resourceId": 113304,
-      "productId": 1
+      "resourceId": "113304",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Get hosts by account",
       "key": "Get_Hosts_By_Site",
-      "resourceId": 429883,
-      "productId": 1
+      "resourceId": "429883",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Get stores by account",
       "key": "Get_Sites_By_Account",
-      "resourceId": 445913,
-      "productId": 1
+      "resourceId": "445913",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "List resources",
       "key": "Resource:List",
-      "resourceId": 458756,
-      "productId": 1
+      "resourceId": "458756",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "Create resource",
       "key": "Resource:Add",
-      "resourceId": 458757,
-      "productId": 1
+      "resourceId": "458757",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "Update resource",
       "key": "Resource:Edit",
-      "resourceId": 458758,
-      "productId": 1
+      "resourceId": "458758",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Web access control",
       "resource": "Delete resource",
       "key": "Resource:Delete",
-      "resourceId": 458759,
-      "productId": 1
+      "resourceId": "458759",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Services access control",
       "resource": "Get Licenses Paged",
       "key": "Get_Licenses_Paged",
-      "resourceId": 721135,
-      "productId": 1
+      "resourceId": "721135",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Get_Active_Accounts",
       "resource": "Get_Active_Accounts",
       "key": "Get_Active_Accounts",
-      "resourceId": 2036795,
-      "productId": 1
+      "resourceId": "2036795",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Internal",
       "resource": "Teams Management",
       "key": "ManageTeams",
-      "resourceId": 2124263,
-      "productId": 1
+      "resourceId": "2124263",
+      "productId": "1"
     },
     {
       "product": "License Manager",
       "category": "Internal",
       "resource": "Services Management",
       "key": "ManageServices",
-      "resourceId": 2124264,
-      "productId": 1
+      "resourceId": "2124264",
+      "productId": "1"
     },
     {
       "product": "Log",
       "category": "Log Admin",
       "resource": "Get App",
       "key": "GetApp",
-      "resourceId": 700271,
-      "productId": 14
+      "resourceId": "700271",
+      "productId": "14"
     },
     {
       "product": "Log",
       "category": "Log Admin",
       "resource": "Create Table ",
       "key": "CreateTable ",
-      "resourceId": 700272,
-      "productId": 14
+      "resourceId": "700272",
+      "productId": "14"
     },
     {
       "product": "Logistics",
       "category": "Logistics access",
       "resource": "Logistics shipping read only",
       "key": "ShippingViewer",
-      "resourceId": 475814,
-      "productId": 9
+      "resourceId": "475814",
+      "productId": "9"
     },
     {
       "product": "Logistics",
       "category": "Logistics access",
       "resource": "LogisticsInternal",
       "key": "LogisticsInternal",
-      "resourceId": 1994105,
-      "productId": 9
+      "resourceId": "1994105",
+      "productId": "9"
     },
     {
       "product": "OMS",
       "category": "Internal",
       "resource": "OMS-InternalApi",
       "key": "OMSInternalApi",
-      "resourceId": 2006417,
-      "productId": 19
+      "resourceId": "2006417",
+      "productId": "19"
     },
     {
       "product": "OMS",
       "category": "Internal",
       "resource": "FeedHookV3Maintenance",
       "key": "FeedHookV3Maintenance",
-      "resourceId": 2064617,
-      "productId": 19
+      "resourceId": "2064617",
+      "productId": "19"
     },
     {
       "product": "Organization Units",
       "category": "units",
       "resource": "Edit Organization Unit",
       "key": "Edit_Organization_Unit",
-      "resourceId": 2071771,
-      "productId": 110
+      "resourceId": "2071771",
+      "productId": "110"
     },
     {
       "product": "Organization Units",
       "category": "units",
       "resource": "Move Organization Unit",
       "key": "Move_Organization_Unit",
-      "resourceId": 2071772,
-      "productId": 110
+      "resourceId": "2071772",
+      "productId": "110"
     },
     {
       "product": "Organization Units",
       "category": "units",
       "resource": "View Organization Unit",
       "key": "View_Organization_Unit",
-      "resourceId": 2071774,
-      "productId": 110
+      "resourceId": "2071774",
+      "productId": "110"
     },
     {
       "product": "PCI Gateway",
       "category": "Payment-ManageStore",
       "resource": "Manage Store AntiFraud",
       "key": "ManageStoreAntiFraud ",
-      "resourceId": 1684988,
+      "resourceId": "1684988",
       "productId": ""
     },
     {
@@ -1181,375 +1181,375 @@
       "category": "Card Token Vault",
       "resource": "View Card Tokens",
       "key": "ViewCardTokens",
-      "resourceId": 2078628,
-      "productId": 114
+      "resourceId": "2078628",
+      "productId": "114"
     },
     {
       "product": "Payments",
       "category": "Card Token Vault",
       "resource": "Edit Card Tokens",
       "key": "ManageCardTokens",
-      "resourceId": 2078744,
-      "productId": 114
+      "resourceId": "2078744",
+      "productId": "114"
     },
     {
       "product": "Payments",
       "category": "Card Token Vault",
       "resource": "Create Card Tokens",
       "key": "CreateCardTokens",
-      "resourceId": 2078845,
-      "productId": 114
+      "resourceId": "2078845",
+      "productId": "114"
     },
     {
       "product": "Payments",
       "category": "Card Token Vault",
       "resource": "Delete Card Token",
       "key": "DeleteCardToken",
-      "resourceId": 2078846,
-      "productId": 114
+      "resourceId": "2078846",
+      "productId": "114"
     },
     {
       "product": "Payments",
       "category": "Card Token Vault",
       "resource": "Import Card Token",
       "key": "ImportCardToken",
-      "resourceId": 2078847,
-      "productId": 114
+      "resourceId": "2078847",
+      "productId": "114"
     },
     {
       "product": "Payments",
       "category": "Card Token Vault",
       "resource": "Get Import Card Token Status ",
       "key": "GetImportCardTokenStatus",
-      "resourceId": 2078848,
-      "productId": 114
+      "resourceId": "2078848",
+      "productId": "114"
     },
     {
       "product": "Payments",
       "category": "Card Token Vault",
       "resource": "Get Import Card Tokens Report",
       "key": "GetImportCardTokensReport",
-      "resourceId": 2078849,
-      "productId": 114
+      "resourceId": "2078849",
+      "productId": "114"
     },
     {
       "product": "Payments Forget Me",
       "category": "Payments Services Management",
       "resource": "Registers Payments Service",
       "key": "payments_services_register",
-      "resourceId": 2029347,
-      "productId": 109
+      "resourceId": "2029347",
+      "productId": "109"
     },
     {
       "product": "Payments Forget Me",
       "category": "Payments Services Management",
       "resource": "Updates Payments Service",
       "key": "payments_services_update",
-      "resourceId": 2029348,
-      "productId": 109
+      "resourceId": "2029348",
+      "productId": "109"
     },
     {
       "product": "Payments Forget Me",
       "category": "Payments Services Management",
       "resource": "Find All Payments Services",
       "key": "payments_services_find_all",
-      "resourceId": 2029349,
-      "productId": 109
+      "resourceId": "2029349",
+      "productId": "109"
     },
     {
       "product": "Payments Forget Me",
       "category": "Payments Services Management",
       "resource": "Find Payments Service",
       "key": "payments_services_find",
-      "resourceId": 2029350,
-      "productId": 109
+      "resourceId": "2029350",
+      "productId": "109"
     },
     {
       "product": "Payments Forget Me",
       "category": "Payments Services Management",
       "resource": "Deletes Payments Service",
       "key": "payments_services_delete",
-      "resourceId": 2029351,
-      "productId": 109
+      "resourceId": "2029351",
+      "productId": "109"
     },
     {
       "product": "PersonalShopper App",
       "category": "Call",
       "resource": "View List Call",
       "key": "view-list-call",
-      "resourceId": 1639430,
-      "productId": 100
+      "resourceId": "1639430",
+      "productId": "100"
     },
     {
       "product": "PersonalShopper App",
       "category": "Analytics",
       "resource": "View Analytics",
       "key": "view-analytics",
-      "resourceId": 1639728,
-      "productId": 100
+      "resourceId": "1639728",
+      "productId": "100"
     },
     {
       "product": "PersonalShopper App",
       "category": "Setting",
       "resource": "View Setting",
       "key": "view-setting",
-      "resourceId": 1643056,
-      "productId": 100
+      "resourceId": "1643056",
+      "productId": "100"
     },
     {
       "product": "Pricing",
       "category": "Price List",
       "resource": "View External Seller Prices",
       "key": "read_External_Seller_Prices",
-      "resourceId": 2067783,
-      "productId": 65
+      "resourceId": "2067783",
+      "productId": "65"
     },
     {
       "product": "Pricing",
       "category": "Price List",
       "resource": "Edit External Seller prices",
       "key": "modify_External_Seller_Prices",
-      "resourceId": 2067814,
-      "productId": 65
+      "resourceId": "2067814",
+      "productId": "65"
     },
     {
       "product": "Profile System",
       "category": "Documents",
       "resource": "Get Item",
       "key": "GetItemResource",
-      "resourceId": 1479422,
-      "productId": 96
+      "resourceId": "1479422",
+      "productId": "96"
     },
     {
       "product": "Profile System",
       "category": "Documents",
       "resource": "Save and Update Item",
       "key": "PutItemResource",
-      "resourceId": 1479648,
-      "productId": 96
+      "resourceId": "1479648",
+      "productId": "96"
     },
     {
       "product": "Profile System",
       "category": "Documents",
       "resource": "Delete Item",
       "key": "DeleteItemResource",
-      "resourceId": 1479726,
-      "productId": 96
+      "resourceId": "1479726",
+      "productId": "96"
     },
     {
       "product": "Profile System",
       "category": "Documents",
       "resource": "Validate Conditions",
       "key": "ValidateConditionsResource",
-      "resourceId": 1926330,
-      "productId": 96
+      "resourceId": "1926330",
+      "productId": "96"
     },
     {
       "product": "Profile System",
       "category": "Documents",
       "resource": "Get Item V2",
       "key": "GetItemResourceV2",
-      "resourceId": 1979918,
-      "productId": 96
+      "resourceId": "1979918",
+      "productId": "96"
     },
     {
       "product": "Profile System",
       "category": "Internal",
       "resource": "ProfileSystem User Rights",
       "key": "ProfileSystemUserRights",
-      "resourceId": 2113461,
-      "productId": 96
+      "resourceId": "2113461",
+      "productId": "96"
     },
     {
       "product": "Rates and Benefits",
       "category": "Promotions",
       "resource": "Manage External Seller Promotions",
       "key": "External_Seller_Promotions",
-      "resourceId": 2067822,
-      "productId": 16
+      "resourceId": "2067822",
+      "productId": "16"
     },
     {
       "product": "Rates and Benefits",
       "category": "Promotions",
       "resource": "Manage promotions activation",
       "key": "manage_promotions_activation",
-      "resourceId": 2072569,
-      "productId": 16
+      "resourceId": "2072569",
+      "productId": "16"
     },
     {
       "product": "Releases",
       "category": "Releases",
       "resource": "Add Updates",
       "key": "edit-update",
-      "resourceId": 1257566,
-      "productId": 91
+      "resourceId": "1257566",
+      "productId": "91"
     },
     {
       "product": "Releases",
       "category": "Releases",
       "resource": "See Releases menu on the side-bar",
       "key": "sidebar_visualizar",
-      "resourceId": 2022233,
-      "productId": 91
+      "resourceId": "2022233",
+      "productId": "91"
     },
     {
       "product": "Sales App",
       "category": "Reports",
       "resource": "View Sales Performance",
       "key": "ViewSalesPerformance",
-      "resourceId": 2126563,
-      "productId": 132
+      "resourceId": "2126563",
+      "productId": "132"
     },
     {
       "product": "Search",
       "category": "Search API",
       "resource": "Product Scroll",
       "key": "product-scroll",
-      "resourceId": 2099302,
-      "productId": 76
+      "resourceId": "2099302",
+      "productId": "76"
     },
     {
       "product": "Security Monitor",
       "category": "security-center-read",
       "resource": "List/Describe reports",
       "key": "read-reports",
-      "resourceId": 1858423,
-      "productId": 103
+      "resourceId": "1858423",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
       "category": "security-center-write",
       "resource": "Create Reports",
       "key": "write-reports",
-      "resourceId": 1858424,
-      "productId": 103
+      "resourceId": "1858424",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
       "category": "security-center-write",
       "resource": "Update Sensors",
       "key": "update-sensors",
-      "resourceId": 1880649,
-      "productId": 103
+      "resourceId": "1880649",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
       "category": "security-center-read",
       "resource": "List/Describe Sensors",
       "key": "read-sensors",
-      "resourceId": 1880664,
-      "productId": 103
+      "resourceId": "1880664",
+      "productId": "103"
     },
     {
       "product": "Suggestion",
       "category": "Suggestion Resources",
       "resource": "mapper",
       "key": "mapper",
-      "resourceId": 1556055,
-      "productId": 50
+      "resourceId": "1556055",
+      "productId": "50"
     },
     {
       "product": "Time Series",
       "category": "Time Series",
       "resource": "Bulk Entry",
       "key": "BulkEntry_old",
-      "resourceId": 600174,
-      "productId": 75
+      "resourceId": "600174",
+      "productId": "75"
     },
     {
       "product": "Time Series",
       "category": "Time Series",
       "resource": "Get Application Configuration",
       "key": "GetApplicationConfiguration",
-      "resourceId": 610118,
-      "productId": 75
+      "resourceId": "610118",
+      "productId": "75"
     },
     {
       "product": "Time Series",
       "category": "Time Series",
       "resource": "Delete Application Configuration Cache",
       "key": "DeleteApplicationConfigurationCache",
-      "resourceId": 610119,
-      "productId": 75
+      "resourceId": "610119",
+      "productId": "75"
     },
     {
       "product": "Unikey",
       "category": "Unikey Resources",
       "resource": "Increment sequence",
       "key": "Increase_Sequence",
-      "resourceId": 1211,
-      "productId": 18
+      "resourceId": "1211",
+      "productId": "18"
     },
     {
       "product": "Unikey",
       "category": "Unikey Resources",
       "resource": "Create bucket",
       "key": "Create_Bucket",
-      "resourceId": 1212,
-      "productId": 18
+      "resourceId": "1212",
+      "productId": "18"
     },
     {
       "product": "Unikey",
       "category": "Unikey Resources",
       "resource": "Get new key",
       "key": "Generate_Key",
-      "resourceId": 1213,
-      "productId": 18
+      "resourceId": "1213",
+      "productId": "18"
     },
     {
       "product": "Unikey",
       "category": "Unikey Resources",
       "resource": "Get bucket configuration",
       "key": "Get_Bucket_Configuration",
-      "resourceId": 1356,
-      "productId": 18
+      "resourceId": "1356",
+      "productId": "18"
     },
     {
       "product": "Unikey",
       "category": "Unikey Resources",
       "resource": "Change bucket configuration",
       "key": "Change_Bucket_Configuration",
-      "resourceId": 1707,
-      "productId": 18
+      "resourceId": "1707",
+      "productId": "18"
     },
     {
       "product": "Unikey",
       "category": "internal",
       "resource": "Unikey-Internal",
       "key": "UnikeyInternal",
-      "resourceId": 1997753,
-      "productId": 18
+      "resourceId": "1997753",
+      "productId": "18"
     },
     {
       "product": "Units",
       "category": "units",
       "resource": "Edit Unit",
       "key": "Edit_Unit",
-      "resourceId": 2029283,
-      "productId": 110
+      "resourceId": "2029283",
+      "productId": "110"
     },
     {
       "product": "Units",
       "category": "units",
       "resource": "Move Unit",
       "key": "Move_Unit",
-      "resourceId": 2029291,
-      "productId": 110
+      "resourceId": "2029291",
+      "productId": "110"
     },
     {
       "product": "Units",
       "category": "units",
       "resource": "View Unit",
       "key": "View_Unit",
-      "resourceId": 2029293,
-      "productId": 110
+      "resourceId": "2029293",
+      "productId": "110"
     },
     {
       "product": "User Rights",
       "category": "applications",
       "resource": "Read Applications",
       "key": "applications_read",
-      "resourceId": 1634515,
+      "resourceId": "1634515",
       "productId": ""
     },
     {
@@ -1557,7 +1557,7 @@
       "category": "applications",
       "resource": "Write Applications",
       "key": "applications_write",
-      "resourceId": 1634523,
+      "resourceId": "1634523",
       "productId": ""
     },
     {
@@ -1565,63 +1565,63 @@
       "category": "user-rights-request",
       "resource": "Read user rights requests",
       "key": "user_rights_request_read",
-      "resourceId": 1634546,
-      "productId": 99
+      "resourceId": "1634546",
+      "productId": "99"
     },
     {
       "product": "User Rights",
       "category": "user-rights-request",
       "resource": "Write user rights requests",
       "key": "user_rights_request_write",
-      "resourceId": 1634554,
-      "productId": 99
+      "resourceId": "1634554",
+      "productId": "99"
     },
     {
       "product": "User Rights",
       "category": "user-rights-request",
       "resource": "Process User Rights Removal Request",
       "key": "removal-request-process",
-      "resourceId": 1705138,
-      "productId": 99
+      "resourceId": "1705138",
+      "productId": "99"
     },
     {
       "product": "User Rights",
       "category": "user-rights-request",
       "resource": "Process User Rights Removal Request",
       "key": "removal-request-process",
-      "resourceId": 1705138,
-      "productId": 99
+      "resourceId": "1705138",
+      "productId": "99"
     },
     {
       "product": "VTEX CX Platform",
       "category": "CX Platform Access",
       "resource": "Access CX Platform",
       "key": "AccessCxPlatform",
-      "resourceId": 2156284,
-      "productId": 135
+      "resourceId": "2156284",
+      "productId": "135"
     },
     {
       "product": "VTEX Fulfilment",
       "category": "Fulfilment Resources",
       "resource": "Place Orders",
       "key": "CriaPedidos",
-      "resourceId": 1360,
-      "productId": 15
+      "resourceId": "1360",
+      "productId": "15"
     },
     {
       "product": "VTEX Fulfilment",
       "category": "Fulfilment Resources",
       "resource": "Order Details",
       "key": "ObtemInfosDeCompra",
-      "resourceId": 1361,
-      "productId": 15
+      "resourceId": "1361",
+      "productId": "15"
     },
     {
       "product": "VTEX Home",
       "category": "Dashboards",
       "resource": "Client",
       "key": "dashboards_cliente",
-      "resourceId": 106513,
+      "resourceId": "106513",
       "productId": ""
     },
     {
@@ -1629,7 +1629,7 @@
       "category": "Dashboards",
       "resource": "Admin",
       "key": "dashboards_admin",
-      "resourceId": 106530,
+      "resourceId": "106530",
       "productId": ""
     },
     {
@@ -1637,7 +1637,7 @@
       "category": "Dashboards",
       "resource": "Analyst",
       "key": "dashboards_analista",
-      "resourceId": 106531,
+      "resourceId": "106531",
       "productId": ""
     },
     {
@@ -1645,104 +1645,104 @@
       "category": "Infrastructure",
       "resource": "File Manager Bucket Config",
       "key": "file-manager-bucket-config",
-      "resourceId": 2156623,
-      "productId": 66
+      "resourceId": "2156623",
+      "productId": "66"
     },
     {
       "product": "VTEX Payment",
       "category": "Payments Administration",
       "resource": "Card Management",
       "key": "card-management",
-      "resourceId": 604283,
-      "productId": 72
+      "resourceId": "604283",
+      "productId": "72"
     },
     {
       "product": "VTEX Payment",
       "category": "Payments Administration",
       "resource": "Banking View",
       "key": "banking-view",
-      "resourceId": 604284,
-      "productId": 72
+      "resourceId": "604284",
+      "productId": "72"
     },
     {
       "product": "VTEX Payment",
       "category": "Payments Administration",
       "resource": "Monetary Activity",
       "key": "monetary-activity",
-      "resourceId": 604285,
-      "productId": 72
+      "resourceId": "604285",
+      "productId": "72"
     },
     {
       "product": "VTEX Payment",
       "category": "Payments Administration",
       "resource": "Configuring",
       "key": "payment-configuring",
-      "resourceId": 604286,
-      "productId": 72
+      "resourceId": "604286",
+      "productId": "72"
     },
     {
       "product": "VTEX Payment",
       "category": "Payments Administration",
       "resource": "Dispute Management",
       "key": "disputes-management",
-      "resourceId": 604287,
-      "productId": 72
+      "resourceId": "604287",
+      "productId": "72"
     },
     {
       "product": "Vtex ID",
       "category": "Admin",
       "resource": "Manage VTEX ID",
       "key": "view_admin",
-      "resourceId": 143458,
-      "productId": 64
+      "resourceId": "143458",
+      "productId": "64"
     },
     {
       "product": "Vtex ID",
       "category": "Account Configuration",
       "resource": "Read Account Config",
       "key": "read_account_config",
-      "resourceId": 1497371,
-      "productId": 64
+      "resourceId": "1497371",
+      "productId": "64"
     },
     {
       "product": "Vtex ID",
       "category": "Account Configuration",
       "resource": "Write Account Config",
       "key": "write_account_config",
-      "resourceId": 1497386,
-      "productId": 64
+      "resourceId": "1497386",
+      "productId": "64"
     },
     {
       "product": "Vtex ID",
       "category": "User Management",
       "resource": "DeleteLoginPreference",
       "key": "DeleteLoginPreference",
-      "resourceId": 2009425,
-      "productId": 64
+      "resourceId": "2009425",
+      "productId": "64"
     },
     {
       "product": "Vtex ID",
       "category": "User Management",
       "resource": "Revoke user login sessions",
       "key": "RevokeLoginSessions",
-      "resourceId": 2051366,
-      "productId": 64
+      "resourceId": "2051366",
+      "productId": "64"
     },
     {
       "product": "Vtex ID",
       "category": "User Management",
       "resource": "Generate Access Code",
       "key": "Generate_Access_Code",
-      "resourceId": 2121783,
-      "productId": 64
+      "resourceId": "2121783",
+      "productId": "64"
     },
     {
       "product": "Vtex ID",
       "category": "User Management",
       "resource": "Read Users",
       "key": "ReadUsers",
-      "resourceId": 2141288,
-      "productId": 64
+      "resourceId": "2141288",
+      "productId": "64"
     }
   ]
 }

--- a/data-tables/license-manager-internal-resources.json
+++ b/data-tables/license-manager-internal-resources.json
@@ -1,0 +1,1748 @@
+{
+  "rows": [
+    {
+      "product": "Audit",
+      "category": "Product",
+      "resource": "Export Job",
+      "key": "ExportJob",
+      "resourceId": 2124114,
+      "productId": 55
+    },
+    {
+      "product": "Availability Notify",
+      "category": "Notification Requests",
+      "resource": "Download Notification Requests",
+      "key": "downloadNotificationRequests",
+      "resourceId": 2156515,
+      "productId": 136
+    },
+    {
+      "product": "B2B",
+      "category": "Import",
+      "resource": "B2BBulkImport",
+      "key": "B2BBulkImport",
+      "resourceId": 1954299,
+      "productId": 105
+    },
+    {
+      "product": "B2B",
+      "category": "Import",
+      "resource": "BulkImportTest",
+      "key": "BulkImportTest",
+      "resourceId": 1957237,
+      "productId": 105
+    },
+    {
+      "product": "B2B",
+      "category": "B2B General",
+      "resource": "B2BBulkExport",
+      "key": "B2BBulkExport",
+      "resourceId": 2045795,
+      "productId": 105
+    },
+    {
+      "product": "Billing",
+      "category": "Company",
+      "resource": "Add Account",
+      "key": "add_accountname",
+      "resourceId": 134736,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Company",
+      "resource": "Delete Account",
+      "key": "delete_accountname",
+      "resourceId": 134737,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Recalculate Invoice",
+      "key": "generate_invoice_overdue",
+      "resourceId": 139181,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Dashboard",
+      "resource": "Get Dashboard Charges",
+      "key": "get_unscrewed_dashboard_charges",
+      "resourceId": 142913,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Reseller",
+      "resource": "List Active Commissions",
+      "key": "list_active_commissions",
+      "resourceId": 1569483,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Reseller",
+      "resource": "List Commissions History",
+      "key": "list_commissions_history",
+      "resourceId": 1569484,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Reseller",
+      "resource": "Get Commission Totalizers",
+      "key": "get_commissions_totalizers",
+      "resourceId": 1569485,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Commands",
+      "resource": "Inflation Report Command",
+      "key": "inflationreport",
+      "resourceId": 1928420,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Contracts",
+      "resource": "Mark Contract as Reviewed",
+      "key": "mark-contract-as-reviewed",
+      "resourceId": 1929752,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Contracts",
+      "resource": "Save contracts with changes to financial values",
+      "key": "put_contract_financial_values",
+      "resourceId": 1933312,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "List Invoice Due Date Change Requests",
+      "key": "list-invoice-due-date-change-requests",
+      "resourceId": 1951668,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Put Invoice Due Date Change Requests",
+      "key": "put-invoice-due-date-change-requests",
+      "resourceId": 1951669,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Review Invoice Due Date Change Requests",
+      "key": "review-invoice-due-date-change-requests",
+      "resourceId": 1951677,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Company",
+      "resource": "Create Child Account",
+      "key": "create_child_account",
+      "resourceId": 2078353,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Update boleto overdue date",
+      "key": "boleto_overdue_date",
+      "resourceId": 2102653,
+      "productId": 43
+    },
+    {
+      "product": "CDN API",
+      "category": "CDN API Internal",
+      "resource": "Update WafControl Config",
+      "key": "UpdateWafControlConfig",
+      "resourceId": 2142571,
+      "productId": 108
+    },
+    {
+      "product": "CDN API",
+      "category": "CDN API Internal",
+      "resource": "View WafControl Config",
+      "key": "ViewWafControlConfig",
+      "resourceId": 2142572,
+      "productId": 108
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketing",
+      "resource": "Experts",
+      "key": "Especialista.aspx",
+      "resourceId": 925,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketing",
+      "resource": "Expert Management",
+      "key": "EspecialistaForm.aspx",
+      "resourceId": 926,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "Experts opinions",
+      "key": "EspecialistaOpiniao.aspx",
+      "resourceId": 927,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Instant Publish",
+      "key": "instant-publish",
+      "resourceId": 1044980,
+      "productId": 2
+    },
+    {
+      "product": "CatalogV2",
+      "category": "Management",
+      "resource": "Product Write",
+      "key": "product-write",
+      "resourceId": 1132306,
+      "productId": ""
+    },
+    {
+      "product": "CatalogV2",
+      "category": "Management",
+      "resource": "Product Read",
+      "key": "product-read",
+      "resourceId": 1132321,
+      "productId": ""
+    },
+    {
+      "product": "CatalogV2",
+      "category": "Management",
+      "resource": "Category Write",
+      "key": "category-write",
+      "resourceId": 1132322,
+      "productId": ""
+    },
+    {
+      "product": "CatalogV2",
+      "category": "Management",
+      "resource": "Category Read",
+      "key": "category-read",
+      "resourceId": 1132323,
+      "productId": ""
+    },
+    {
+      "product": "CatalogV2",
+      "category": "Management",
+      "resource": "Brand Write",
+      "key": "brand-write",
+      "resourceId": 1132324,
+      "productId": ""
+    },
+    {
+      "product": "CatalogV2",
+      "category": "Management",
+      "resource": "Brand Read",
+      "key": "brand-read",
+      "resourceId": 1132325,
+      "productId": ""
+    },
+    {
+      "product": "CatalogV2",
+      "category": "Management",
+      "resource": "Save Image",
+      "key": "image-write",
+      "resourceId": 1330546,
+      "productId": ""
+    },
+    {
+      "product": "Checkout",
+      "category": "CheckoutResources",
+      "resource": "Order Cancellation",
+      "key": "CancelaPedidos",
+      "resourceId": 1357,
+      "productId": 5
+    },
+    {
+      "product": "Checkout",
+      "category": "CheckoutResources",
+      "resource": "Save card token to user profile",
+      "key": "SaveCardTokenToUserProfile",
+      "resourceId": 721440,
+      "productId": 5
+    },
+    {
+      "product": "Checkout",
+      "category": "CheckoutResources",
+      "resource": "RecaptchaAllowlist",
+      "key": "RecaptchaAllowlist",
+      "resourceId": 1936124,
+      "productId": 5
+    },
+    {
+      "product": "Checkout",
+      "category": "CheckoutResources",
+      "resource": "Lock an OrderForm",
+      "key": "CanLockOrderForm",
+      "resourceId": 2154439,
+      "productId": 5
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Branch",
+      "resource": "Save to main branch",
+      "key": "SaveToMainBranch",
+      "resourceId": 2086248,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Entry",
+      "resource": "Delete entry",
+      "key": "DeleteEntry",
+      "resourceId": 2086249,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Branch",
+      "resource": "Remove from main branch",
+      "key": "RemoveFromMainBranch",
+      "resourceId": 2086250,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Branch",
+      "resource": "Merge branch",
+      "key": "MergeBranch",
+      "resourceId": 2086251,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Media Gallery",
+      "resource": "Upload Image",
+      "key": "UploadImage",
+      "resourceId": 2114634,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Branch",
+      "resource": "Delete Branch",
+      "key": "DeleteBranch",
+      "resourceId": 2153203,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Branch",
+      "resource": "Create Branch",
+      "key": "CreateBranch",
+      "resourceId": 2153204,
+      "productId": 115
+    },
+    {
+      "product": "Conditions Evaluator",
+      "category": "Conditions",
+      "resource": "Read conditions",
+      "key": "read_conditions",
+      "resourceId": 446093,
+      "productId": 69
+    },
+    {
+      "product": "Conditions Evaluator",
+      "category": "Conditions",
+      "resource": "Modify conditions",
+      "key": "modify_conditions",
+      "resourceId": 446094,
+      "productId": 69
+    },
+    {
+      "product": "Conversation Tracker",
+      "category": "Email",
+      "resource": "End Conversation",
+      "key": "Finalizar_Conversa",
+      "resourceId": 1137,
+      "productId": 20
+    },
+    {
+      "product": "Conversation Tracker",
+      "category": "Email",
+      "resource": "Extend Conversation",
+      "key": "Prorrogar_Conversa",
+      "resourceId": 1138,
+      "productId": 20
+    },
+    {
+      "product": "Conversation Tracker",
+      "category": "Internal",
+      "resource": "ConversationTracker-InternalApi",
+      "key": "ConversationTrackerInternalApi",
+      "resourceId": 2006418,
+      "productId": 20
+    },
+    {
+      "product": "Conversation Tracker",
+      "category": "Email",
+      "resource": "ConversationTracker Email Mapping",
+      "key": "ConversationTracker-EmailMapping",
+      "resourceId": 2123571,
+      "productId": 20
+    },
+    {
+      "product": "Credit Control",
+      "category": "Purchase Conditions",
+      "resource": "Read Cross Profile Purchase Conditions",
+      "key": "read_cross_profile_purchase_conditions",
+      "resourceId": 2128450,
+      "productId": 58
+    },
+    {
+      "product": "Customer Management",
+      "category": "Contract",
+      "resource": "View Contracts",
+      "key": "ViewContracts",
+      "resourceId": 2106494,
+      "productId": 130
+    },
+    {
+      "product": "Customer Management",
+      "category": "Contract",
+      "resource": "Edit Contracts",
+      "key": "EditContracts",
+      "resourceId": 2106495,
+      "productId": 130
+    },
+    {
+      "product": "Dandelion",
+      "category": "Export Functions",
+      "resource": "Export Resource",
+      "key": "dandelion-export",
+      "resourceId": 1014315,
+      "productId": 85
+    },
+    {
+      "product": "Dandelion",
+      "category": "Import Functions",
+      "resource": "Import Resource",
+      "key": "dandelion-import",
+      "resourceId": 1014380,
+      "productId": 85
+    },
+    {
+      "product": "Data Vault",
+      "category": "Internal",
+      "resource": "Tokenize",
+      "key": "Tokenize",
+      "resourceId": 2128438,
+      "productId": 133
+    },
+    {
+      "product": "Data Vault",
+      "category": "Internal",
+      "resource": "Detokenize",
+      "key": "Detokenize",
+      "resourceId": 2128439,
+      "productId": 133
+    },
+    {
+      "product": "Data Vault",
+      "category": "Internal",
+      "resource": "Fingerprint",
+      "key": "Fingerprint",
+      "resourceId": 2128440,
+      "productId": 133
+    },
+    {
+      "product": "Data Vault",
+      "category": "Internal",
+      "resource": "User Rights Delete",
+      "key": "DataVaultUserRightsDelete",
+      "resourceId": 2128441,
+      "productId": 133
+    },
+    {
+      "product": "Data Vault",
+      "category": "Internal",
+      "resource": "User Rights Retrieve",
+      "key": "DataVaultUserRightsRetrieve",
+      "resourceId": 2128442,
+      "productId": 133
+    },
+    {
+      "product": "Delivery Promises",
+      "category": "ProductAvailability",
+      "resource": "Notify Product Availability Change",
+      "key": "NotifyProductAvailabilityChange",
+      "resourceId": 2032871,
+      "productId": 111
+    },
+    {
+      "product": "Delivery Promises",
+      "category": "ProductAvailability",
+      "resource": "Delivery Promises ReprocessItem",
+      "key": "DeliveryPromisesReprocessItem",
+      "resourceId": 2118039,
+      "productId": 111
+    },
+    {
+      "product": "FastStore",
+      "category": "Secrets",
+      "resource": "View Secrets",
+      "key": "ViewSecrets",
+      "resourceId": 2100329,
+      "productId": 129
+    },
+    {
+      "product": "FastStore",
+      "category": "Secrets",
+      "resource": "Edit Secrets",
+      "key": "EditSecrets",
+      "resourceId": 2100330,
+      "productId": 129
+    },
+    {
+      "product": "Fraud Prevention",
+      "category": "Transaction Attempts",
+      "resource": "View transaction attempts",
+      "key": "ViewTransactionAttempts",
+      "resourceId": 2134012,
+      "productId": 127
+    },
+    {
+      "product": "Fraud Prevention",
+      "category": "Transaction Attempts",
+      "resource": "Edit transaction attempt action settings",
+      "key": "EditTransactionAttemptActionSettings",
+      "resourceId": 2134013,
+      "productId": 127
+    },
+    {
+      "product": "Fraud Prevention",
+      "category": "Transaction Attempts",
+      "resource": "Edit transaction attempt score settings",
+      "key": "EditTransactionAttemptScoreSettings",
+      "resourceId": 2134014,
+      "productId": 127
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get applications",
+      "key": "Get_Applications",
+      "resourceId": 1066,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Find user by email",
+      "key": "Get_User_By_Identifier",
+      "resourceId": 1070,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "View users with account access",
+      "key": "Get_Users_By_Account",
+      "resourceId": 1071,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "View all admin users",
+      "key": "Get_Users_By_IsAdmin",
+      "resourceId": 1072,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Button linking user to role",
+      "key": "Create_Role_User",
+      "resourceId": 1073,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get resource by key",
+      "key": "Get_Resource_By_Key",
+      "resourceId": 1082,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Link user to role",
+      "key": "Associate_Login_To_Role",
+      "resourceId": 1084,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Unlink user from role",
+      "key": "Disassociate_Login_To_Role",
+      "resourceId": 1085,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "View accounts a user has access to",
+      "key": "Get_Licensed_Accounts_From_ProductId",
+      "resourceId": 1093,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Delete access profile",
+      "key": "Role:Delete",
+      "resourceId": 1131,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get admin status",
+      "key": "Get_Admin_Status",
+      "resourceId": 1180,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get accounts",
+      "key": "Get_Accounts_Paged",
+      "resourceId": 1181,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Set/Unset production status from account",
+      "key": "Remove_Account_From_Production",
+      "resourceId": 113305,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "View API Keys",
+      "key": "View_ApiKeys",
+      "resourceId": 1991888,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Internal access control",
+      "resource": "Block Cascading User",
+      "key": "BlockUser",
+      "resourceId": 2004075,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "View Storefront User Permissions",
+      "key": "View_Storefront_User_Permissions",
+      "resourceId": 2082433,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Edit Storefront User Permissions",
+      "key": "Edit_Storefront_User_Permissions",
+      "resourceId": 2082434,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get paged products",
+      "key": "Get_Products_Paged",
+      "resourceId": 1187,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Save license",
+      "key": "Save_License",
+      "resourceId": 1198,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Link license to account",
+      "key": "Save_License_In_Account",
+      "resourceId": 1058,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Set account domain",
+      "key": "Set_Domain",
+      "resourceId": 1060,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Check if provisioned",
+      "key": "Check_in_Provisioning",
+      "resourceId": 1062,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get all accounts",
+      "key": "Get_All_Accounts",
+      "resourceId": 1065,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Find product url",
+      "key": "Get_Product_Endpoint",
+      "resourceId": 1068,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Save resource",
+      "key": "Save_Resource",
+      "resourceId": 1080,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Remove resource by key",
+      "key": "Remove_Resource_By_Key",
+      "resourceId": 1081,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Account list",
+      "key": "Account:List",
+      "resourceId": 1098,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Create account",
+      "key": "Account:Add",
+      "resourceId": 1099,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Edit account",
+      "key": "Account:Edit",
+      "resourceId": 1100,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Delete account",
+      "key": "Account:Delete",
+      "resourceId": 1101,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "Ui - Product list",
+      "key": "Product:List",
+      "resourceId": 1102,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Create product",
+      "key": "Product:Add",
+      "resourceId": 1103,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Edit product",
+      "key": "Product:Edit",
+      "resourceId": 1104,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Delete product",
+      "key": "Product:Delete",
+      "resourceId": 1105,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - List of licenses",
+      "key": "License:List",
+      "resourceId": 1106,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Create license",
+      "key": "License:Add",
+      "resourceId": 1107,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Edit license",
+      "key": "License:Edit",
+      "resourceId": 1108,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Delete license",
+      "key": "License:Delete",
+      "resourceId": 1109,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Link product to license",
+      "key": "License:AssociateProducts",
+      "resourceId": 1110,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Unlink product from license",
+      "key": "License:DisassociateProducts",
+      "resourceId": 1111,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Users list",
+      "key": "User:List",
+      "resourceId": 1116,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Create user",
+      "key": "User:Add",
+      "resourceId": 1117,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Edit user",
+      "key": "User:Edit",
+      "resourceId": 1118,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Delete User",
+      "key": "User:Delete",
+      "resourceId": 1119,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Create resource category",
+      "key": "ResourceCategory:Add",
+      "resourceId": 1125,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Role list",
+      "key": "Role:List",
+      "resourceId": 1128,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Create Role",
+      "key": "Role:Add",
+      "resourceId": 1129,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Edit role",
+      "key": "Role:Edit",
+      "resourceId": 1130,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Link user to role",
+      "key": "Role:AssociateUser",
+      "resourceId": 1133,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Unlink user from role",
+      "key": "Role:DisassociateUser",
+      "resourceId": 1134,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Link resource to role",
+      "key": "Role:AssociateResource",
+      "resourceId": 1135,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "UI - Unlink resource from role",
+      "key": "Role:DisassociateResource",
+      "resourceId": 1136,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Add resource",
+      "key": "Create_Resource",
+      "resourceId": 1176,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "Remove account",
+      "key": "Delete_Account",
+      "resourceId": 1182,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Add product",
+      "key": "Create_Product",
+      "resourceId": 1186,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "Remove license",
+      "key": "Delete_License",
+      "resourceId": 1199,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "Get account provision status",
+      "key": "Get_Products_In_Provisioning",
+      "resourceId": 1200,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Update application token",
+      "key": "Update_Token",
+      "resourceId": 1208,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get product",
+      "key": "Get_Product",
+      "resourceId": 1618,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Turn on/off account",
+      "key": "Inactivate_Account",
+      "resourceId": 113304,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get hosts by account",
+      "key": "Get_Hosts_By_Site",
+      "resourceId": 429883,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get stores by account",
+      "key": "Get_Sites_By_Account",
+      "resourceId": 445913,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "List resources",
+      "key": "Resource:List",
+      "resourceId": 458756,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "Create resource",
+      "key": "Resource:Add",
+      "resourceId": 458757,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "Update resource",
+      "key": "Resource:Edit",
+      "resourceId": 458758,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Web access control",
+      "resource": "Delete resource",
+      "key": "Resource:Delete",
+      "resourceId": 458759,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get Licenses Paged",
+      "key": "Get_Licenses_Paged",
+      "resourceId": 721135,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Get_Active_Accounts",
+      "resource": "Get_Active_Accounts",
+      "key": "Get_Active_Accounts",
+      "resourceId": 2036795,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Internal",
+      "resource": "Teams Management",
+      "key": "ManageTeams",
+      "resourceId": 2124263,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Internal",
+      "resource": "Services Management",
+      "key": "ManageServices",
+      "resourceId": 2124264,
+      "productId": 1
+    },
+    {
+      "product": "Log",
+      "category": "Log Admin",
+      "resource": "Get App",
+      "key": "GetApp",
+      "resourceId": 700271,
+      "productId": 14
+    },
+    {
+      "product": "Log",
+      "category": "Log Admin",
+      "resource": "Create Table ",
+      "key": "CreateTable ",
+      "resourceId": 700272,
+      "productId": 14
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Logistics shipping read only",
+      "key": "ShippingViewer",
+      "resourceId": 475814,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "LogisticsInternal",
+      "key": "LogisticsInternal",
+      "resourceId": 1994105,
+      "productId": 9
+    },
+    {
+      "product": "OMS",
+      "category": "Internal",
+      "resource": "OMS-InternalApi",
+      "key": "OMSInternalApi",
+      "resourceId": 2006417,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "Internal",
+      "resource": "FeedHookV3Maintenance",
+      "key": "FeedHookV3Maintenance",
+      "resourceId": 2064617,
+      "productId": 19
+    },
+    {
+      "product": "Organization Units",
+      "category": "units",
+      "resource": "Edit Organization Unit",
+      "key": "Edit_Organization_Unit",
+      "resourceId": 2071771,
+      "productId": 110
+    },
+    {
+      "product": "Organization Units",
+      "category": "units",
+      "resource": "Move Organization Unit",
+      "key": "Move_Organization_Unit",
+      "resourceId": 2071772,
+      "productId": 110
+    },
+    {
+      "product": "Organization Units",
+      "category": "units",
+      "resource": "View Organization Unit",
+      "key": "View_Organization_Unit",
+      "resourceId": 2071774,
+      "productId": 110
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ManageStore",
+      "resource": "Manage Store AntiFraud",
+      "key": "ManageStoreAntiFraud ",
+      "resourceId": 1684988,
+      "productId": ""
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "View Card Tokens",
+      "key": "ViewCardTokens",
+      "resourceId": 2078628,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Edit Card Tokens",
+      "key": "ManageCardTokens",
+      "resourceId": 2078744,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Create Card Tokens",
+      "key": "CreateCardTokens",
+      "resourceId": 2078845,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Delete Card Token",
+      "key": "DeleteCardToken",
+      "resourceId": 2078846,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Import Card Token",
+      "key": "ImportCardToken",
+      "resourceId": 2078847,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Get Import Card Token Status ",
+      "key": "GetImportCardTokenStatus",
+      "resourceId": 2078848,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Get Import Card Tokens Report",
+      "key": "GetImportCardTokensReport",
+      "resourceId": 2078849,
+      "productId": 114
+    },
+    {
+      "product": "Payments Forget Me",
+      "category": "Payments Services Management",
+      "resource": "Registers Payments Service",
+      "key": "payments_services_register",
+      "resourceId": 2029347,
+      "productId": 109
+    },
+    {
+      "product": "Payments Forget Me",
+      "category": "Payments Services Management",
+      "resource": "Updates Payments Service",
+      "key": "payments_services_update",
+      "resourceId": 2029348,
+      "productId": 109
+    },
+    {
+      "product": "Payments Forget Me",
+      "category": "Payments Services Management",
+      "resource": "Find All Payments Services",
+      "key": "payments_services_find_all",
+      "resourceId": 2029349,
+      "productId": 109
+    },
+    {
+      "product": "Payments Forget Me",
+      "category": "Payments Services Management",
+      "resource": "Find Payments Service",
+      "key": "payments_services_find",
+      "resourceId": 2029350,
+      "productId": 109
+    },
+    {
+      "product": "Payments Forget Me",
+      "category": "Payments Services Management",
+      "resource": "Deletes Payments Service",
+      "key": "payments_services_delete",
+      "resourceId": 2029351,
+      "productId": 109
+    },
+    {
+      "product": "PersonalShopper App",
+      "category": "Call",
+      "resource": "View List Call",
+      "key": "view-list-call",
+      "resourceId": 1639430,
+      "productId": 100
+    },
+    {
+      "product": "PersonalShopper App",
+      "category": "Analytics",
+      "resource": "View Analytics",
+      "key": "view-analytics",
+      "resourceId": 1639728,
+      "productId": 100
+    },
+    {
+      "product": "PersonalShopper App",
+      "category": "Setting",
+      "resource": "View Setting",
+      "key": "view-setting",
+      "resourceId": 1643056,
+      "productId": 100
+    },
+    {
+      "product": "Pricing",
+      "category": "Price List",
+      "resource": "View External Seller Prices",
+      "key": "read_External_Seller_Prices",
+      "resourceId": 2067783,
+      "productId": 65
+    },
+    {
+      "product": "Pricing",
+      "category": "Price List",
+      "resource": "Edit External Seller prices",
+      "key": "modify_External_Seller_Prices",
+      "resourceId": 2067814,
+      "productId": 65
+    },
+    {
+      "product": "Profile System",
+      "category": "Documents",
+      "resource": "Get Item",
+      "key": "GetItemResource",
+      "resourceId": 1479422,
+      "productId": 96
+    },
+    {
+      "product": "Profile System",
+      "category": "Documents",
+      "resource": "Save and Update Item",
+      "key": "PutItemResource",
+      "resourceId": 1479648,
+      "productId": 96
+    },
+    {
+      "product": "Profile System",
+      "category": "Documents",
+      "resource": "Delete Item",
+      "key": "DeleteItemResource",
+      "resourceId": 1479726,
+      "productId": 96
+    },
+    {
+      "product": "Profile System",
+      "category": "Documents",
+      "resource": "Validate Conditions",
+      "key": "ValidateConditionsResource",
+      "resourceId": 1926330,
+      "productId": 96
+    },
+    {
+      "product": "Profile System",
+      "category": "Documents",
+      "resource": "Get Item V2",
+      "key": "GetItemResourceV2",
+      "resourceId": 1979918,
+      "productId": 96
+    },
+    {
+      "product": "Profile System",
+      "category": "Internal",
+      "resource": "ProfileSystem User Rights",
+      "key": "ProfileSystemUserRights",
+      "resourceId": 2113461,
+      "productId": 96
+    },
+    {
+      "product": "Rates and Benefits",
+      "category": "Promotions",
+      "resource": "Manage External Seller Promotions",
+      "key": "External_Seller_Promotions",
+      "resourceId": 2067822,
+      "productId": 16
+    },
+    {
+      "product": "Rates and Benefits",
+      "category": "Promotions",
+      "resource": "Manage promotions activation",
+      "key": "manage_promotions_activation",
+      "resourceId": 2072569,
+      "productId": 16
+    },
+    {
+      "product": "Releases",
+      "category": "Releases",
+      "resource": "Add Updates",
+      "key": "edit-update",
+      "resourceId": 1257566,
+      "productId": 91
+    },
+    {
+      "product": "Releases",
+      "category": "Releases",
+      "resource": "See Releases menu on the side-bar",
+      "key": "sidebar_visualizar",
+      "resourceId": 2022233,
+      "productId": 91
+    },
+    {
+      "product": "Sales App",
+      "category": "Reports",
+      "resource": "View Sales Performance",
+      "key": "ViewSalesPerformance",
+      "resourceId": 2126563,
+      "productId": 132
+    },
+    {
+      "product": "Search",
+      "category": "Search API",
+      "resource": "Product Scroll",
+      "key": "product-scroll",
+      "resourceId": 2099302,
+      "productId": 76
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-read",
+      "resource": "List/Describe reports",
+      "key": "read-reports",
+      "resourceId": 1858423,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-write",
+      "resource": "Create Reports",
+      "key": "write-reports",
+      "resourceId": 1858424,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-write",
+      "resource": "Update Sensors",
+      "key": "update-sensors",
+      "resourceId": 1880649,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-read",
+      "resource": "List/Describe Sensors",
+      "key": "read-sensors",
+      "resourceId": 1880664,
+      "productId": 103
+    },
+    {
+      "product": "Suggestion",
+      "category": "Suggestion Resources",
+      "resource": "mapper",
+      "key": "mapper",
+      "resourceId": 1556055,
+      "productId": 50
+    },
+    {
+      "product": "Time Series",
+      "category": "Time Series",
+      "resource": "Bulk Entry",
+      "key": "BulkEntry_old",
+      "resourceId": 600174,
+      "productId": 75
+    },
+    {
+      "product": "Time Series",
+      "category": "Time Series",
+      "resource": "Get Application Configuration",
+      "key": "GetApplicationConfiguration",
+      "resourceId": 610118,
+      "productId": 75
+    },
+    {
+      "product": "Time Series",
+      "category": "Time Series",
+      "resource": "Delete Application Configuration Cache",
+      "key": "DeleteApplicationConfigurationCache",
+      "resourceId": 610119,
+      "productId": 75
+    },
+    {
+      "product": "Unikey",
+      "category": "Unikey Resources",
+      "resource": "Increment sequence",
+      "key": "Increase_Sequence",
+      "resourceId": 1211,
+      "productId": 18
+    },
+    {
+      "product": "Unikey",
+      "category": "Unikey Resources",
+      "resource": "Create bucket",
+      "key": "Create_Bucket",
+      "resourceId": 1212,
+      "productId": 18
+    },
+    {
+      "product": "Unikey",
+      "category": "Unikey Resources",
+      "resource": "Get new key",
+      "key": "Generate_Key",
+      "resourceId": 1213,
+      "productId": 18
+    },
+    {
+      "product": "Unikey",
+      "category": "Unikey Resources",
+      "resource": "Get bucket configuration",
+      "key": "Get_Bucket_Configuration",
+      "resourceId": 1356,
+      "productId": 18
+    },
+    {
+      "product": "Unikey",
+      "category": "Unikey Resources",
+      "resource": "Change bucket configuration",
+      "key": "Change_Bucket_Configuration",
+      "resourceId": 1707,
+      "productId": 18
+    },
+    {
+      "product": "Unikey",
+      "category": "internal",
+      "resource": "Unikey-Internal",
+      "key": "UnikeyInternal",
+      "resourceId": 1997753,
+      "productId": 18
+    },
+    {
+      "product": "Units",
+      "category": "units",
+      "resource": "Edit Unit",
+      "key": "Edit_Unit",
+      "resourceId": 2029283,
+      "productId": 110
+    },
+    {
+      "product": "Units",
+      "category": "units",
+      "resource": "Move Unit",
+      "key": "Move_Unit",
+      "resourceId": 2029291,
+      "productId": 110
+    },
+    {
+      "product": "Units",
+      "category": "units",
+      "resource": "View Unit",
+      "key": "View_Unit",
+      "resourceId": 2029293,
+      "productId": 110
+    },
+    {
+      "product": "User Rights",
+      "category": "applications",
+      "resource": "Read Applications",
+      "key": "applications_read",
+      "resourceId": 1634515,
+      "productId": ""
+    },
+    {
+      "product": "User Rights",
+      "category": "applications",
+      "resource": "Write Applications",
+      "key": "applications_write",
+      "resourceId": 1634523,
+      "productId": ""
+    },
+    {
+      "product": "User Rights",
+      "category": "user-rights-request",
+      "resource": "Read user rights requests",
+      "key": "user_rights_request_read",
+      "resourceId": 1634546,
+      "productId": 99
+    },
+    {
+      "product": "User Rights",
+      "category": "user-rights-request",
+      "resource": "Write user rights requests",
+      "key": "user_rights_request_write",
+      "resourceId": 1634554,
+      "productId": 99
+    },
+    {
+      "product": "User Rights",
+      "category": "user-rights-request",
+      "resource": "Process User Rights Removal Request",
+      "key": "removal-request-process",
+      "resourceId": 1705138,
+      "productId": 99
+    },
+    {
+      "product": "User Rights",
+      "category": "user-rights-request",
+      "resource": "Process User Rights Removal Request",
+      "key": "removal-request-process",
+      "resourceId": 1705138,
+      "productId": 99
+    },
+    {
+      "product": "VTEX CX Platform",
+      "category": "CX Platform Access",
+      "resource": "Access CX Platform",
+      "key": "AccessCxPlatform",
+      "resourceId": 2156284,
+      "productId": 135
+    },
+    {
+      "product": "VTEX Fulfilment",
+      "category": "Fulfilment Resources",
+      "resource": "Place Orders",
+      "key": "CriaPedidos",
+      "resourceId": 1360,
+      "productId": 15
+    },
+    {
+      "product": "VTEX Fulfilment",
+      "category": "Fulfilment Resources",
+      "resource": "Order Details",
+      "key": "ObtemInfosDeCompra",
+      "resourceId": 1361,
+      "productId": 15
+    },
+    {
+      "product": "VTEX Home",
+      "category": "Dashboards",
+      "resource": "Client",
+      "key": "dashboards_cliente",
+      "resourceId": 106513,
+      "productId": ""
+    },
+    {
+      "product": "VTEX Home",
+      "category": "Dashboards",
+      "resource": "Admin",
+      "key": "dashboards_admin",
+      "resourceId": 106530,
+      "productId": ""
+    },
+    {
+      "product": "VTEX Home",
+      "category": "Dashboards",
+      "resource": "Analyst",
+      "key": "dashboards_analista",
+      "resourceId": 106531,
+      "productId": ""
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "File Manager Bucket Config",
+      "key": "file-manager-bucket-config",
+      "resourceId": 2156623,
+      "productId": 66
+    },
+    {
+      "product": "VTEX Payment",
+      "category": "Payments Administration",
+      "resource": "Card Management",
+      "key": "card-management",
+      "resourceId": 604283,
+      "productId": 72
+    },
+    {
+      "product": "VTEX Payment",
+      "category": "Payments Administration",
+      "resource": "Banking View",
+      "key": "banking-view",
+      "resourceId": 604284,
+      "productId": 72
+    },
+    {
+      "product": "VTEX Payment",
+      "category": "Payments Administration",
+      "resource": "Monetary Activity",
+      "key": "monetary-activity",
+      "resourceId": 604285,
+      "productId": 72
+    },
+    {
+      "product": "VTEX Payment",
+      "category": "Payments Administration",
+      "resource": "Configuring",
+      "key": "payment-configuring",
+      "resourceId": 604286,
+      "productId": 72
+    },
+    {
+      "product": "VTEX Payment",
+      "category": "Payments Administration",
+      "resource": "Dispute Management",
+      "key": "disputes-management",
+      "resourceId": 604287,
+      "productId": 72
+    },
+    {
+      "product": "Vtex ID",
+      "category": "Admin",
+      "resource": "Manage VTEX ID",
+      "key": "view_admin",
+      "resourceId": 143458,
+      "productId": 64
+    },
+    {
+      "product": "Vtex ID",
+      "category": "Account Configuration",
+      "resource": "Read Account Config",
+      "key": "read_account_config",
+      "resourceId": 1497371,
+      "productId": 64
+    },
+    {
+      "product": "Vtex ID",
+      "category": "Account Configuration",
+      "resource": "Write Account Config",
+      "key": "write_account_config",
+      "resourceId": 1497386,
+      "productId": 64
+    },
+    {
+      "product": "Vtex ID",
+      "category": "User Management",
+      "resource": "DeleteLoginPreference",
+      "key": "DeleteLoginPreference",
+      "resourceId": 2009425,
+      "productId": 64
+    },
+    {
+      "product": "Vtex ID",
+      "category": "User Management",
+      "resource": "Revoke user login sessions",
+      "key": "RevokeLoginSessions",
+      "resourceId": 2051366,
+      "productId": 64
+    },
+    {
+      "product": "Vtex ID",
+      "category": "User Management",
+      "resource": "Generate Access Code",
+      "key": "Generate_Access_Code",
+      "resourceId": 2121783,
+      "productId": 64
+    },
+    {
+      "product": "Vtex ID",
+      "category": "User Management",
+      "resource": "Read Users",
+      "key": "ReadUsers",
+      "resourceId": 2141288,
+      "productId": 64
+    }
+  ]
+}

--- a/data-tables/license-manager-resources.json
+++ b/data-tables/license-manager-resources.json
@@ -1,0 +1,9512 @@
+{
+  "en": [
+    {
+      "product": "Application Logs Stream",
+      "category": "Logs",
+      "resource": "Read logs stream",
+      "description": "Read VTEX IO application logs belonging to this account.",
+      "key": "read_logs",
+      "resourceId": 728560,
+      "productId": 81
+    },
+    {
+      "product": "Audit",
+      "category": "General",
+      "resource": "Save Event",
+      "description": "Save audit events.",
+      "key": "SaveEvent",
+      "resourceId": 1353337,
+      "productId": 55
+    },
+    {
+      "product": "B2B",
+      "category": "B2B General",
+      "resource": "B2BBulkExport",
+      "description": "It allows B2B stores to export their data in bulk to files.",
+      "key": "B2BBulkExport",
+      "resourceId": 2045795,
+      "productId": 105
+    },
+    {
+      "product": "B2B",
+      "category": "Import",
+      "resource": "B2BBulkImport",
+      "description": "Allows B2B stores to bulk import multiple buyer organizations into VTEX B2B solution.",
+      "key": "B2BBulkImport",
+      "resourceId": 1954299,
+      "productId": 105
+    },
+    {
+      "product": "B2B",
+      "category": "Import",
+      "resource": "BulkImportTest",
+      "description": "Allows B2B stores to bulk import multiple buyer organizations into VTEX B2B solution.",
+      "key": "BulkImportTest",
+      "resourceId": 1957237,
+      "productId": 105
+    },
+    {
+      "product": "Billing",
+      "category": "Company",
+      "resource": "Edit Company Information",
+      "description": "Edit a customer's registration information, including: company name, trade name, branch, sales region, tier, billing status, and address.",
+      "key": "edit_company",
+      "resourceId": 118281,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Company",
+      "resource": "Display Company info",
+      "description": "View a customer's registration information, which includes: company name, trade name, branch, sales region, tier, billing status, and address.",
+      "key": "get_company",
+      "resourceId": 118283,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Company",
+      "resource": "Edit Company's Document",
+      "description": "Edit company documents and information.",
+      "key": "edit_companys_document",
+      "resourceId": 131970,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Company",
+      "resource": "Merge companies",
+      "description": "To perform a merger of two accounts, so that all invoice and contract information from one account is transferred to the other account.",
+      "key": "company_merge",
+      "resourceId": 277452,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Company",
+      "resource": "Split companies",
+      "description": "Separate two accounts, with invoice and contract information recorded in one, and the other remaining blank.",
+      "key": "company_split",
+      "resourceId": 277453,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Contacts",
+      "resource": "Contacts List ",
+      "description": "View which contacts receive email notifications when a specific customer's invoice is generated.",
+      "key": "list_contacts",
+      "resourceId": 118284,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Contacts",
+      "resource": "Edit Contacts",
+      "description": "Add or edit a contact.",
+      "key": "edit_contact",
+      "resourceId": 118285,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Contracts",
+      "resource": "Contracts List ",
+      "description": "View contracts and billing terms registered in the Invoices module of the VTEX platform.",
+      "key": "list_contracts",
+      "resourceId": 118282,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Contracts",
+      "resource": "Save contracts",
+      "description": "Edit contracts in the VTEX platform's Invoices module, including registering invoices of any value and charging take rates at any percentage.",
+      "key": "put_contract",
+      "resourceId": 134738,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Invoices List ",
+      "description": "Viewing the customer's invoice list, as well as the invoice details, which includes information such as GMV and take rate.",
+      "key": "list_invoices",
+      "resourceId": 105015,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Generate new Invoice",
+      "description": "Create an invoice for a client, but only when a contract has already been created and has a defined value. The feature does not allow the user to set the invoice amount.",
+      "key": "put_invoices",
+      "resourceId": 120233,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Cancel Invoice Document",
+      "description": "Cancel the tax document generated by the issuer.",
+      "key": "cancel_nfe",
+      "resourceId": 134739,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Issue Invoice Document",
+      "description": "Generate the tax document, but only on the issuer's platform.",
+      "key": "issue_nfe",
+      "resourceId": 134740,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Invoice reconciliation",
+      "description": "Inform the system of the date and amount paid for an invoice.",
+      "key": "conciliate_invoice",
+      "resourceId": 134741,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Generate Invoice for overdue payment without added interest fees",
+      "description": "Change the due date of an invoice without incurring standard late fees and interest.",
+      "key": "generate_invoice_overdue_without_interest",
+      "resourceId": 134743,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Cancel Invoice",
+      "description": "Canceling an invoice in the Invoices module of the VTEX platform and in the issuer.",
+      "key": "cancel_invoice",
+      "resourceId": 134744,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Change payment status",
+      "description": "Change the company's payment status to: Alert, Blocked, Timer, or Ok.",
+      "key": "set_paymentstatus",
+      "resourceId": 138192,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Unpaid invoices",
+      "description": "Resetting an invoice to the \"opened\" status will cancel the payment date and the amount paid.",
+      "key": "unpaid_invoices",
+      "resourceId": 525925,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Simulate Invoices Creation",
+      "description": "Simulating invoices without actually creating them.",
+      "key": "simulate_invoices",
+      "resourceId": 1362361,
+      "productId": 43
+    },
+    {
+      "product": "Buyer Organizations",
+      "category": "Management",
+      "resource": "Buyer Organization View",
+      "description": "View the list of purchasing organizations.",
+      "key": "buyer_organization_view",
+      "resourceId": 1522234,
+      "productId": 97
+    },
+    {
+      "product": "Buyer Organizations",
+      "category": "Management",
+      "resource": "Buyer Organization Edit",
+      "description": "Create or edit purchasing organizations.",
+      "key": "buyer_organization_edit",
+      "resourceId": 1522235,
+      "productId": 97
+    },
+    {
+      "product": "CDN API",
+      "category": "Certificate management",
+      "resource": "View certificate",
+      "description": "View the details of the CDN certificates.",
+      "key": "ViewCertificate",
+      "resourceId": 2022646,
+      "productId": 108
+    },
+    {
+      "product": "CDN API",
+      "category": "Certificate management",
+      "resource": "Update certificate",
+      "description": "Replace the existing CDN certificates.",
+      "key": "UpdateCertificate",
+      "resourceId": 2022647,
+      "productId": 108
+    },
+    {
+      "product": "CDN API",
+      "category": "WAF Control",
+      "resource": "View WafControl Metrics",
+      "description": "View WAF metrics.",
+      "key": "ViewWafControlMetrics",
+      "resourceId": 2142573,
+      "productId": 108
+    },
+    {
+      "product": "CDN Service",
+      "category": "Domain Management",
+      "resource": "Query status of domains",
+      "description": "Allows the user to check the status of the store's domains in production.",
+      "key": "query-domain",
+      "resourceId": 1271517,
+      "productId": 84
+    },
+    {
+      "product": "CMS",
+      "category": "cms",
+      "resource": "See CMS menu on the top-bar",
+      "description": "View the CMS menu in the top bar.",
+      "key": "topbar_visualizar",
+      "resourceId": 111439,
+      "productId": 38
+    },
+    {
+      "product": "CMS",
+      "category": "cms",
+      "resource": "Settings",
+      "description": "Edit CMS settings.",
+      "key": "cms_settings",
+      "resourceId": 1434680,
+      "productId": 38
+    },
+    {
+      "product": "CMS",
+      "category": "GraphQL",
+      "resource": "CMS GraphQL API",
+      "description": "Use the VTEX IO CMS GraphQL API.",
+      "key": "access-cms-graphql-api",
+      "resourceId": 1032772,
+      "productId": 38
+    },
+    {
+      "product": "CMS",
+      "category": "GraphQL",
+      "resource": "Read CMS GraphQL API",
+      "description": "Grants read-only access to the GraphQL API of the VTEX IO CMS.",
+      "key": "read-cms-graphql-api",
+      "resourceId": 2143073,
+      "productId": 38
+    },
+    {
+      "product": "Catalog",
+      "category": "Admin",
+      "resource": "Admin list",
+      "description": "List the system administrators.",
+      "key": "Administrador.aspx",
+      "resourceId": 882,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Admin",
+      "resource": "Homepage",
+      "description": "Homepage",
+      "key": "Home.aspx",
+      "resourceId": 1047,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Admin",
+      "resource": "Help page",
+      "description": "Help homepage",
+      "key": "Help.aspx",
+      "resourceId": 1048,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Collection",
+      "resource": "Read Collections",
+      "description": "Allows you to view collections.",
+      "key": "collections-read",
+      "resourceId": 627875,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Collection",
+      "resource": "Write Collections",
+      "description": "Allows you to create a new product collection.",
+      "key": "collections-write",
+      "resourceId": 627876,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "Expert Reviews Management",
+      "description": "Expert opinion registration form",
+      "key": "EspecialistaOpiniaoForm.aspx",
+      "resourceId": 928,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "Similar product category",
+      "description": "Add a category similar to the product.",
+      "key": "ProdutoCategoriaSimilar.aspx",
+      "resourceId": 981,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "Similar category product management",
+      "description": "Product registration for a similar category",
+      "key": "ProdutoCategoriaSimilarForm.aspx",
+      "resourceId": 982,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "SKU management",
+      "description": "SKU registration form",
+      "key": "SkuForm.aspx",
+      "resourceId": 1001,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "SKU Services",
+      "description": "SKU Services",
+      "key": "SkuServicoForm.aspx",
+      "resourceId": 1004,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "Prices for SKU Services",
+      "description": "List of SKU service prices",
+      "key": "SkuServicoValor.aspx",
+      "resourceId": 1005,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "SKU service price management",
+      "description": "Form for registering a value for a SKU service.",
+      "key": "SkuServicoValorForm.aspx",
+      "resourceId": 1006,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "Commercial condition",
+      "description": "Definition of trade policies",
+      "key": "SkuCondicaoComercial.aspx",
+      "resourceId": 1019,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "SKU type management",
+      "description": "Form for registering SKU service types.",
+      "key": "SkuServicoTipo.aspx",
+      "resourceId": 1045,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "Configuration Management",
+      "description": "Configuration registration form",
+      "key": "ConfigForm.aspx",
+      "resourceId": 917,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "File types list",
+      "description": "List of file types",
+      "key": "TipoArquivo.aspx",
+      "resourceId": 1009,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "File types management",
+      "description": "Form for registering standard image sizes and other file types.",
+      "key": "TipoArquivoForm.aspx",
+      "resourceId": 1010,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "Store Texts",
+      "description": "Developer tool with all the base texts for the store.",
+      "key": "TextoSite.aspx",
+      "resourceId": 1034,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "CMS Management",
+      "description": "CMS (Portal) Settings",
+      "key": "PortalManagement",
+      "resourceId": 1202,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "SEO Configurations",
+      "description": "SEO Content Settings (Robots.txt)",
+      "key": "ConfigSEOContents.aspx",
+      "resourceId": 1222,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "Gift Registry Types List",
+      "description": "List of List Types",
+      "key": "GiftListType.aspx",
+      "resourceId": 1631,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "Gift Registry Lists Management",
+      "description": "Form for creating and editing list types (GiftList)",
+      "key": "GiftListTypeForm.aspx",
+      "resourceId": 1633,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "Geographic Region Management",
+      "description": "Manage the geographic region listing page.",
+      "key": "GeographicRegion.aspx",
+      "resourceId": 2138652,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "Geographic Region Form",
+      "description": "Manage the form for creating and editing geographic regions.",
+      "key": "GeographicRegionForm.aspx",
+      "resourceId": 2138653,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "StoreForm.aspx",
+      "description": "View the commercial policy details screen.",
+      "key": "StoreForm.aspx",
+      "resourceId": 2142219,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "InsertOrUpdateStoreForm.aspx",
+      "description": "Create and modify business policies (subject to recurring charges).",
+      "key": "InsertOrUpdateStoreForm.aspx",
+      "resourceId": 2142347,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Product management",
+      "description": "View the product registration and modification screen",
+      "key": "ProdutoForm.aspx",
+      "resourceId": 873,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Product Form",
+      "description": "Access to the product screen",
+      "key": "Produto.aspx",
+      "resourceId": 874,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Change SKU Pricing",
+      "description": "Change SKU prices",
+      "key": "AlterarPrecoSku",
+      "resourceId": 877,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "SKU images management",
+      "description": "Insert and modify SKU images",
+      "key": "ManterImagemProdutoSku",
+      "resourceId": 880,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Product and SKU Management",
+      "description": "Product and SKU modification and addition",
+      "key": "ManterFormularioProdutoSku",
+      "resourceId": 881,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Reviews list",
+      "description": "List all reviews",
+      "key": "Avaliacao.aspx",
+      "resourceId": 885,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Reviews management",
+      "description": "Evaluation registration form",
+      "key": "AvaliacaoForm.aspx",
+      "resourceId": 886,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Fields list",
+      "description": "Lists all fields in the system.",
+      "key": "Campo.aspx",
+      "resourceId": 891,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Attributes Management",
+      "description": "Form for registering fields.",
+      "key": "CampoForm.aspx",
+      "resourceId": 896,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Value fields list",
+      "description": "List of values ​​for a field",
+      "key": "CampoValor.aspx",
+      "resourceId": 897,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Attribute values management",
+      "description": "Field registration form",
+      "key": "CampoValorForm.aspx",
+      "resourceId": 898,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Category ",
+      "description": "List all categories",
+      "key": "Categoria.aspx",
+      "resourceId": 899,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Categories Management",
+      "description": "Category registration form",
+      "key": "CategoriaForm.aspx",
+      "resourceId": 900,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Similar Category ",
+      "description": "List all similar categories",
+      "key": "CategoriaSimilar.aspx",
+      "resourceId": 901,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Similar Categories Management",
+      "description": "Similar categories form",
+      "key": "CategoriaSimilarForm.aspx",
+      "resourceId": 902,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Price range",
+      "description": "List all price ranges",
+      "key": "FaixaPreco.aspx",
+      "resourceId": 933,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Price Range Management",
+      "description": "Price registration form",
+      "key": "FaixaPrecoForm.aspx",
+      "resourceId": 934,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Providers",
+      "description": "Lists the suppliers registered in the system.",
+      "key": "Fornecedor.aspx",
+      "resourceId": 938,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Supplier management",
+      "description": "Supplier registration form",
+      "key": "FornecedorForm.aspx",
+      "resourceId": 939,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Groups",
+      "description": "List all category groups",
+      "key": "Grupo.aspx",
+      "resourceId": 944,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Group Management ",
+      "description": "Category group registration form",
+      "key": "GrupoForm.aspx",
+      "resourceId": 945,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Brands",
+      "description": "List of all registered brands",
+      "key": "Marca.aspx",
+      "resourceId": 955,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Brands Management",
+      "description": "Brand registration form",
+      "key": "MarcaForm.aspx",
+      "resourceId": 956,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "SKUs",
+      "description": "List all registered SKUs.",
+      "key": "Sku.aspx",
+      "resourceId": 996,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Enable Product and SKU",
+      "description": "Product and SKU activation",
+      "key": "Ativar Produto Sku",
+      "resourceId": 1013,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Category Management",
+      "description": "Access verification for adding or changing a new category.",
+      "key": "InsertOrUpdateCategoriaFromCategoriaForm.aspx",
+      "resourceId": 1216,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Similar Category Management",
+      "description": "Access verification for adding or changing a new similar category.",
+      "key": "InsertOrUpdateCategoriaFromCategoriaSimilarForm.aspx",
+      "resourceId": 1217,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Brand Management",
+      "description": "Validation for adding or changing a brand.",
+      "key": "InsertOrUpdateMarcaFromMarcaForm.aspx",
+      "resourceId": 1218,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Insert or Update Group",
+      "description": "Insert or modify within the category group.",
+      "key": "InsertOrUpdateGrupoFromGrupoForm.aspx",
+      "resourceId": 1219,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Field validation",
+      "description": "Field validation",
+      "key": "InsertOrUpdateCampoFromCampoForm.aspx",
+      "resourceId": 1220,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Value field validation",
+      "description": "Field value validation",
+      "key": "InsertOrUpdateCampoValorFromCampoValorForm.aspx",
+      "resourceId": 1221,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketing",
+      "resource": "Buy Together Management",
+      "description": "Registration form for \"Buy Together\"",
+      "key": "CompreJuntoForm.aspx",
+      "resourceId": 915,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketing",
+      "resource": "Reviews",
+      "description": "SKU review database",
+      "key": "Resenha.aspx",
+      "resourceId": 988,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketing",
+      "resource": "Gift/Refund Vouchers",
+      "description": "Create a Purchase Voucher",
+      "key": "Vale.aspx",
+      "resourceId": 1016,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketing",
+      "resource": "Product Collections XML",
+      "description": "XML Collections",
+      "key": "Xml.aspx",
+      "resourceId": 1026,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketing",
+      "resource": "Tags management",
+      "description": "Keyword Control - Tags",
+      "key": "Tag.aspx",
+      "resourceId": 1027,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketplace",
+      "resource": "Sales channels management",
+      "description": "List of trade policies",
+      "key": "Store.aspx",
+      "resourceId": 1226,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketplace",
+      "resource": "Sellers",
+      "description": "List of Sellers (Stores)",
+      "key": "Seller.aspx",
+      "resourceId": 1227,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketplace",
+      "resource": "Seller SKUs",
+      "description": "SKU List Sellers",
+      "key": "SkuSeller.aspx",
+      "resourceId": 1229,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Miscellaneous",
+      "resource": "SKU Bundles",
+      "description": "Interface between Kits and SKUs",
+      "key": "SkuKit.aspx",
+      "resourceId": 1002,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Miscellaneous",
+      "resource": "Product Bundle Management",
+      "description": "Kit registration form",
+      "key": "SkuKitForm.aspx",
+      "resourceId": 1003,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "News Report",
+      "description": "Newsletter Report",
+      "key": "RelatorioNews.aspx",
+      "resourceId": 1020,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "SKUs Report",
+      "description": "SKUs Report",
+      "key": "Relatorio_Skus.aspx",
+      "resourceId": 1022,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "Out of stock notification",
+      "description": "Notify Me Request Report",
+      "key": "Relatorio_AviseMeSku.aspx",
+      "resourceId": 1025,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "Full-text Search",
+      "description": "Full-text search report",
+      "key": "RelatorioFullText.aspx",
+      "resourceId": 1028,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "Security Monitoring",
+      "description": "Security Monitoring",
+      "key": "Relatorio_Seguranca.aspx",
+      "resourceId": 1031,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "Gift Registry List",
+      "description": "See all lists (GiftList)",
+      "key": "GiftList.aspx",
+      "resourceId": 1632,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "Assisted Sales Gift Registry List Management",
+      "description": "It allows the administrator to manage a user's lists on the Site, as if they were the user themselves.",
+      "key": "GiftListImpersonation",
+      "resourceId": 1634,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Telesales",
+      "resource": "Assisted Sales",
+      "description": "Telesales features. After the login, the user is redirected to the telesales site www.{storename} .com.br/a/telesales. This way, the operator can use telesales features such as navigating the store in the name of the customer. As this resource causes an automatic redirect to the store, the user who logs in an account with this resource in their role will not have access to important resources from Admin. Therefore, we recommend using two separate accounts (with distinct emails) for telesales users: a Call Center Operator role account (with this resource and the View Order resource) and another account to perform operations on the administrative menu if necessary.",
+      "key": "Televendas",
+      "resourceId": 1046,
+      "productId": 2
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "View Product",
+      "description": "View product and SKU details.",
+      "key": "ViewProduct",
+      "resourceId": 2017533,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "Edit Product",
+      "description": "Edit product details and SKUs.",
+      "key": "EditProduct",
+      "resourceId": 2038155,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "View Category",
+      "description": "View category details.",
+      "key": "ViewCategory",
+      "resourceId": 2038156,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "Edit Category",
+      "description": "Edit category details.",
+      "key": "EditCategory",
+      "resourceId": 2038157,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "View Collection",
+      "description": "View collection details.",
+      "key": "ViewCollection",
+      "resourceId": 2038158,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "Edit Collection",
+      "description": "Edit collection details.",
+      "key": "EditCollection",
+      "resourceId": 2038159,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "View Brand",
+      "description": "View brand details.",
+      "key": "ViewBrand",
+      "resourceId": 2038160,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "Edit Brand",
+      "description": "Edit brand details.",
+      "key": "EditBrand",
+      "resourceId": 2038161,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "Import Spreadsheet",
+      "description": "Import products and SKUs via spreadsheet.",
+      "key": "ImportSpreadsheet",
+      "resourceId": 2038162,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "Export Spreadsheet",
+      "description": "Export catalog information spreadsheet.",
+      "key": "ExportSpreadsheet",
+      "resourceId": 2038163,
+      "productId": 107
+    },
+    {
+      "product": "Channels",
+      "category": "UI resources",
+      "resource": "Send Marketplace Suggestions",
+      "description": "It allows sellers to submit listings to the marketplace, which will be reviewed and approved by the marketplace through the Received SKUs page or the Match Received SKUs API.",
+      "key": "EnviaSugestao",
+      "resourceId": 1139,
+      "productId": 13
+    },
+    {
+      "product": "Channels",
+      "category": "UI resources",
+      "resource": "Sellers SKUs List",
+      "description": "Allows sellers to view the list of SKUs sent to the marketplaces where they sell their products. In the VTEX Admin, the list can be accessed under MARKETPLACE > Integrations > Products.",
+      "key": "Consulta",
+      "resourceId": 1154,
+      "productId": 13
+    },
+    {
+      "product": "Channels",
+      "category": "UI resources",
+      "resource": "Save Suggestion Rules",
+      "description": "Allows marketplaces to create and modify VTEX Matcher rules for the approval of received SKUs. This configuration is done through the SKU Approval Settings API.",
+      "key": "SalvaRegras",
+      "resourceId": 1155,
+      "productId": 13
+    },
+    {
+      "product": "Channels",
+      "category": "UI resources",
+      "resource": "Marketplace seller setup",
+      "description": "Allows you to associate a seller with a new marketplace or change an existing setting. Sellers included in the Seller Portal can only have their settings changed, but cannot be associated with more than one marketplace. VTEX sellers, however, can be associated with other marketplaces and have their settings changed by enabling this feature. This action can be done via VTEX Admin or via the REST API.",
+      "key": "ConfiguraSeller",
+      "resourceId": 1156,
+      "productId": 13
+    },
+    {
+      "product": "Channels",
+      "category": "UI resources",
+      "resource": "Access the Marketplace Network",
+      "description": "Create, edit, and list your store's profile on the Marketplace Network and send messages to other stores.",
+      "key": "MarketplaceNetwork",
+      "resourceId": 1107285,
+      "productId": 13
+    },
+    {
+      "product": "Checkout",
+      "category": "CheckoutResources",
+      "resource": "Shopping Cart Full Access",
+      "description": "Read and write access for all shopping carts. Allows cart data to be displayed in its entirety (not masked). Also allows private cart simulation requests.",
+      "key": "AcessaTodosCarrinhos",
+      "resourceId": 1091,
+      "productId": 5
+    },
+    {
+      "product": "Checkout",
+      "category": "CheckoutResources",
+      "resource": "Orders Full Access",
+      "description": "Read and write access to all orders via the Checkout API. Access to orders through the order management module flow is not permitted.",
+      "key": "AcessaTodosPedidos",
+      "resourceId": 1092,
+      "productId": 5
+    },
+    {
+      "product": "Checkout",
+      "category": "CheckoutResources",
+      "resource": "Save Order Configuration",
+      "description": "Save order settings.",
+      "key": "SaveOrderConfiguration",
+      "resourceId": 600072,
+      "productId": 5
+    },
+    {
+      "product": "Checkout",
+      "category": "CheckoutResources",
+      "resource": "Save OrderForm Configuration",
+      "description": "Save shopping cart settings.",
+      "key": "SaveOrderFormConfiguration",
+      "resourceId": 600073,
+      "productId": 5
+    },
+    {
+      "product": "Checkout",
+      "category": "CheckoutResources",
+      "resource": "Read Shopping Cart",
+      "description": "Reads and lists all shopping carts. Does not allow access to unmasked cart data.",
+      "key": "GetOrderForm",
+      "resourceId": 1949421,
+      "productId": 5
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Branch",
+      "resource": "Save to main branch",
+      "description": "Adds changes directly to the main branch.",
+      "key": "SaveToMainBranch",
+      "resourceId": 2086248,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Branch",
+      "resource": "Remove from main branch",
+      "description": "Remove changes from the main branch.",
+      "key": "RemoveFromMainBranch",
+      "resourceId": 2086250,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Branch",
+      "resource": "Merge branch",
+      "description": "Merges changes from one branch to the main branch.",
+      "key": "MergeBranch",
+      "resourceId": 2086251,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Branch",
+      "resource": "Delete Branch",
+      "description": "Allows you to delete a branch and all versioned content associated with it.",
+      "key": "DeleteBranch",
+      "resourceId": 2153203,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Branch",
+      "resource": "Create Branch",
+      "description": "It allows you to create a new branch to develop, test, and save new versions of content in isolation.",
+      "key": "CreateBranch",
+      "resourceId": 2153204,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Entry",
+      "resource": "Delete entry",
+      "description": "Permanently deletes an entry from all history and branches.",
+      "key": "DeleteEntry",
+      "resourceId": 2086249,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Stores",
+      "resource": "Create Store",
+      "description": "Create a new Commerce Content store in the account.",
+      "key": "CreateStore",
+      "resourceId": 2086252,
+      "productId": 115
+    },
+    {
+      "product": "Credit Control",
+      "category": "Checking Accounts",
+      "resource": "Read Checking Accounts",
+      "description": "Viewing account information.",
+      "key": "read_checkingaccounts",
+      "resourceId": 170921,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Checking Accounts",
+      "resource": "Create Checking Accounts",
+      "description": "Account creation.",
+      "key": "create_checkingaccounts",
+      "resourceId": 170929,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Checking Accounts",
+      "resource": "Edit credits",
+      "description": "Change the credit limit of an account.",
+      "key": "edit_credits",
+      "resourceId": 197575,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Invoices",
+      "resource": "Read Invoices",
+      "description": "Viewing invoices.",
+      "key": "read_invoices",
+      "resourceId": 170930,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Invoices",
+      "resource": "Create Invoices",
+      "description": "Issuing invoices.",
+      "key": "create_invoices",
+      "resourceId": 170931,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Invoices",
+      "resource": "Pay Invoice",
+      "description": "Bill payment.",
+      "key": "pay_invoice",
+      "resourceId": 200613,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Main",
+      "resource": "Main Access",
+      "description": "Allows main access",
+      "key": "suggestions",
+      "resourceId": 109448,
+      "productId": 50
+    },
+    {
+      "product": "Credit Control",
+      "category": "Statements",
+      "resource": "Read Statements",
+      "description": "Reading account statements.",
+      "key": "read_statements",
+      "resourceId": 170918,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Statements",
+      "resource": "Create Statements",
+      "description": "Creating account statements.",
+      "key": "create_statements",
+      "resourceId": 170920,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Store Configuration",
+      "resource": "Edit Configuration",
+      "description": "Change the store settings.",
+      "key": "edit_config",
+      "resourceId": 198649,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Store Configuration",
+      "resource": "Read Configuration",
+      "description": "Viewing store settings.",
+      "key": "read_config",
+      "resourceId": 198650,
+      "productId": 58
+    },
+    {
+      "product": "Delivery Promises",
+      "category": "ProductAvailability",
+      "resource": "Notify Product Availability Change",
+      "description": "Update the availability of items from external sellers within the context of Delivery Promise.",
+      "key": "NotifyProductAvailabilityChange",
+      "resourceId": 2032871,
+      "productId": 111
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Data entity",
+      "resource": "List data entity",
+      "description": "List data entities.",
+      "key": "2_dataentity_list",
+      "resourceId": 69077,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Data entity",
+      "resource": "Create data entity",
+      "description": "Create a data entity.",
+      "key": "1_dataentity_create",
+      "resourceId": 69078,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Data entity",
+      "resource": "Edit schema",
+      "description": "Edit schema.",
+      "key": "1_dataentity_edit",
+      "resourceId": 69079,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Data entity",
+      "resource": "Remove data entity",
+      "description": "Delete data entity.",
+      "key": "1_dataentity_delete",
+      "resourceId": 69080,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Data entity",
+      "resource": "View data entity details",
+      "description": "View data entity details.",
+      "key": "2_dataentity_view",
+      "resourceId": 69081,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Data entity",
+      "resource": "Publish index",
+      "description": "Publish index.",
+      "key": "1_dataentity_publish",
+      "resourceId": 69082,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Dynamic storage generic resources",
+      "resource": "Master Data administrator",
+      "description": "Manage Master Data.",
+      "key": "ADMIN_DS",
+      "resourceId": 69073,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Dynamic storage generic resources",
+      "resource": "Full access to all documents",
+      "description": "Full access to all documents.",
+      "key": "POWER_USER_DS",
+      "resourceId": 69074,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Dynamic storage generic resources",
+      "resource": "Insert or update document (not remove)",
+      "description": "Creating and updating documents, but not deleting them.",
+      "key": "NOREMOVE_USER_DS",
+      "resourceId": 69075,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Dynamic storage generic resources",
+      "resource": "Read only documents",
+      "description": "Document reading only.",
+      "key": "READONLY_USER_DS",
+      "resourceId": 69076,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Index",
+      "resource": "List index",
+      "description": "List indexes.",
+      "key": "1_Index_list",
+      "resourceId": 105916,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Index",
+      "resource": "Create index",
+      "description": "Create index.",
+      "key": "1_Index_create",
+      "resourceId": 105917,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Index",
+      "resource": "Edit index",
+      "description": "Edit index.",
+      "key": "1_Index_edit",
+      "resourceId": 105918,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Index",
+      "resource": "Remove index",
+      "description": "Remove index.",
+      "key": "1_Index_delete",
+      "resourceId": 105919,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Index",
+      "resource": "View index details",
+      "description": "View index details.",
+      "key": "1_Index_view",
+      "resourceId": 105920,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Internal-Log",
+      "resource": "List internal logs",
+      "description": "List internal logs.",
+      "key": "1_internallog_list",
+      "resourceId": 105921,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "internal-warning",
+      "resource": "List internal alerts",
+      "description": "List internal alerts.",
+      "key": "1_internalwarning_list",
+      "resourceId": 106143,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Schemas",
+      "resource": "View detail schema",
+      "description": "View schema details.",
+      "key": "1_dataentity_list",
+      "resourceId": 137232,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Triggers",
+      "resource": "List trigger",
+      "description": "List triggers.",
+      "key": "2_datarule_list",
+      "resourceId": 69083,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Triggers",
+      "resource": "Create trigger",
+      "description": "Create triggers.",
+      "key": "1_datarule_create",
+      "resourceId": 69084,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Triggers",
+      "resource": "Edit trigger",
+      "description": "Edit triggers.",
+      "key": "1_datarule_edit",
+      "resourceId": 69085,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Triggers",
+      "resource": "Remove trigger",
+      "description": "Delete triggers.",
+      "key": "1_datarule_delete",
+      "resourceId": 69086,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Triggers",
+      "resource": "View trigger details",
+      "description": "View trigger details.",
+      "key": "2_datarule_view",
+      "resourceId": 69087,
+      "productId": 25
+    },
+    {
+      "product": "FastStore",
+      "category": "Secrets",
+      "resource": "View Secrets",
+      "description": "Allows you to view the secrets configured in WebOps.",
+      "key": "ViewSecrets",
+      "resourceId": 2100329,
+      "productId": 129
+    },
+    {
+      "product": "FastStore",
+      "category": "Secrets",
+      "resource": "Edit Secrets",
+      "description": "Allows you to create, delete, and edit secrets in WebOps.",
+      "key": "EditSecrets",
+      "resourceId": 2100330,
+      "productId": 129
+    },
+    {
+      "product": "Fraud Prevention",
+      "category": "Transaction Attempts",
+      "resource": "View transaction attempts",
+      "description": "View transaction attempts on the Fraud Prevention page.",
+      "key": "ViewTransactionAttempts",
+      "resourceId": 2134012,
+      "productId": 127
+    },
+    {
+      "product": "Fraud Prevention",
+      "category": "Transaction Attempts",
+      "resource": "Edit transaction attempt action settings",
+      "description": "Enable or disable actions related to attempted transactions on the Fraud Prevention page.",
+      "key": "EditTransactionAttemptActionSettings",
+      "resourceId": 2134013,
+      "productId": 127
+    },
+    {
+      "product": "Fraud Prevention",
+      "category": "Transaction Attempts",
+      "resource": "Edit transaction attempt score settings",
+      "description": "Modify scoring settings for transaction attempts on the Fraud Prevention page.",
+      "key": "EditTransactionAttemptScoreSettings",
+      "resourceId": 2134014,
+      "productId": 127
+    },
+    {
+      "product": "GiftCard",
+      "category": "GiftCard",
+      "resource": "Gift card full access",
+      "description": "Create and edit all functions related to gift cards, their providers, and transactions.",
+      "key": "GiftCardAdmin",
+      "resourceId": 472959,
+      "productId": 70
+    },
+    {
+      "product": "GiftCard",
+      "category": "GiftCard",
+      "resource": "Gift card viewer",
+      "description": "Reads all functions of gift cards, their providers and transactions.",
+      "key": "GiftCardReadOnly",
+      "resourceId": 472961,
+      "productId": 70
+    },
+    {
+      "product": "GiftCard",
+      "category": "GiftCard",
+      "resource": "View Gift Cards",
+      "description": "Enable card reading operations for gift cards and transactions.",
+      "key": "view_giftcards",
+      "resourceId": 994855,
+      "productId": 70
+    },
+    {
+      "product": "GiftCard",
+      "category": "GiftCard",
+      "resource": "Edit Gift Cards",
+      "description": "Enable to read and write gift cards and transactions.",
+      "key": "edit_giftcards",
+      "resourceId": 994919,
+      "productId": 70
+    },
+    {
+      "product": "GiftCard",
+      "category": "GiftCard",
+      "resource": "View Gift Card providers",
+      "description": "Reading about gift card providers and their gift cards.",
+      "key": "view_giftcard_providers",
+      "resourceId": 994983,
+      "productId": 70
+    },
+    {
+      "product": "GiftCard",
+      "category": "GiftCard",
+      "resource": "Edit Gift Card providers",
+      "description": "Reading and editing gift card vendors and their gift cards.",
+      "key": "edit_giftcard_providers",
+      "resourceId": 994991,
+      "productId": 70
+    },
+    {
+      "product": "Insights",
+      "category": "Analysis",
+      "resource": "Insights Metrics",
+      "description": "Allows you to view all the metrics and data present in the VTEX Admin dashboards, including the following pages: Sales Performance, Admin Home page, Insights and Audit.",
+      "key": "view_metrics",
+      "resourceId": 129814,
+      "productId": 57
+    },
+    {
+      "product": "License Manager",
+      "category": "Admin User Management",
+      "resource": "Edit Admin Users",
+      "description": "Allows you to create, edit, and remove administrative users.",
+      "key": "EditAdminUsers",
+      "resourceId": 2099310,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Admin User Management",
+      "resource": "View Admin Users",
+      "description": "Allows you to view user information and access profiles.",
+      "key": "ViewAdminUsers",
+      "resourceId": 2099311,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "API Key Management",
+      "resource": "View API keys",
+      "description": "View, filter, search, sort, and export generated and third-party API keys.",
+      "key": "ViewApiKeys",
+      "resourceId": 2042457,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "API Key Management",
+      "resource": "Edit API keys",
+      "description": "Create, delete, change the status of, and add or remove permissions for API keys.",
+      "key": "EditApiKeys",
+      "resourceId": 2042458,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "API Key Management",
+      "resource": "Edit API keys settings",
+      "description": "Modify API key configurations, such as token duration.",
+      "key": "EditApiKeysSettings",
+      "resourceId": 2042466,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "API Key Management",
+      "resource": "Renew API Token",
+      "description": "View and renew tokens from generated keys.",
+      "key": "RenewApiToken",
+      "resourceId": 2042467,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Save account",
+      "description": "Save an account (change sites, bindings, hosts, etc., contact address).",
+      "key": "Save_Account",
+      "resourceId": 1057,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get account by identifier",
+      "description": "A query that returns an account by identifier, which can be the account ID, host, or application name associated with the account.",
+      "key": "Get_Account_By_Identifier",
+      "resourceId": 1064,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Save user",
+      "description": "Create users, add or delete user roles, edit user data, create and edit application keys.",
+      "key": "Save_User",
+      "resourceId": 1074,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Remove user",
+      "description": "Revoke user access.",
+      "key": "Remove_User",
+      "resourceId": 1075,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Save access profile",
+      "description": "Create or modify an access profile.",
+      "key": "Create_Role",
+      "resourceId": 1083,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Find account resources",
+      "description": "List all the resources that an account has access to.",
+      "key": "Get_Resources_By_Account",
+      "resourceId": 1086,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get role",
+      "description": "List the resources associated with an access profile ID and the users associated with that access profile.",
+      "key": "Get_Role",
+      "resourceId": 1088,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get paged roles",
+      "description": "List all access profiles for an account.",
+      "key": "Get_Roles_Paged",
+      "resourceId": 1178,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get paged users",
+      "description": "List all administrative users of an account.",
+      "key": "Get_Users_Paged",
+      "resourceId": 1179,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Upload account logo",
+      "description": "Access to upload the account logo image.",
+      "key": "Upload_Logo",
+      "resourceId": 1183,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get account by host",
+      "description": "[Internal] Returns all authorized hosts for an account and the account hosts that it authorized.",
+      "key": "Get_Hosts_By_Account",
+      "resourceId": 1210,
+      "productId": 1
+    },
+    {
+      "product": "Live Shopping",
+      "category": "General",
+      "resource": "view_live_shopping",
+      "description": "Intended for invited users on the Live Shopping app, such as influencers, who do not need access to account information.",
+      "key": "view_live_shopping",
+      "resourceId": 1532000,
+      "productId": 98
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Logistics full access",
+      "description": "Full access to all logistics features (viewing, creating, editing, and canceling settings).",
+      "key": "LogisticsAdmin",
+      "resourceId": 1158,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Logistics viewer",
+      "description": "Visualization of the initial area of ​​the logistics module.",
+      "key": "LogisticsViewer",
+      "resourceId": 1926,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Logistics inventory full access",
+      "description": "Full access to the logistics inventory (viewing, creating, editing, and canceling settings).",
+      "key": "InventoryAdmin",
+      "resourceId": 475811,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Logistics inventory read only",
+      "description": "View inventory module.",
+      "key": "InventoryViewer",
+      "resourceId": 475812,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Logistics shipping full access",
+      "description": "Full access to all shipping functions of the logistics module (creation, editing, and cancellation of configurations).",
+      "key": "ShippingAdmin",
+      "resourceId": 475813,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Request Logistics Reports",
+      "description": "Request logistics reports.",
+      "key": "RequestLogisticsReports",
+      "resourceId": 881768,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Transportation full access",
+      "description": "Full access to transportation.",
+      "key": "TransportationAdmin",
+      "resourceId": 885164,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Transportation read only",
+      "description": "View VTEX Shipping Network orders, packages, and shipping labels.",
+      "key": "TransportationViewer",
+      "resourceId": 1881967,
+      "productId": 9
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "List Applications",
+      "description": "List applications.",
+      "key": "1_application_list",
+      "resourceId": 52286,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "Create Applications",
+      "description": "Create applications.",
+      "key": "1_application_create",
+      "resourceId": 52287,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "Edit Applications",
+      "description": "Edit applications.",
+      "key": "1_application_edit",
+      "resourceId": 52288,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "Remove Applications",
+      "description": "Delete applications.",
+      "key": "1_application_delete",
+      "resourceId": 52289,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "Create custom search",
+      "description": "Create a custom search.",
+      "key": "3_application_searchcreate",
+      "resourceId": 52290,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "Allow data export",
+      "description": "Data export.",
+      "key": "3_application_export",
+      "resourceId": 52291,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "View logs",
+      "description": "Viewing logs.",
+      "key": "4_application_logview",
+      "resourceId": 52292,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Comment",
+      "resource": "List Comments",
+      "description": "List comments.",
+      "key": "1_commentmanager_list",
+      "resourceId": 52293,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Comment",
+      "resource": "Remove Comment",
+      "description": "Delete comments.",
+      "key": "1_commentmanager_delete",
+      "resourceId": 52294,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Customized Search",
+      "resource": "List Custom Search",
+      "description": "List custom search.",
+      "key": "1_customsearch_list",
+      "resourceId": 52295,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Customized Search",
+      "resource": "Exclude Custom Search",
+      "description": "Remove custom search.",
+      "key": "1_customsearch_delete",
+      "resourceId": 52296,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Form",
+      "resource": "List Forms",
+      "description": "List forms.",
+      "key": "1_form_list",
+      "resourceId": 52297,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Form",
+      "resource": "Create Forms",
+      "description": "Create forms.",
+      "key": "1_form_create",
+      "resourceId": 52298,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Form",
+      "resource": "Edit Forms",
+      "description": "Edit forms.",
+      "key": "1_form_edit",
+      "resourceId": 52299,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Form",
+      "resource": "Remove Form",
+      "description": "Delete forms.",
+      "key": "1_form_delete",
+      "resourceId": 52300,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Generic resources",
+      "resource": "CRM administrator",
+      "description": "Manage CRM information.",
+      "key": "ADMIN_CRM",
+      "resourceId": 25786,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Generic resources",
+      "resource": "Full access to forms",
+      "description": "Full access to forms.",
+      "key": "POWER_USER_CRM",
+      "resourceId": 52283,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Generic resources",
+      "resource": "Access to insert and edit but not to delete",
+      "description": "Read and edit access, but not removal.",
+      "key": "NOREMOVE_USER_CRM",
+      "resourceId": 52284,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Generic resources",
+      "resource": "Read-only form access",
+      "description": "Read-only form access",
+      "key": "READONLY_USER_CRM",
+      "resourceId": 52285,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Import",
+      "resource": "Run import",
+      "description": "Run the import process.",
+      "key": "3_import_run",
+      "resourceId": 52306,
+      "productId": 3
+    },
+    {
+      "product": "Message Center",
+      "category": "Messages",
+      "resource": "Send Message ",
+      "description": "Send a message in the Message Center.",
+      "key": "send-message",
+      "resourceId": 1026939,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Providers",
+      "resource": "View provider list",
+      "description": "Viewing the list of senders in the Message Center.",
+      "key": "provider-listar",
+      "resourceId": 52282,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Providers",
+      "resource": "Add or edit provider",
+      "description": "Create or edit senders (providers) created in the senders area of ​​the Message Center.",
+      "key": "provider-salvar",
+      "resourceId": 52325,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Providers",
+      "resource": "Remove provider",
+      "description": "Remove senders created in the Message Center's senders area (providers).",
+      "key": "provider-excluir",
+      "resourceId": 52326,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Templates",
+      "resource": "View template list",
+      "description": "View the list of available templates in the Message Center.",
+      "key": "template-listar",
+      "resourceId": 1203,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Templates",
+      "resource": "Add new template",
+      "description": "Add new templates to the Message Center template list.",
+      "key": "template-criar",
+      "resourceId": 1204,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Templates",
+      "resource": "Remove template",
+      "description": "Remove new templates from the Message Center template list.",
+      "key": "template-excluir",
+      "resourceId": 1205,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Templates",
+      "resource": "Edit template",
+      "description": "Editing and customizing templates in the Message Center.",
+      "key": "template-editar",
+      "resourceId": 1207,
+      "productId": 23
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Change order workflow status",
+      "description": "Actions within the order flow to change the order status, via the Actions button in the flow.",
+      "key": "WorkflowAction",
+      "resourceId": 1150,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Notify payment",
+      "description": "Access the button that manually notifies the payment gateway in the payment area within the order.",
+      "key": "PaymentAction",
+      "resourceId": 1151,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Notify invoice",
+      "description": "Allows you to manually enter invoices (NF) and tracking data into the OMS.",
+      "key": "ShippingAction",
+      "resourceId": 1152,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "View order",
+      "description": "View all orders from the given account.",
+      "key": "OMSViewer",
+      "resourceId": 1153,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Notify refund",
+      "description": "Allows you to notify us of an incoming invoice.",
+      "key": "RefundAction",
+      "resourceId": 1407,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Cancel order",
+      "description": "Allows you to cancel an order in OMS.",
+      "key": "CancelAction",
+      "resourceId": 1408,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Order feed subscription",
+      "description": "Allows the user to subscribe to receive order status updates in the Order Feed.",
+      "key": "FeedSubscription",
+      "resourceId": 1409,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Change order",
+      "description": "Allows you to register changes to the order (discounts and/or exchanges).",
+      "key": "Changes",
+      "resourceId": 1621,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "View store sales stats",
+      "description": "Displays totals within the All Orders section of Order Management. Shows total sales in addition to order details.",
+      "key": "ShowTotalizers",
+      "resourceId": 98200,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Only show orders created by the user (via call center)",
+      "description": "Orders will be processed via the email address registered with callcenteroperatoremail.",
+      "key": "callCenterOperatorFilter",
+      "resourceId": 428968,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Feed v3 and Hook Admin",
+      "description": "Create, edit, and delete Feed v3/hook settings.",
+      "key": "FeedHookV3Admin",
+      "resourceId": 592028,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Feed v3 and Hook view only",
+      "description": "View Feed v3/hook data.",
+      "key": "FeedHookV3Viewer",
+      "resourceId": 592029,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Subscription view only",
+      "description": "View store subscription data.",
+      "key": "SubscriptionViewer",
+      "resourceId": 592030,
+      "productId": ""
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Subscription admin",
+      "description": "Subscriptions Admin view and action. Access to the retry button.",
+      "key": "SubscriptionAdmin",
+      "resourceId": 592031,
+      "productId": ""
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Subscription metrics and reports",
+      "description": "Access to metrics and report visualization on the Subscriptions dashboard.",
+      "key": "SubscriptionMetrics",
+      "resourceId": 592032,
+      "productId": ""
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Subscription view and edit",
+      "description": "Allows viewing and editing of signatures.",
+      "key": "SubscriptionManager",
+      "resourceId": 592033,
+      "productId": ""
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "List Orders",
+      "description": "List all orders from the given account.",
+      "key": "ListOrders",
+      "resourceId": 1860145,
+      "productId": 19
+    },
+    {
+      "product": "Order Authorization",
+      "category": "Order Authorization Admin",
+      "resource": "Save Configuration",
+      "description": "View and change the order acceptance settings for orders with value differences in the order authorization section within order management.",
+      "key": "SaveConfiguration",
+      "resourceId": 600081,
+      "productId": 74
+    },
+    {
+      "product": "Order Authorization",
+      "category": "Order Authorization Admin",
+      "resource": "View Configuration",
+      "description": "View the order acceptance settings for value differences in the order authorization section within order management.",
+      "key": "ViewConfiguration",
+      "resourceId": 600082,
+      "productId": 74
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Edit",
+      "resource": "BIN Manager Edit Permission",
+      "description": "Allows you to edit which bank or financial institution a given BIN belongs to.",
+      "key": "binManagerEditPermission",
+      "resourceId": 631530,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-MakePayments",
+      "resource": "Process payments",
+      "description": "It represents the transactional operations of the payment gateway.",
+      "key": "MakePayments",
+      "resourceId": 1052,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ManageInfrastructure",
+      "resource": "Manage Infrastructure",
+      "description": "Perform critical configurations on the Gateway infrastructure. Available to administrators only.",
+      "key": "ManageInfrastructure",
+      "resourceId": 1157,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ManageStore",
+      "resource": "Manage Store",
+      "description": "Change the settings.",
+      "key": "ManageStore",
+      "resourceId": 1097,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ManageStore",
+      "resource": "Manage Store Rules",
+      "description": "Permission to manage the store's payment methods.",
+      "key": "ManageStoreRules",
+      "resourceId": 1684986,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ManageStore",
+      "resource": "Manage Store Affiliations",
+      "description": "Permission to manage the store's Gateway affiliations.",
+      "key": "ManageStoreAffiliations",
+      "resourceId": 1684987,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ManageStore",
+      "resource": "Manage Store AntiFraud",
+      "description": "Permission to manage the anti-fraud features of the store's payment methods.",
+      "key": "ManageStoreAntiFraud ",
+      "resourceId": 1684988,
+      "productId": ""
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-NotifyPayments",
+      "resource": "Notify Payments",
+      "description": "Payment approval notification.",
+      "key": "NotifyPayments",
+      "resourceId": 1512,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-NotifyPayments",
+      "resource": "Payments Notification",
+      "description": "Payment approval notification using the Payments Gateway API.",
+      "key": "PaymentsNotification",
+      "resourceId": 2061772,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ViewPaymentData",
+      "resource": "View Payment Data",
+      "description": "Retrieve a transaction.",
+      "key": "ViewPayments",
+      "resourceId": 1096,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ViewPaymentData",
+      "resource": "View Payments Sensitive Data",
+      "description": "Viewing personally identifiable information (PII) for stores that use a data privacy compliance environment.",
+      "key": "ViewPaymentsSensitiveData",
+      "resourceId": 1515091,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "View",
+      "resource": "BIN Manager View Permission",
+      "description": "Allows you to search and view which bank or financial institution a given BIN belongs to.",
+      "key": "binManagerViewPermission",
+      "resourceId": 631529,
+      "productId": 6
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "View Card Tokens",
+      "description": "Allows viewing of tokenized card data.",
+      "key": "ViewCardTokens",
+      "resourceId": 2078628,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Edit Card Tokens",
+      "description": "Allows editing of data from tokenized cards previously created in the Card Token Vault.",
+      "key": "ManageCardTokens",
+      "resourceId": 2078744,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Create Card Tokens",
+      "description": "Allows tokenized cards to be stored.",
+      "key": "CreateCardTokens",
+      "resourceId": 2078845,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Delete Card Token",
+      "description": "Allows you to delete a previously stored tokenized card.",
+      "key": "DeleteCardToken",
+      "resourceId": 2078846,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Import Card Token",
+      "description": "Allows you to initiate the import of credit card tokens.",
+      "key": "ImportCardToken",
+      "resourceId": 2078847,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Get Import Card Token Status ",
+      "description": "Allows you to view the token import status.",
+      "key": "GetImportCardTokenStatus",
+      "resourceId": 2078848,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Get Import Card Tokens Report",
+      "description": "Download the error report for the import errors that occurred.",
+      "key": "GetImportCardTokensReport",
+      "resourceId": 2078849,
+      "productId": 114
+    },
+    {
+      "product": "PersonalShopper App",
+      "category": "Analytics",
+      "resource": "View Analytics",
+      "description": "View Analytics for the Personal Shopper app.",
+      "key": "view-analytics",
+      "resourceId": 1639728,
+      "productId": 100
+    },
+    {
+      "product": "PersonalShopper App",
+      "category": "Call",
+      "resource": "View List Call",
+      "description": "View the call page.",
+      "key": "view-list-call",
+      "resourceId": 1639430,
+      "productId": 100
+    },
+    {
+      "product": "PersonalShopper App",
+      "category": "Setting",
+      "resource": "View Setting",
+      "description": "Edit Personal Shopper app settings.",
+      "key": "view-setting",
+      "resourceId": 1643056,
+      "productId": 100
+    },
+    {
+      "product": "Portal",
+      "category": "API",
+      "resource": "Manage portal",
+      "description": "Create and edit templates, shelves, and pages in the CMS (Portal) and edit Checkout settings.",
+      "key": "AdminPortal",
+      "resourceId": 1299,
+      "productId": 27
+    },
+    {
+      "product": "Pricing",
+      "category": "Price List",
+      "resource": "Read prices",
+      "description": "View all prices for a SKU.",
+      "key": "read_prices",
+      "resourceId": 152730,
+      "productId": 65
+    },
+    {
+      "product": "Pricing",
+      "category": "Price List",
+      "resource": "Modify prices",
+      "description": "Change or create a price for a SKU.",
+      "key": "modify_prices",
+      "resourceId": 152731,
+      "productId": 65
+    },
+    {
+      "product": "Pricing",
+      "category": "Price List",
+      "resource": "Read trade policy configurations",
+      "description": "View all commercial policies for the account.",
+      "key": "read_tradePolicySettings",
+      "resourceId": 152732,
+      "productId": 65
+    },
+    {
+      "product": "Pricing",
+      "category": "Price List",
+      "resource": "Modify trade policy configurations",
+      "description": "Delete all commercial policies from the account.",
+      "key": "modify_tradePolicySettings",
+      "resourceId": 152733,
+      "productId": 65
+    },
+    {
+      "product": "Pricing",
+      "category": "Price List",
+      "resource": "Delete all prices from account",
+      "description": "Delete all prices from the account.",
+      "key": "modify_prices_delete_all",
+      "resourceId": 152736,
+      "productId": 65
+    },
+    {
+      "product": "Promotions Policy Engine",
+      "category": "Policies",
+      "resource": "Evaluate Policy",
+      "description": "Obtain policy evaluation.",
+      "key": "EvaluatePolicy",
+      "resourceId": 1212434,
+      "productId": 89
+    },
+    {
+      "product": "Promotions Policy Engine",
+      "category": "Policies",
+      "resource": "Create or Update Policy",
+      "description": "Create or update a policy.",
+      "key": "CreateOrUpdatePolicy",
+      "resourceId": 1212435,
+      "productId": 89
+    },
+    {
+      "product": "Promotions Policy Engine",
+      "category": "Policies",
+      "resource": "Get Policy",
+      "description": "To obtain the policy objective.",
+      "key": "GetPolicy",
+      "resourceId": 1212492,
+      "productId": 89
+    },
+    {
+      "product": "Promotions Policy Engine",
+      "category": "Policies",
+      "resource": "Delete Policy",
+      "description": "Delete a policy.",
+      "key": "DeletePolicy",
+      "resourceId": 1212493,
+      "productId": 89
+    },
+    {
+      "product": "Promotions Policy Engine",
+      "category": "Policies",
+      "resource": "List Policies",
+      "description": "List the existing policies.",
+      "key": "ListPolicies",
+      "resourceId": 1212494,
+      "productId": 89
+    },
+    {
+      "product": "Rates and Benefits",
+      "category": "Promotions",
+      "resource": "Manage benefits and rates",
+      "description": "Create, edit, or archive promotions, coupons, campaigns, and fees.",
+      "key": "GerenciarPromocoesETarifas",
+      "resourceId": 98201,
+      "productId": 16
+    },
+    {
+      "product": "Rates and Benefits",
+      "category": "Promotions",
+      "resource": "Manage Policies",
+      "description": "Enable the management of commercial policies.",
+      "key": "GerenciarPolicies",
+      "resourceId": 1118700,
+      "productId": 16
+    },
+    {
+      "product": "Releases",
+      "category": "Releases",
+      "resource": "Edit Release",
+      "description": "Creating, scheduling, rescheduling, and deleting entries.",
+      "key": "edit-release",
+      "resourceId": 1257521,
+      "productId": 91
+    },
+    {
+      "product": "Releases",
+      "category": "Releases",
+      "resource": "Visualize Releases",
+      "description": "View the list of releases and updates for each release.",
+      "key": "get-release",
+      "resourceId": 1257551,
+      "productId": 91
+    },
+    {
+      "product": "Sales App",
+      "category": "Reports",
+      "resource": "View Sales Performance",
+      "description": "Allows the sales associate to view the sales performance page in the VTEX Sales App for a sales operation point (physical store).",
+      "key": "ViewSalesPerformance",
+      "resourceId": 2126563,
+      "productId": 132
+    },
+    {
+      "product": "Search",
+      "category": "Search Settings",
+      "resource": "General Settings",
+      "description": "Edit general settings for VTEX Intelligent Search.",
+      "key": "general-settings",
+      "resourceId": 719379,
+      "productId": 76
+    },
+    {
+      "product": "Security Monitor",
+      "category": "findings",
+      "resource": "View Findings",
+      "description": "Obtain, list and view information about findings and types of findings in the Security Monitor.",
+      "key": "ViewFindings",
+      "resourceId": 2000228,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "findings",
+      "resource": "Edit Findings",
+      "description": "Snooze or unsnooze a finding in the Security Monitor.",
+      "key": "EditFindings",
+      "resourceId": 2000236,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "notifications settings",
+      "resource": "Edit Notification Settings",
+      "description": "Edit the notification recipient settings on Security Monitor alerts.",
+      "key": "EditNotificationSettings",
+      "resourceId": 2000244,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-read",
+      "resource": "List/Describe reports",
+      "description": "View a report or list of reports in Security Monitor.",
+      "key": "read-reports",
+      "resourceId": 1858423,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-read",
+      "resource": "List/Describe Sensors",
+      "description": "View sensor details in Security Monitor.",
+      "key": "read-sensors",
+      "resourceId": 1880664,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-read",
+      "resource": "Read Notifications Settings",
+      "description": "Read Security Monitor notification settings.",
+      "key": "read-notifications-settings",
+      "resourceId": 1980709,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-write",
+      "resource": "Create Reports",
+      "description": "Create new reports in Security Monitor.",
+      "key": "write-reports",
+      "resourceId": 1858424,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-write",
+      "resource": "Update Sensors",
+      "description": "Enable or disable sensors in Security Monitor.",
+      "key": "update-sensors",
+      "resourceId": 1880649,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-write",
+      "resource": "Write Notifications Settings",
+      "description": "Edit Security Monitor notification settings.",
+      "key": "write-notifications-settings",
+      "resourceId": 1980710,
+      "productId": 103
+    },
+    {
+      "product": "Seller Register",
+      "category": "Seller Administration",
+      "resource": "View Seller",
+      "description": "View all sellers linked to the marketplace account described on the Seller Management page, including retrieving seller data, either from the seller list or a specific seller.",
+      "key": "view-seller",
+      "resourceId": 575457,
+      "productId": 73
+    },
+    {
+      "product": "Seller Register",
+      "category": "Seller Administration",
+      "resource": "Save Seller",
+      "description": "Create new sellers and edit data for all sellers linked to the marketplace account from the Seller Management page.",
+      "key": "save-seller",
+      "resourceId": 575458,
+      "productId": 73
+    },
+    {
+      "product": "Subscriptions",
+      "category": "ApplicationAccess",
+      "resource": "Subscription view only",
+      "description": "View store subscription data.",
+      "key": "SubscriptionViewer",
+      "resourceId": 592030,
+      "productId": ""
+    },
+    {
+      "product": "Subscriptions",
+      "category": "ApplicationAccess",
+      "resource": "Subscription admin",
+      "description": "Subscriptions Admin view and action. Access to the retry button.",
+      "key": "SubscriptionAdmin",
+      "resourceId": 592031,
+      "productId": ""
+    },
+    {
+      "product": "Subscriptions",
+      "category": "ApplicationAccess",
+      "resource": "Subscription view and edit",
+      "description": "Viewing and editing signatures.",
+      "key": "SubscriptionManager",
+      "resourceId": 592033,
+      "productId": ""
+    },
+    {
+      "product": "Subscriptions",
+      "category": "ApplicationAccess",
+      "resource": "Subscription metrics and reports",
+      "description": "View metrics and reports on the Subscription dashboard.",
+      "key": "SubscriptionMetrics",
+      "resourceId": 592032,
+      "productId": ""
+    },
+    {
+      "product": "Suggestion",
+      "category": "Suggestion Resources",
+      "resource": "Main Access",
+      "description": "Unrestricted access to all components of the Received SKUs page, including viewing page data, as well as ad approval actions. Learn more at [Received SKUs Cataloging](https://help.vtex.com/pt/tutorial/sugerindo-e-aprovando-skus/).",
+      "key": "suggestions",
+      "resourceId": 109448,
+      "productId": 50
+    },
+    {
+      "product": "User Rights",
+      "category": "applications",
+      "resource": "Read Applications",
+      "description": "View operations in user rights applications, either in list or detailed view.",
+      "key": "applications_read",
+      "resourceId": 1634515,
+      "productId": ""
+    },
+    {
+      "product": "User Rights",
+      "category": "applications",
+      "resource": "Write Applications",
+      "description": "Create, update, or remove user rights applications.",
+      "key": "applications_write",
+      "resourceId": 1634523,
+      "productId": ""
+    },
+    {
+      "product": "User Rights",
+      "category": "user-rights-request",
+      "resource": "Read user rights requests",
+      "description": "View user rights requests, either in list or detailed format.",
+      "key": "user_rights_request_read",
+      "resourceId": 1634546,
+      "productId": 99
+    },
+    {
+      "product": "User Rights",
+      "category": "user-rights-request",
+      "resource": "Write user rights requests",
+      "description": "Create, update, or remove user rights requests.",
+      "key": "user_rights_request_write",
+      "resourceId": 1634554,
+      "productId": 99
+    },
+    {
+      "product": "User Rights",
+      "category": "user-rights-request",
+      "resource": "Process User Rights Removal Request",
+      "description": "Process user rights requests of the removal type.",
+      "key": "removal-request-process",
+      "resourceId": 1705138,
+      "productId": 99
+    },
+    {
+      "product": "VTEX Ad Network",
+      "category": "Advertisers",
+      "resource": "View Advertiser's details",
+      "description": "View advertiser information relating to the VTEX Ad Network.",
+      "key": "view-advertiser-details",
+      "resourceId": 2012197,
+      "productId": 106
+    },
+    {
+      "product": "VTEX Ad Network",
+      "category": "Advertisers",
+      "resource": "View Advertiser's campaigns",
+      "description": "View campaign information for a VTEX Ad Network advertiser.",
+      "key": "view-advertiser-campaigns",
+      "resourceId": 2012200,
+      "productId": 106
+    },
+    {
+      "product": "VTEX Ad Network",
+      "category": "Advertisers",
+      "resource": "Edit Advertiser's campaigns",
+      "description": "Edit campaign information for a VTEX Ad Network advertiser.",
+      "key": "edit-advertiser-campaigns",
+      "resourceId": 2012201,
+      "productId": 106
+    },
+    {
+      "product": "VTEX Ad Network",
+      "category": "Publishers",
+      "resource": "View Publisher's details",
+      "description": "View merchant information regarding the publishing of VTEX Ad Network ads.",
+      "key": "view-publisher-details",
+      "resourceId": 2012196,
+      "productId": 106
+    },
+    {
+      "product": "VTEX Bridge",
+      "category": "Items",
+      "resource": "List Itens",
+      "description": "Viewing Bridge documents.",
+      "key": "listItems",
+      "resourceId": 106704,
+      "productId": 48
+    },
+    {
+      "product": "VTEX Bridge",
+      "category": "Items",
+      "resource": "Execute Actions",
+      "description": "Take action on a log item. For example, reprocess the submission of a particular item.",
+      "key": "executeActions",
+      "resourceId": 106965,
+      "productId": 48
+    },
+    {
+      "product": "VTEX Bridge",
+      "category": "Settings",
+      "resource": "View Configs",
+      "description": "Viewing the settings for each integration.",
+      "key": "viewConfig",
+      "resourceId": 106706,
+      "productId": 48
+    },
+    {
+      "product": "VTEX Bridge",
+      "category": "Settings",
+      "resource": "Manage Configs",
+      "description": "Edit the settings of an integration.",
+      "key": "editConfig",
+      "resourceId": 106707,
+      "productId": 48
+    },
+    {
+      "product": "VTEX IO",
+      "category": "A/B Test",
+      "resource": "Manage A/B Test",
+      "description": "Start, finish, or obtain the status of an A/B test.",
+      "key": "manage-abtest",
+      "resourceId": 664798,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Read Workspace Apps",
+      "description": "Reading the applications installed in the workspace and their dependencies.",
+      "key": "read-workspace-apps",
+      "resourceId": 253175,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Link App",
+      "description": "Link and unlink applications, as well as list existing links within a given application.",
+      "key": "link-app",
+      "resourceId": 253206,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Install App",
+      "description": "Installing and uninstalling applications without billing options.",
+      "key": "install-apps",
+      "resourceId": 253207,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Vbase Read Only",
+      "description": "VBase read-only.",
+      "key": "vbase-read-only",
+      "resourceId": 253582,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Vbase Read Write",
+      "description": "Reading and writing to VBase.",
+      "key": "vbase-read-write",
+      "resourceId": 253583,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Read Workspace Services",
+      "description": "Reading the infrastructure of applications installed on the desktop.",
+      "key": "read-workspace-services",
+      "resourceId": 257862,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Install Service",
+      "description": "Installation and uninstallation of infrastructure services.",
+      "key": "install-services",
+      "resourceId": 257864,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Log Access - Read-only",
+      "description": "Reading logs from all applications.",
+      "key": "colossus-read-logs",
+      "resourceId": 259184,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Read Published Service",
+      "description": "Reading data from the infra-registry services.",
+      "key": "read-infra-service",
+      "resourceId": 259251,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Debug App",
+      "description": "Connect a debugger to a linked application.",
+      "key": "debug-app",
+      "resourceId": 377794,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Workspace CRUD",
+      "description": "Creation, deletion, and modification of workspaces.",
+      "key": "workspace-read-write",
+      "resourceId": 379639,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Buy App",
+      "description": "Installation and uninstallation of all types of applications, including those with billing options.",
+      "key": "buy-app",
+      "resourceId": 382623,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Import Redirects",
+      "description": "Manage redirects using the VTEX IO command-line interface.",
+      "key": "import-redirects",
+      "resourceId": 661667,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Workspace Manipulation",
+      "description": "Create, modify, and delete a workspace.",
+      "key": "workspace-read-write-v2",
+      "resourceId": 794788,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Workspace Promotion",
+      "description": "To promote a workspace.",
+      "key": "workspace-promote",
+      "resourceId": 794789,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Read Edition",
+      "description": "Reading the edited version of an account or workspace.",
+      "key": "read-edition",
+      "resourceId": 797718,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Allow APP configuration",
+      "description": "Configure applications.",
+      "key": "read-write-apps-settings",
+      "resourceId": 808001,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Change sponsored tenant edition",
+      "description": "Define the edition of a tenant that is sponsored by the account where this permission is granted.",
+      "key": "change-edition-of-sponsored-tenant",
+      "resourceId": 945388,
+      "productId": 66
+    },
+    {
+      "product": "VTEX Support",
+      "category": "Ticket",
+      "resource": "Open Support Ticket",
+      "description": "Open support ticket for VTEX. Valid only for accounts in Brazil.",
+      "key": "open-support-ticket",
+      "resourceId": 1945378,
+      "productId": 104
+    },
+    {
+      "product": "VTable",
+      "category": "VTable",
+      "resource": "View apps",
+      "description": "VTable app visualization.",
+      "key": "view-apps",
+      "resourceId": 257872,
+      "productId": 67
+    },
+    {
+      "product": "VTable",
+      "category": "VTable",
+      "resource": "Main access",
+      "description": "Main access point of the VTable.",
+      "key": "main_access_old",
+      "resourceId": 258007,
+      "productId": 67
+    },
+    {
+      "product": "Vtex ID",
+      "category": "Identity Providers",
+      "resource": "Write Identity Providers",
+      "description": "Create and update the identity providers (admin and webstore) for an account.",
+      "key": "write_identity_providers",
+      "resourceId": 631952,
+      "productId": 64
+    },
+    {
+      "product": "Vtex ID",
+      "category": "Identity Providers",
+      "resource": "Read Identity Providers",
+      "description": "Read the identity providers (admin and webstore) of an account.",
+      "key": "read_identity_providers",
+      "resourceId": 631953,
+      "productId": 64
+    },
+    {
+      "product": "Vtex ID",
+      "category": "Identity Providers",
+      "resource": "Can Punchout",
+      "description": "Allow API keys to authenticate users via punchout.",
+      "key": "CanPunchout",
+      "resourceId": 2074726,
+      "productId": 64
+    },
+    {
+      "product": "Vtex ID",
+      "category": "User Management",
+      "resource": "Expire User Password",
+      "description": "Define the password of a given user as null.",
+      "key": "expire_user_password",
+      "resourceId": 1844857,
+      "productId": 64
+    },
+    {
+      "product": "Vtex ID",
+      "category": "User Management",
+      "resource": "Create User",
+      "description": "Create a front-end user.",
+      "key": "CreateUser",
+      "resourceId": 2117393,
+      "productId": 64
+    },
+    {
+      "product": "WebService",
+      "category": "Web service",
+      "resource": "Webservice access",
+      "description": "Create, edit, and delete catalog information using the WebService.",
+      "key": "orders",
+      "resourceId": 136106,
+      "productId": 61
+    }
+  ],
+  "es": [
+    {
+      "product": "Application Logs Stream",
+      "category": "Logs",
+      "resource": "Read logs stream",
+      "description": "Lea los registros de la aplicación VTEX IO pertenecientes a esta cuenta.",
+      "key": "read_logs",
+      "resourceId": 728560,
+      "productId": 81
+    },
+    {
+      "product": "Audit",
+      "category": "General",
+      "resource": "Save Event",
+      "description": "Guardar eventos de auditoría.",
+      "key": "SaveEvent",
+      "resourceId": 1353337,
+      "productId": 55
+    },
+    {
+      "product": "B2B",
+      "category": "B2B General",
+      "resource": "B2BBulkExport",
+      "description": "Permite a las tiendas B2B exportar sus datos de forma masiva a archivos.",
+      "key": "B2BBulkExport",
+      "resourceId": 2045795,
+      "productId": 105
+    },
+    {
+      "product": "B2B",
+      "category": "Import",
+      "resource": "B2BBulkImport",
+      "description": "Permite que las tiendas B2B importen varias organizaciones de compras para la solución VTEX B2B.",
+      "key": "B2BBulkImport",
+      "resourceId": 1954299,
+      "productId": 105
+    },
+    {
+      "product": "B2B",
+      "category": "Import",
+      "resource": "BulkImportTest",
+      "description": "Permite a las tiendas B2B importar de forma masiva múltiples organizaciones de compradores a la solución B2B de VTEX.",
+      "key": "BulkImportTest",
+      "resourceId": 1957237,
+      "productId": 105
+    },
+    {
+      "product": "Billing",
+      "category": "Company",
+      "resource": "Edit Company Information",
+      "description": "Edite la información de registro de un cliente, que incluye: nombre de la empresa, nombre comercial, sucursal, región de ventas, nivel, estado de facturación y dirección.",
+      "key": "edit_company",
+      "resourceId": 118281,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Company",
+      "resource": "Display Company info",
+      "description": "Consulte la información de registro de un cliente, que incluye: nombre de la empresa, nombre comercial, sucursal, región de ventas, nivel, estado de facturación y dirección.",
+      "key": "get_company",
+      "resourceId": 118283,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Company",
+      "resource": "Edit Company's Document",
+      "description": "Editar documentos e información de la empresa.",
+      "key": "edit_companys_document",
+      "resourceId": 131970,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Company",
+      "resource": "Merge companies",
+      "description": "Realizar una fusión de dos cuentas, de modo que toda la información de facturas y contratos de una cuenta se transfiera a la otra.",
+      "key": "company_merge",
+      "resourceId": 277452,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Company",
+      "resource": "Split companies",
+      "description": "Separe dos cuentas: en una registre la información de facturas y contratos, y en la otra deje el texto en blanco.",
+      "key": "company_split",
+      "resourceId": 277453,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Contacts",
+      "resource": "Contacts List ",
+      "description": "Consulta qué contactos reciben notificaciones por correo electrónico cuando se genera la factura de un cliente específico.",
+      "key": "list_contacts",
+      "resourceId": 118284,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Contacts",
+      "resource": "Edit Contacts",
+      "description": "Agregar o editar un contacto.",
+      "key": "edit_contact",
+      "resourceId": 118285,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Contracts",
+      "resource": "Contracts List ",
+      "description": "Consulte los contratos y las condiciones de facturación registradas en el módulo de Facturas de la plataforma VTEX.",
+      "key": "list_contracts",
+      "resourceId": 118282,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Contracts",
+      "resource": "Save contracts",
+      "description": "Edite los contratos en el módulo de Facturas de la plataforma VTEX, incluyendo el registro de facturas de cualquier valor y el cálculo de comisiones en cualquier porcentaje.",
+      "key": "put_contract",
+      "resourceId": 134738,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Invoices List ",
+      "description": "Visualización de la lista de facturas del cliente, así como de los detalles de la factura, que incluyen información como el volumen bruto de mercancías (GMV) y el margen de beneficio.",
+      "key": "list_invoices",
+      "resourceId": 105015,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Generate new Invoice",
+      "description": "Crea una factura para un cliente, pero solo cuando ya se haya creado un contrato con un valor definido. Esta función no permite al usuario establecer el importe de la factura.",
+      "key": "put_invoices",
+      "resourceId": 120233,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Cancel Invoice Document",
+      "description": "Cancelar el documento fiscal generado por el emisor.",
+      "key": "cancel_nfe",
+      "resourceId": 134739,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Issue Invoice Document",
+      "description": "Genere el documento fiscal, pero solo en la plataforma del emisor.",
+      "key": "issue_nfe",
+      "resourceId": 134740,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Invoice reconciliation",
+      "description": "Informar al sistema de la fecha y el importe pagado de una factura.",
+      "key": "conciliate_invoice",
+      "resourceId": 134741,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Generate Invoice for overdue payment without added interest fees",
+      "description": "Modifique la fecha de vencimiento de una factura sin incurrir en recargos por mora ni intereses.",
+      "key": "generate_invoice_overdue_without_interest",
+      "resourceId": 134743,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Cancel Invoice",
+      "description": "Cancelación de una factura en el módulo de Facturas de la plataforma VTEX y en el emisor.",
+      "key": "cancel_invoice",
+      "resourceId": 134744,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Change payment status",
+      "description": "Cambie el estado de pago de la empresa a: Alerta, Bloqueado, Temporizador o Aceptar.",
+      "key": "set_paymentstatus",
+      "resourceId": 138192,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Unpaid invoices",
+      "description": "Al restablecer una factura al estado de \"abierta\", se cancelará la fecha de pago y el importe pagado.",
+      "key": "unpaid_invoices",
+      "resourceId": 525925,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Simulate Invoices Creation",
+      "description": "Simular facturas sin crearlas realmente.",
+      "key": "simulate_invoices",
+      "resourceId": 1362361,
+      "productId": 43
+    },
+    {
+      "product": "Buyer Organizations",
+      "category": "Management",
+      "resource": "Buyer Organization View",
+      "description": "Consulte la lista de organizaciones compradoras.",
+      "key": "buyer_organization_view",
+      "resourceId": 1522234,
+      "productId": 97
+    },
+    {
+      "product": "Buyer Organizations",
+      "category": "Management",
+      "resource": "Buyer Organization Edit",
+      "description": "Crear o editar organizaciones de compras.",
+      "key": "buyer_organization_edit",
+      "resourceId": 1522235,
+      "productId": 97
+    },
+    {
+      "product": "CDN API",
+      "category": "Certificate management",
+      "resource": "View certificate",
+      "description": "Ver detalles del certificado CDN.",
+      "key": "ViewCertificate",
+      "resourceId": 2022646,
+      "productId": 108
+    },
+    {
+      "product": "CDN API",
+      "category": "Certificate management",
+      "resource": "Update certificate",
+      "description": "Sustituir los certificados CDN existentes.",
+      "key": "UpdateCertificate",
+      "resourceId": 2022647,
+      "productId": 108
+    },
+    {
+      "product": "CDN API",
+      "category": "WAF Control",
+      "resource": "View WafControl Metrics",
+      "description": "Ver métricas WAF.",
+      "key": "ViewWafControlMetrics",
+      "resourceId": 2142573,
+      "productId": 108
+    },
+    {
+      "product": "CDN Service",
+      "category": "Domain Management",
+      "resource": "Query status of domains",
+      "description": "Permite al usuario comprobar el estado de los dominios de la tienda en producción.",
+      "key": "query-domain",
+      "resourceId": 1271517,
+      "productId": 84
+    },
+    {
+      "product": "CMS",
+      "category": "cms",
+      "resource": "See CMS menu on the top-bar",
+      "description": "Consulta el menú del CMS en la barra superior.",
+      "key": "topbar_visualizar",
+      "resourceId": 111439,
+      "productId": 38
+    },
+    {
+      "product": "CMS",
+      "category": "cms",
+      "resource": "Settings",
+      "description": "Editar la configuración del CMS.",
+      "key": "cms_settings",
+      "resourceId": 1434680,
+      "productId": 38
+    },
+    {
+      "product": "CMS",
+      "category": "GraphQL",
+      "resource": "CMS GraphQL API",
+      "description": "Utilice la API GraphQL de VTEX IO CMS.",
+      "key": "access-cms-graphql-api",
+      "resourceId": 1032772,
+      "productId": 38
+    },
+    {
+      "product": "CMS",
+      "category": "GraphQL",
+      "resource": "Read CMS GraphQL API",
+      "description": "Otorga acceso de solo lectura a la API GraphQL del CMS VTEX IO.",
+      "key": "read-cms-graphql-api",
+      "resourceId": 2143073,
+      "productId": 38
+    },
+    {
+      "product": "Catalog",
+      "category": "Admin",
+      "resource": "Admin list",
+      "description": "Enumere a los administradores del sistema.",
+      "key": "Administrador.aspx",
+      "resourceId": 882,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Admin",
+      "resource": "Homepage",
+      "description": "Página principal",
+      "key": "Home.aspx",
+      "resourceId": 1047,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Admin",
+      "resource": "Help page",
+      "description": "Página de inicio de ayuda",
+      "key": "Help.aspx",
+      "resourceId": 1048,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Collection",
+      "resource": "Read Collections",
+      "description": "Te permite ver colecciones.",
+      "key": "collections-read",
+      "resourceId": 627875,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Collection",
+      "resource": "Write Collections",
+      "description": "Te permite crear una nueva colección de productos.",
+      "key": "collections-write",
+      "resourceId": 627876,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "Expert Reviews Management",
+      "description": "Formulario de registro de opinión de expertos",
+      "key": "EspecialistaOpiniaoForm.aspx",
+      "resourceId": 928,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "Similar product category",
+      "description": "Añade una categoría similar al producto.",
+      "key": "ProdutoCategoriaSimilar.aspx",
+      "resourceId": 981,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "Similar category product management",
+      "description": "Registro de producto para una categoría similar",
+      "key": "ProdutoCategoriaSimilarForm.aspx",
+      "resourceId": 982,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "SKU management",
+      "description": "Formulario de registro de SKU",
+      "key": "SkuForm.aspx",
+      "resourceId": 1001,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "SKU Services",
+      "description": "Servicios de SKU",
+      "key": "SkuServicoForm.aspx",
+      "resourceId": 1004,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "Prices for SKU Services",
+      "description": "Lista de precios de servicio de SKU",
+      "key": "SkuServicoValor.aspx",
+      "resourceId": 1005,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "SKU service price management",
+      "description": "Formulario para registrar un valor para un servicio SKU.",
+      "key": "SkuServicoValorForm.aspx",
+      "resourceId": 1006,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "Commercial condition",
+      "description": "Definición de políticas comerciales",
+      "key": "SkuCondicaoComercial.aspx",
+      "resourceId": 1019,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "SKU type management",
+      "description": "Formulario para registrar tipos de servicio SKU.",
+      "key": "SkuServicoTipo.aspx",
+      "resourceId": 1045,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "Configuration Management",
+      "description": "Formulario de registro de configuración",
+      "key": "ConfigForm.aspx",
+      "resourceId": 917,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "File types list",
+      "description": "Lista de tipos de archivo",
+      "key": "TipoArquivo.aspx",
+      "resourceId": 1009,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "File types management",
+      "description": "Formulario para registrar tamaños de imagen estándar y otros tipos de archivo.",
+      "key": "TipoArquivoForm.aspx",
+      "resourceId": 1010,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "Store Texts",
+      "description": "Herramienta para desarrolladores con todos los textos base para la tienda.",
+      "key": "TextoSite.aspx",
+      "resourceId": 1034,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "CMS Management",
+      "description": "Configuración del CMS (Portal)",
+      "key": "PortalManagement",
+      "resourceId": 1202,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "SEO Configurations",
+      "description": "Configuración de contenido SEO (Robots.txt)",
+      "key": "ConfigSEOContents.aspx",
+      "resourceId": 1222,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "Gift Registry Types List",
+      "description": "Lista de tipos de listas",
+      "key": "GiftListType.aspx",
+      "resourceId": 1631,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "Gift Registry Lists Management",
+      "description": "Formulario para crear y editar tipos de listas (Lista de regalos)",
+      "key": "GiftListTypeForm.aspx",
+      "resourceId": 1633,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "Geographic Region Management",
+      "description": "Gestionar la página de listado de regiones geográficas.",
+      "key": "GeographicRegion.aspx",
+      "resourceId": 2138652,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "Geographic Region Form",
+      "description": "Gestionar el formulario para crear y editar regiones geográficas.",
+      "key": "GeographicRegionForm.aspx",
+      "resourceId": 2138653,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "StoreForm.aspx",
+      "description": "Consulte la pantalla de detalles de la póliza comercial.",
+      "key": "StoreForm.aspx",
+      "resourceId": 2142219,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "InsertOrUpdateStoreForm.aspx",
+      "description": "Crear y modificar políticas empresariales (sujeto a cargos recurrentes).",
+      "key": "InsertOrUpdateStoreForm.aspx",
+      "resourceId": 2142347,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Product management",
+      "description": "Vea la pantalla de registro y modificación del producto.",
+      "key": "ProdutoForm.aspx",
+      "resourceId": 873,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Product Form",
+      "description": "Acceso a la pantalla del producto",
+      "key": "Produto.aspx",
+      "resourceId": 874,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Change SKU Pricing",
+      "description": "Cambiar precios de SKU",
+      "key": "AlterarPrecoSku",
+      "resourceId": 877,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "SKU images management",
+      "description": "Insertar y modificar imágenes SKU",
+      "key": "ManterImagemProdutoSku",
+      "resourceId": 880,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Product and SKU Management",
+      "description": "Modificación y adición de productos y SKU",
+      "key": "ManterFormularioProdutoSku",
+      "resourceId": 881,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Reviews list",
+      "description": "Ver todas las reseñas",
+      "key": "Avaliacao.aspx",
+      "resourceId": 885,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Reviews management",
+      "description": "Formulario de inscripción para la evaluación",
+      "key": "AvaliacaoForm.aspx",
+      "resourceId": 886,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Fields list",
+      "description": "Enumera todos los campos del sistema.",
+      "key": "Campo.aspx",
+      "resourceId": 891,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Attributes Management",
+      "description": "Formulario para registrar campos.",
+      "key": "CampoForm.aspx",
+      "resourceId": 896,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Value fields list",
+      "description": "Lista de valores para un campo",
+      "key": "CampoValor.aspx",
+      "resourceId": 897,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Attribute values management",
+      "description": "Formulario de inscripción de campo",
+      "key": "CampoValorForm.aspx",
+      "resourceId": 898,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Category ",
+      "description": "Enumerar todas las categorías",
+      "key": "Categoria.aspx",
+      "resourceId": 899,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Categories Management",
+      "description": "Formulario de registro de categoría",
+      "key": "CategoriaForm.aspx",
+      "resourceId": 900,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Similar Category ",
+      "description": "Enumera todas las categorías similares",
+      "key": "CategoriaSimilar.aspx",
+      "resourceId": 901,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Similar Categories Management",
+      "description": "Se forman categorías similares",
+      "key": "CategoriaSimilarForm.aspx",
+      "resourceId": 902,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Price range",
+      "description": "Enumerar todos los rangos de precios",
+      "key": "FaixaPreco.aspx",
+      "resourceId": 933,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Price Range Management",
+      "description": "Formulario de registro de precios",
+      "key": "FaixaPrecoForm.aspx",
+      "resourceId": 934,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Providers",
+      "description": "Muestra la lista de proveedores registrados en el sistema.",
+      "key": "Fornecedor.aspx",
+      "resourceId": 938,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Supplier management",
+      "description": "Formulario de registro de proveedores",
+      "key": "FornecedorForm.aspx",
+      "resourceId": 939,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Groups",
+      "description": "Enumerar todos los grupos de categorías",
+      "key": "Grupo.aspx",
+      "resourceId": 944,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Group Management ",
+      "description": "Formulario de registro de grupo de categoría",
+      "key": "GrupoForm.aspx",
+      "resourceId": 945,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Brands",
+      "description": "Lista de todas las marcas registradas",
+      "key": "Marca.aspx",
+      "resourceId": 955,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Brands Management",
+      "description": "Formulario de registro de marca",
+      "key": "MarcaForm.aspx",
+      "resourceId": 956,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "SKUs",
+      "description": "Enumera todos los SKU registrados.",
+      "key": "Sku.aspx",
+      "resourceId": 996,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Enable Product and SKU",
+      "description": "Activación de producto y SKU",
+      "key": "Ativar Produto Sku",
+      "resourceId": 1013,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Category Management",
+      "description": "Verificación de acceso para agregar o cambiar una nueva categoría.",
+      "key": "InsertOrUpdateCategoriaFromCategoriaForm.aspx",
+      "resourceId": 1216,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Similar Category Management",
+      "description": "Verificación de acceso para agregar o cambiar una nueva categoría similar.",
+      "key": "InsertOrUpdateCategoriaFromCategoriaSimilarForm.aspx",
+      "resourceId": 1217,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Brand Management",
+      "description": "Validación para agregar o cambiar una marca.",
+      "key": "InsertOrUpdateMarcaFromMarcaForm.aspx",
+      "resourceId": 1218,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Insert or Update Group",
+      "description": "Insertar o modificar dentro del grupo de categorías.",
+      "key": "InsertOrUpdateGrupoFromGrupoForm.aspx",
+      "resourceId": 1219,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Field validation",
+      "description": "Validación de campo",
+      "key": "InsertOrUpdateCampoFromCampoForm.aspx",
+      "resourceId": 1220,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Value field validation",
+      "description": "Validación de valores de campo",
+      "key": "InsertOrUpdateCampoValorFromCampoValorForm.aspx",
+      "resourceId": 1221,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketing",
+      "resource": "Buy Together Management",
+      "description": "Formulario de inscripción para \"Comprar Juntos\"",
+      "key": "CompreJuntoForm.aspx",
+      "resourceId": 915,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketing",
+      "resource": "Reviews",
+      "description": "base de datos de revisión de SKU",
+      "key": "Resenha.aspx",
+      "resourceId": 988,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketing",
+      "resource": "Gift/Refund Vouchers",
+      "description": "Crear un comprobante de compra",
+      "key": "Vale.aspx",
+      "resourceId": 1016,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketing",
+      "resource": "Product Collections XML",
+      "description": "Colecciones XML",
+      "key": "Xml.aspx",
+      "resourceId": 1026,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketing",
+      "resource": "Tags management",
+      "description": "Control de palabras clave - Etiquetas",
+      "key": "Tag.aspx",
+      "resourceId": 1027,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketplace",
+      "resource": "Sales channels management",
+      "description": "Lista de políticas comerciales",
+      "key": "Store.aspx",
+      "resourceId": 1226,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketplace",
+      "resource": "Sellers",
+      "description": "Lista de vendedores (tiendas)",
+      "key": "Seller.aspx",
+      "resourceId": 1227,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketplace",
+      "resource": "Seller SKUs",
+      "description": "Lista de SKU de vendedores",
+      "key": "SkuSeller.aspx",
+      "resourceId": 1229,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Miscellaneous",
+      "resource": "SKU Bundles",
+      "description": "Interfaz entre kits y SKU",
+      "key": "SkuKit.aspx",
+      "resourceId": 1002,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Miscellaneous",
+      "resource": "Product Bundle Management",
+      "description": "Formulario de registro del kit",
+      "key": "SkuKitForm.aspx",
+      "resourceId": 1003,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "News Report",
+      "description": "Informe del boletín informativo",
+      "key": "RelatorioNews.aspx",
+      "resourceId": 1020,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "SKUs Report",
+      "description": "Informe de SKU",
+      "key": "Relatorio_Skus.aspx",
+      "resourceId": 1022,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "Out of stock notification",
+      "description": "Notificarme Solicitar informe",
+      "key": "Relatorio_AviseMeSku.aspx",
+      "resourceId": 1025,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "Full-text Search",
+      "description": "Informe de búsqueda de texto completo",
+      "key": "RelatorioFullText.aspx",
+      "resourceId": 1028,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "Security Monitoring",
+      "description": "Vigilancia de seguridad",
+      "key": "Relatorio_Seguranca.aspx",
+      "resourceId": 1031,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "Gift Registry List",
+      "description": "Ver todas las listas (Lista de regalos)",
+      "key": "GiftList.aspx",
+      "resourceId": 1632,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "Assisted Sales Gift Registry List Management",
+      "description": "Permite al administrador gestionar las listas de un usuario en el sitio web, como si fuera el propio usuario.",
+      "key": "GiftListImpersonation",
+      "resourceId": 1634,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Telesales",
+      "resource": "Assisted Sales",
+      "description": "Funcionalidades de televenta. Tras iniciar sesión, el usuario es redirigido al sitio web de televenta www.{nombredetienda}.com.br/a/televendas. De esta forma, el operador puede utilizar las funcionalidades de televenta, como navegar por la tienda en nombre del cliente. Como este recurso provoca la redirección automática a la tienda, el usuario que entre en una cuenta con un rol con este recurso no tendrá acceso a importantes funcionalidades del Admin. Por lo tanto, recomendamos utilizar dos cuentas separadas (con correos electrónicos separados) para los usuarios de televenta: una cuenta para el rol de Call Center Operator (con este recurso y el recurso View Order) y otra cuenta para realizar operaciones en el menú de administración, si es necesario.",
+      "key": "Televendas",
+      "resourceId": 1046,
+      "productId": 2
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "View Product",
+      "description": "Ver detalles de productos y SKUs.",
+      "key": "ViewProduct",
+      "resourceId": 2017533,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "Edit Product",
+      "description": "Editar detalles del producto y SKU.",
+      "key": "EditProduct",
+      "resourceId": 2038155,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "View Category",
+      "description": "Ver detalles de la categoría.",
+      "key": "ViewCategory",
+      "resourceId": 2038156,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "Edit Category",
+      "description": "Editar detalles de la categoría.",
+      "key": "EditCategory",
+      "resourceId": 2038157,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "View Collection",
+      "description": "Ver detalles de la colección.",
+      "key": "ViewCollection",
+      "resourceId": 2038158,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "Edit Collection",
+      "description": "Editar detalles de la colección.",
+      "key": "EditCollection",
+      "resourceId": 2038159,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "View Brand",
+      "description": "Ver detalles de la marca.",
+      "key": "ViewBrand",
+      "resourceId": 2038160,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "Edit Brand",
+      "description": "Editar detalles de la marca.",
+      "key": "EditBrand",
+      "resourceId": 2038161,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "Import Spreadsheet",
+      "description": "Importar productos y referencias mediante hoja de cálculo.",
+      "key": "ImportSpreadsheet",
+      "resourceId": 2038162,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "Export Spreadsheet",
+      "description": "Exportar la hoja de cálculo con la información del catálogo.",
+      "key": "ExportSpreadsheet",
+      "resourceId": 2038163,
+      "productId": 107
+    },
+    {
+      "product": "Channels",
+      "category": "UI resources",
+      "resource": "Send Marketplace Suggestions",
+      "description": "Permite a los vendedores enviar anuncios al mercado, que serán revisados ​​y aprobados por el mercado a través de la página de SKU recibidos o la API de coincidencia de SKU recibidos.",
+      "key": "EnviaSugestao",
+      "resourceId": 1139,
+      "productId": 13
+    },
+    {
+      "product": "Channels",
+      "category": "UI resources",
+      "resource": "Sellers SKUs List",
+      "description": "Permite a los vendedores ver la lista de SKU enviados a los marketplaces donde venden sus productos. En el panel de administración de VTEX, se puede acceder a la lista en MARKETPLACE > Integrations > Products.",
+      "key": "Consulta",
+      "resourceId": 1154,
+      "productId": 13
+    },
+    {
+      "product": "Channels",
+      "category": "UI resources",
+      "resource": "Save Suggestion Rules",
+      "description": "Permite a los marketplaces crear y modificar reglas de VTEX Matcher para la aprobación de los SKU recibidos. Esta configuración se realiza a través de la API de configuración de aprobación de SKU.",
+      "key": "SalvaRegras",
+      "resourceId": 1155,
+      "productId": 13
+    },
+    {
+      "product": "Channels",
+      "category": "UI resources",
+      "resource": "Marketplace seller setup",
+      "description": "Permite asociar un vendedor a un nuevo mercado o modificar una configuración existente. Los vendedores incluidos en el Portal del Vendedor solo pueden modificar su configuración, pero no pueden asociarse a más de un mercado. Sin embargo, los vendedores de VTEX pueden asociarse a otros mercados y modificar su configuración activando esta función. Esta acción se puede realizar a través de VTEX Admin o mediante la API REST.",
+      "key": "ConfiguraSeller",
+      "resourceId": 1156,
+      "productId": 13
+    },
+    {
+      "product": "Channels",
+      "category": "UI resources",
+      "resource": "Access the Marketplace Network",
+      "description": "Crea, edita y publica el perfil de tu tienda en la red Marketplace y envía mensajes a otras tiendas.",
+      "key": "MarketplaceNetwork",
+      "resourceId": 1107285,
+      "productId": 13
+    },
+    {
+      "product": "Checkout",
+      "category": "CheckoutResources",
+      "resource": "Shopping Cart Full Access",
+      "description": "Acceso de lectura y escritura para todos los carritos de compra. Permite visualizar los datos del carrito en su totalidad (sin enmascarar). También permite solicitudes de simulación de carritos privados.",
+      "key": "AcessaTodosCarrinhos",
+      "resourceId": 1091,
+      "productId": 5
+    },
+    {
+      "product": "Checkout",
+      "category": "CheckoutResources",
+      "resource": "Orders Full Access",
+      "description": "Acceso de lectura y escritura a todos los pedidos a través de la API de pago. No se permite el acceso a los pedidos mediante el módulo de gestión de pedidos.",
+      "key": "AcessaTodosPedidos",
+      "resourceId": 1092,
+      "productId": 5
+    },
+    {
+      "product": "Checkout",
+      "category": "CheckoutResources",
+      "resource": "Save Order Configuration",
+      "description": "Guardar la configuración del pedido.",
+      "key": "SaveOrderConfiguration",
+      "resourceId": 600072,
+      "productId": 5
+    },
+    {
+      "product": "Checkout",
+      "category": "CheckoutResources",
+      "resource": "Save OrderForm Configuration",
+      "description": "Guardar la configuración del carrito de compra.",
+      "key": "SaveOrderFormConfiguration",
+      "resourceId": 600073,
+      "productId": 5
+    },
+    {
+      "product": "Checkout",
+      "category": "CheckoutResources",
+      "resource": "Read Shopping Cart",
+      "description": "Lee y lista todos los carritos de compra. No permite el acceso a los datos del carrito sin enmascarar.",
+      "key": "GetOrderForm",
+      "resourceId": 1949421,
+      "productId": 5
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Branch",
+      "resource": "Save to main branch",
+      "description": "Agrega los cambios directamente a la rama principal.",
+      "key": "SaveToMainBranch",
+      "resourceId": 2086248,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Branch",
+      "resource": "Remove from main branch",
+      "description": "Eliminar los cambios de la rama principal.",
+      "key": "RemoveFromMainBranch",
+      "resourceId": 2086250,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Branch",
+      "resource": "Merge branch",
+      "description": "Fusiona los cambios de una rama con la rama principal.",
+      "key": "MergeBranch",
+      "resourceId": 2086251,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Branch",
+      "resource": "Delete Branch",
+      "description": "Permite eliminar una rama y todo el contenido versionado asociado a ella.",
+      "key": "DeleteBranch",
+      "resourceId": 2153203,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Branch",
+      "resource": "Create Branch",
+      "description": "Te permite crear una nueva rama para desarrollar, probar y guardar nuevas versiones del contenido de forma aislada.",
+      "key": "CreateBranch",
+      "resourceId": 2153204,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Entry",
+      "resource": "Delete entry",
+      "description": "Elimina permanentemente una entrada de todo el historial y las ramas.",
+      "key": "DeleteEntry",
+      "resourceId": 2086249,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Stores",
+      "resource": "Create Store",
+      "description": "Crea una nueva tienda de contenido comercial en la cuenta.",
+      "key": "CreateStore",
+      "resourceId": 2086252,
+      "productId": 115
+    },
+    {
+      "product": "Credit Control",
+      "category": "Checking Accounts",
+      "resource": "Read Checking Accounts",
+      "description": "Visualización de la información de la cuenta.",
+      "key": "read_checkingaccounts",
+      "resourceId": 170921,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Checking Accounts",
+      "resource": "Create Checking Accounts",
+      "description": "Creación de cuenta.",
+      "key": "create_checkingaccounts",
+      "resourceId": 170929,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Checking Accounts",
+      "resource": "Edit credits",
+      "description": "Cambiar el límite de crédito de una cuenta.",
+      "key": "edit_credits",
+      "resourceId": 197575,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Invoices",
+      "resource": "Read Invoices",
+      "description": "Visualización de facturas.",
+      "key": "read_invoices",
+      "resourceId": 170930,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Invoices",
+      "resource": "Create Invoices",
+      "description": "Emisión de facturas.",
+      "key": "create_invoices",
+      "resourceId": 170931,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Invoices",
+      "resource": "Pay Invoice",
+      "description": "Pago de facturas.",
+      "key": "pay_invoice",
+      "resourceId": 200613,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Main",
+      "resource": "Main Access",
+      "description": "Permite el acceso principal",
+      "key": "suggestions",
+      "resourceId": 109448,
+      "productId": 50
+    },
+    {
+      "product": "Credit Control",
+      "category": "Statements",
+      "resource": "Read Statements",
+      "description": "Lectura de extractos bancarios.",
+      "key": "read_statements",
+      "resourceId": 170918,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Statements",
+      "resource": "Create Statements",
+      "description": "Creación de extractos de cuenta.",
+      "key": "create_statements",
+      "resourceId": 170920,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Store Configuration",
+      "resource": "Edit Configuration",
+      "description": "Cambia la configuración de la tienda.",
+      "key": "edit_config",
+      "resourceId": 198649,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Store Configuration",
+      "resource": "Read Configuration",
+      "description": "Visualización de la configuración de la tienda.",
+      "key": "read_config",
+      "resourceId": 198650,
+      "productId": 58
+    },
+    {
+      "product": "Delivery Promises",
+      "category": "ProductAvailability",
+      "resource": "Notify Product Availability Change",
+      "description": "Actualizar la disponibilidad de artículos de vendedores externos en el contexto de la Promesa de Entrega.",
+      "key": "NotifyProductAvailabilityChange",
+      "resourceId": 2032871,
+      "productId": 111
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Data entity",
+      "resource": "List data entity",
+      "description": "Enumerar las entidades de datos.",
+      "key": "2_dataentity_list",
+      "resourceId": 69077,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Data entity",
+      "resource": "Create data entity",
+      "description": "Crear una entidad de datos.",
+      "key": "1_dataentity_create",
+      "resourceId": 69078,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Data entity",
+      "resource": "Edit schema",
+      "description": "Editar schema.",
+      "key": "1_dataentity_edit",
+      "resourceId": 69079,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Data entity",
+      "resource": "Remove data entity",
+      "description": "Eliminar entidad de datos.",
+      "key": "1_dataentity_delete",
+      "resourceId": 69080,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Data entity",
+      "resource": "View data entity details",
+      "description": "Ver detalles de la entidad de datos.",
+      "key": "2_dataentity_view",
+      "resourceId": 69081,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Data entity",
+      "resource": "Publish index",
+      "description": "Publicar índice.",
+      "key": "1_dataentity_publish",
+      "resourceId": 69082,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Dynamic storage generic resources",
+      "resource": "Master Data administrator",
+      "description": "Administre Master Data.",
+      "key": "ADMIN_DS",
+      "resourceId": 69073,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Dynamic storage generic resources",
+      "resource": "Full access to all documents",
+      "description": "Acceso completo a todos los documentos.",
+      "key": "POWER_USER_DS",
+      "resourceId": 69074,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Dynamic storage generic resources",
+      "resource": "Insert or update document (not remove)",
+      "description": "Crear y actualizar documentos, pero no eliminarlos.",
+      "key": "NOREMOVE_USER_DS",
+      "resourceId": 69075,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Dynamic storage generic resources",
+      "resource": "Read only documents",
+      "description": "Solo lectura del documento.",
+      "key": "READONLY_USER_DS",
+      "resourceId": 69076,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Index",
+      "resource": "List index",
+      "description": "Listar índices.",
+      "key": "1_Index_list",
+      "resourceId": 105916,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Index",
+      "resource": "Create index",
+      "description": "Crear índice.",
+      "key": "1_Index_create",
+      "resourceId": 105917,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Index",
+      "resource": "Edit index",
+      "description": "Editar índice.",
+      "key": "1_Index_edit",
+      "resourceId": 105918,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Index",
+      "resource": "Remove index",
+      "description": "Eliminar índice.",
+      "key": "1_Index_delete",
+      "resourceId": 105919,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Index",
+      "resource": "View index details",
+      "description": "Ver detalles del índice.",
+      "key": "1_Index_view",
+      "resourceId": 105920,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Internal-Log",
+      "resource": "List internal logs",
+      "description": "Listar los registros internos.",
+      "key": "1_internallog_list",
+      "resourceId": 105921,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "internal-warning",
+      "resource": "List internal alerts",
+      "description": "Enumerar las alertas internas.",
+      "key": "1_internalwarning_list",
+      "resourceId": 106143,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Schemas",
+      "resource": "View detail schema",
+      "description": "Ver detalles del esquema.",
+      "key": "1_dataentity_list",
+      "resourceId": 137232,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Triggers",
+      "resource": "List trigger",
+      "description": "Listar triggers.",
+      "key": "2_datarule_list",
+      "resourceId": 69083,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Triggers",
+      "resource": "Create trigger",
+      "description": "Crear triggers.",
+      "key": "1_datarule_create",
+      "resourceId": 69084,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Triggers",
+      "resource": "Edit trigger",
+      "description": "Editar triggers.",
+      "key": "1_datarule_edit",
+      "resourceId": 69085,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Triggers",
+      "resource": "Remove trigger",
+      "description": "Eliminar triggers.",
+      "key": "1_datarule_delete",
+      "resourceId": 69086,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Triggers",
+      "resource": "View trigger details",
+      "description": "Ver dettalles de triggers.",
+      "key": "2_datarule_view",
+      "resourceId": 69087,
+      "productId": 25
+    },
+    {
+      "product": "FastStore",
+      "category": "Secrets",
+      "resource": "View Secrets",
+      "description": "Permite ver los secretos configurados en WebOps.",
+      "key": "ViewSecrets",
+      "resourceId": 2100329,
+      "productId": 129
+    },
+    {
+      "product": "FastStore",
+      "category": "Secrets",
+      "resource": "Edit Secrets",
+      "description": "Permite crear, eliminar y editar secretos en WebOps.",
+      "key": "EditSecrets",
+      "resourceId": 2100330,
+      "productId": 129
+    },
+    {
+      "product": "Fraud Prevention",
+      "category": "Transaction Attempts",
+      "resource": "View transaction attempts",
+      "description": "Consulte los intentos de transacción en la página de Prevención de Fraude.",
+      "key": "ViewTransactionAttempts",
+      "resourceId": 2134012,
+      "productId": 127
+    },
+    {
+      "product": "Fraud Prevention",
+      "category": "Transaction Attempts",
+      "resource": "Edit transaction attempt action settings",
+      "description": "Habilite o deshabilite las acciones relacionadas con los intentos de transacción en la página de Prevención de Fraude.",
+      "key": "EditTransactionAttemptActionSettings",
+      "resourceId": 2134013,
+      "productId": 127
+    },
+    {
+      "product": "Fraud Prevention",
+      "category": "Transaction Attempts",
+      "resource": "Edit transaction attempt score settings",
+      "description": "Modifique la configuración de puntuación para los intentos de transacción en la página de Prevención de Fraude.",
+      "key": "EditTransactionAttemptScoreSettings",
+      "resourceId": 2134014,
+      "productId": 127
+    },
+    {
+      "product": "GiftCard",
+      "category": "GiftCard",
+      "resource": "Gift card full access",
+      "description": "Crea y edita todas las funciones relacionadas con las tarjetas de regalo, sus proveedores y las transacciones.",
+      "key": "GiftCardAdmin",
+      "resourceId": 472959,
+      "productId": 70
+    },
+    {
+      "product": "GiftCard",
+      "category": "GiftCard",
+      "resource": "Gift card viewer",
+      "description": "Lee todas las funciones de las tarjetas de regalo, sus proveedores y las transacciones.",
+      "key": "GiftCardReadOnly",
+      "resourceId": 472961,
+      "productId": 70
+    },
+    {
+      "product": "GiftCard",
+      "category": "GiftCard",
+      "resource": "View Gift Cards",
+      "description": "Habilitar las operaciones de lectura de tarjetas para tarjetas de regalo y transacciones.",
+      "key": "view_giftcards",
+      "resourceId": 994855,
+      "productId": 70
+    },
+    {
+      "product": "GiftCard",
+      "category": "GiftCard",
+      "resource": "Edit Gift Cards",
+      "description": "Permite leer y escribir tarjetas de regalo y transacciones.",
+      "key": "edit_giftcards",
+      "resourceId": 994919,
+      "productId": 70
+    },
+    {
+      "product": "GiftCard",
+      "category": "GiftCard",
+      "resource": "View Gift Card providers",
+      "description": "Información sobre proveedores de tarjetas de regalo y sus tarjetas de regalo.",
+      "key": "view_giftcard_providers",
+      "resourceId": 994983,
+      "productId": 70
+    },
+    {
+      "product": "GiftCard",
+      "category": "GiftCard",
+      "resource": "Edit Gift Card providers",
+      "description": "Lectura y edición de proveedores de tarjetas de regalo y sus tarjetas de regalo.",
+      "key": "edit_giftcard_providers",
+      "resourceId": 994991,
+      "productId": 70
+    },
+    {
+      "product": "Insights",
+      "category": "Analysis",
+      "resource": "Insights Metrics",
+      "description": "Permite la visualización sin restricciones de todas las métricas y datos presentes en los dashboards de VTEX Admin, incluyendo las siguientes páginas: Rendimiento de ventas, Página de inicio de Admin, Insights y Audit.",
+      "key": "view_metrics",
+      "resourceId": 129814,
+      "productId": 57
+    },
+    {
+      "product": "License Manager",
+      "category": "Admin User Management",
+      "resource": "Edit Admin Users",
+      "description": "Permite crear, editar y eliminar usuarios administradores.",
+      "key": "EditAdminUsers",
+      "resourceId": 2099310,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Admin User Management",
+      "resource": "View Admin Users",
+      "description": "Permite ver la información del usuario y acceder a los perfiles.",
+      "key": "ViewAdminUsers",
+      "resourceId": 2099311,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "API Key Management",
+      "resource": "View API keys",
+      "description": "Visualiza, filtra, busca, ordena y exporta las claves API generadas y de terceros.",
+      "key": "ViewApiKeys",
+      "resourceId": 2042457,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "API Key Management",
+      "resource": "Edit API keys",
+      "description": "Crear, eliminar, cambiar el estado y agregar o eliminar permisos para las claves API.",
+      "key": "EditApiKeys",
+      "resourceId": 2042458,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "API Key Management",
+      "resource": "Edit API keys settings",
+      "description": "Modificar los ajustes relacionados con las claves API, como la duración de los tokens.",
+      "key": "EditApiKeysSettings",
+      "resourceId": 2042466,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "API Key Management",
+      "resource": "Renew API Token",
+      "description": "Ver y renovar el token de una clave API.",
+      "key": "RenewApiToken",
+      "resourceId": 2042467,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Save account",
+      "description": "Guardar una cuenta (cambiar sitios, enlaces, hosts, etc., dirección de contacto).",
+      "key": "Save_Account",
+      "resourceId": 1057,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get account by identifier",
+      "description": "Una consulta que devuelve una cuenta por identificador, que puede ser el ID de la cuenta, el host o el nombre de la aplicación asociada a la cuenta.",
+      "key": "Get_Account_By_Identifier",
+      "resourceId": 1064,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Save user",
+      "description": "Cree usuarios, agregue o elimine roles de usuarios, edite datos de usuario, cree y cambie claves de aplicación.",
+      "key": "Save_User",
+      "resourceId": 1074,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Remove user",
+      "description": "Revocar el acceso del usuario.",
+      "key": "Remove_User",
+      "resourceId": 1075,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Save access profile",
+      "description": "Crear o modificar un perfil de acceso.",
+      "key": "Create_Role",
+      "resourceId": 1083,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Find account resources",
+      "description": "Enumera todos los recursos a los que tiene acceso una cuenta.",
+      "key": "Get_Resources_By_Account",
+      "resourceId": 1086,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get role",
+      "description": "Enumere los recursos asociados a un ID de perfil de acceso y los usuarios asociados a dicho perfil de acceso.",
+      "key": "Get_Role",
+      "resourceId": 1088,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get paged roles",
+      "description": "Enumera todos los perfiles de acceso de una cuenta.",
+      "key": "Get_Roles_Paged",
+      "resourceId": 1178,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get paged users",
+      "description": "Enumera todos los usuarios administradores de una cuenta.",
+      "key": "Get_Users_Paged",
+      "resourceId": 1179,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Upload account logo",
+      "description": "Acceso para subir la imagen del logotipo de la cuenta.",
+      "key": "Upload_Logo",
+      "resourceId": 1183,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get account by host",
+      "description": "[Interno] Devuelve todos los hosts autorizados para una cuenta y los hosts de la cuenta que autorizó.",
+      "key": "Get_Hosts_By_Account",
+      "resourceId": 1210,
+      "productId": 1
+    },
+    {
+      "product": "Live Shopping",
+      "category": "General",
+      "resource": "view_live_shopping",
+      "description": "Está destinada a usuarios invitados de la aplicación Live Shopping, como por ejemplo personas influyentes, que no necesitan acceso a la información de la cuenta.",
+      "key": "view_live_shopping",
+      "resourceId": 1532000,
+      "productId": 98
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Logistics full access",
+      "description": "Acceso completo a todas las funciones de logística (visualización, creación, edición y cancelación de ajustes).",
+      "key": "LogisticsAdmin",
+      "resourceId": 1158,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Logistics viewer",
+      "description": "Visualización del área inicial del módulo logístico.",
+      "key": "LogisticsViewer",
+      "resourceId": 1926,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Logistics inventory full access",
+      "description": "Acceso completo al inventario logístico (visualización, creación, edición y cancelación de ajustes).",
+      "key": "InventoryAdmin",
+      "resourceId": 475811,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Logistics inventory read only",
+      "description": "Ver módulo de inventario.",
+      "key": "InventoryViewer",
+      "resourceId": 475812,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Logistics shipping full access",
+      "description": "Acceso completo a todas las funciones de envío del módulo de logística (creación, edición y cancelación de configuraciones).",
+      "key": "ShippingAdmin",
+      "resourceId": 475813,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Request Logistics Reports",
+      "description": "Solicitar informes logísticos.",
+      "key": "RequestLogisticsReports",
+      "resourceId": 881768,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Transportation full access",
+      "description": "Acceso completo al transporte.",
+      "key": "TransportationAdmin",
+      "resourceId": 885164,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Transportation read only",
+      "description": "Ver los pedidos, paquetes y etiquetas de envío de VTEX Shipping Network.",
+      "key": "TransportationViewer",
+      "resourceId": 1881967,
+      "productId": 9
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "List Applications",
+      "description": "Enumerar las solicitudes.",
+      "key": "1_application_list",
+      "resourceId": 52286,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "Create Applications",
+      "description": "Crear aplicaciones.",
+      "key": "1_application_create",
+      "resourceId": 52287,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "Edit Applications",
+      "description": "Editar aplicaciones.",
+      "key": "1_application_edit",
+      "resourceId": 52288,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "Remove Applications",
+      "description": "Eliminar aplicaciones.",
+      "key": "1_application_delete",
+      "resourceId": 52289,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "Create custom search",
+      "description": "Crea una búsqueda personalizada.",
+      "key": "3_application_searchcreate",
+      "resourceId": 52290,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "Allow data export",
+      "description": "Exportación de datos.",
+      "key": "3_application_export",
+      "resourceId": 52291,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "View logs",
+      "description": "Visualización de registros.",
+      "key": "4_application_logview",
+      "resourceId": 52292,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Comment",
+      "resource": "List Comments",
+      "description": "Lista de comentarios.",
+      "key": "1_commentmanager_list",
+      "resourceId": 52293,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Comment",
+      "resource": "Remove Comment",
+      "description": "Eliminar comentarios.",
+      "key": "1_commentmanager_delete",
+      "resourceId": 52294,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Customized Search",
+      "resource": "List Custom Search",
+      "description": "Lista de búsqueda personalizada.",
+      "key": "1_customsearch_list",
+      "resourceId": 52295,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Customized Search",
+      "resource": "Exclude Custom Search",
+      "description": "Eliminar búsqueda personalizada.",
+      "key": "1_customsearch_delete",
+      "resourceId": 52296,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Form",
+      "resource": "List Forms",
+      "description": "Formularios de lista.",
+      "key": "1_form_list",
+      "resourceId": 52297,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Form",
+      "resource": "Create Forms",
+      "description": "Crear formularios.",
+      "key": "1_form_create",
+      "resourceId": 52298,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Form",
+      "resource": "Edit Forms",
+      "description": "Editar formularios.",
+      "key": "1_form_edit",
+      "resourceId": 52299,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Form",
+      "resource": "Remove Form",
+      "description": "Eliminar formularios.",
+      "key": "1_form_delete",
+      "resourceId": 52300,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Generic resources",
+      "resource": "CRM administrator",
+      "description": "Gestionar la información del CRM.",
+      "key": "ADMIN_CRM",
+      "resourceId": 25786,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Generic resources",
+      "resource": "Full access to forms",
+      "description": "Acceso completo a los formularios.",
+      "key": "POWER_USER_CRM",
+      "resourceId": 52283,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Generic resources",
+      "resource": "Access to insert and edit but not to delete",
+      "description": "Acceso de lectura y edición, pero no de eliminación.",
+      "key": "NOREMOVE_USER_CRM",
+      "resourceId": 52284,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Generic resources",
+      "resource": "Read-only form access",
+      "description": "Solo lectura de formularios.",
+      "key": "READONLY_USER_CRM",
+      "resourceId": 52285,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Import",
+      "resource": "Run import",
+      "description": "Ejecutar el proceso de importación.",
+      "key": "3_import_run",
+      "resourceId": 52306,
+      "productId": 3
+    },
+    {
+      "product": "Message Center",
+      "category": "Messages",
+      "resource": "Send Message ",
+      "description": "Envía un mensaje desde el Centro de mensajes.",
+      "key": "send-message",
+      "resourceId": 1026939,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Providers",
+      "resource": "View provider list",
+      "description": "Visualización de la lista de remitentes en el Centro de mensajes.",
+      "key": "provider-listar",
+      "resourceId": 52282,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Providers",
+      "resource": "Add or edit provider",
+      "description": "Cree o edite remitentes (proveedores) creados en el área de remitentes del Centro de mensajes.",
+      "key": "provider-salvar",
+      "resourceId": 52325,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Providers",
+      "resource": "Remove provider",
+      "description": "Elimine los remitentes creados en el área de remitentes (proveedores) del Centro de mensajes.",
+      "key": "provider-excluir",
+      "resourceId": 52326,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Templates",
+      "resource": "View template list",
+      "description": "Consulta la lista de plantillas disponibles en el Centro de mensajes.",
+      "key": "template-listar",
+      "resourceId": 1203,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Templates",
+      "resource": "Add new template",
+      "description": "Agregue nuevas plantillas a la lista de plantillas del Centro de mensajes.",
+      "key": "template-criar",
+      "resourceId": 1204,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Templates",
+      "resource": "Remove template",
+      "description": "Eliminar las plantillas nuevas de la lista de plantillas del Centro de mensajes.",
+      "key": "template-excluir",
+      "resourceId": 1205,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Templates",
+      "resource": "Edit template",
+      "description": "Edición y personalización de plantillas en el Centro de mensajes.",
+      "key": "template-editar",
+      "resourceId": 1207,
+      "productId": 23
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Change order workflow status",
+      "description": "Acciones dentro del flujo de pedidos para cambiar el estado del pedido, a través del botón Acciones en el flujo.",
+      "key": "WorkflowAction",
+      "resourceId": 1150,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Notify payment",
+      "description": "Acceda al botón que notifica manualmente a la pasarela de pago en el área de pago dentro del pedido.",
+      "key": "PaymentAction",
+      "resourceId": 1151,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Notify invoice",
+      "description": "Le permite ingresar manualmente facturas (NF) y datos de seguimiento en el OMS.",
+      "key": "ShippingAction",
+      "resourceId": 1152,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "View order",
+      "description": "Visualizar todos los pedidos de la cuenta.",
+      "key": "OMSViewer",
+      "resourceId": 1153,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Notify refund",
+      "description": "Le permite notificarnos la llegada de una factura.",
+      "key": "RefundAction",
+      "resourceId": 1407,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Cancel order",
+      "description": "Te permite cancelar un pedido en OMS.",
+      "key": "CancelAction",
+      "resourceId": 1408,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Order feed subscription",
+      "description": "Permite al usuario suscribirse para recibir actualizaciones del estado de los pedidos en el Feed de pedidos.",
+      "key": "FeedSubscription",
+      "resourceId": 1409,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Change order",
+      "description": "Le permite registrar cambios en el pedido (descuentos y/o cambios).",
+      "key": "Changes",
+      "resourceId": 1621,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "View store sales stats",
+      "description": "Muestra los totales en la sección \"Todos los pedidos\" de la gestión de pedidos. Muestra las ventas totales además de los detalles del pedido.",
+      "key": "ShowTotalizers",
+      "resourceId": 98200,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Only show orders created by the user (via call center)",
+      "description": "Los pedidos se procesarán a través de la dirección de correo electrónico registrada en callcenteroperatoremail.",
+      "key": "callCenterOperatorFilter",
+      "resourceId": 428968,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Feed v3 and Hook Admin",
+      "description": "Crea, edita y elimina la configuración de Feed v3/hook.",
+      "key": "FeedHookV3Admin",
+      "resourceId": 592028,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Feed v3 and Hook view only",
+      "description": "Ver datos de Feed v3/hook.",
+      "key": "FeedHookV3Viewer",
+      "resourceId": 592029,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Subscription view only",
+      "description": "Ver datos de suscripción de la tienda.",
+      "key": "SubscriptionViewer",
+      "resourceId": 592030,
+      "productId": ""
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Subscription admin",
+      "description": "Acción y vista del Admin de subscripciones. Acces al botón de prueba novamente.",
+      "key": "SubscriptionAdmin",
+      "resourceId": 592031,
+      "productId": ""
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Subscription metrics and reports",
+      "description": "Acceso a métricas y visualización de informes en el panel de control de suscripciones.",
+      "key": "SubscriptionMetrics",
+      "resourceId": 592032,
+      "productId": ""
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Subscription view and edit",
+      "description": "Permite visualizar y editar firmas.",
+      "key": "SubscriptionManager",
+      "resourceId": 592033,
+      "productId": ""
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "List Orders",
+      "description": "Listar todos los pedidos de la cuenta.",
+      "key": "ListOrders",
+      "resourceId": 1860145,
+      "productId": 19
+    },
+    {
+      "product": "Order Authorization",
+      "category": "Order Authorization Admin",
+      "resource": "Save Configuration",
+      "description": "En la sección de autorización de pedidos, dentro de la gestión de pedidos, podrá ver y modificar la configuración de aceptación de pedidos con diferencias de valor.",
+      "key": "SaveConfiguration",
+      "resourceId": 600081,
+      "productId": 74
+    },
+    {
+      "product": "Order Authorization",
+      "category": "Order Authorization Admin",
+      "resource": "View Configuration",
+      "description": "Consulte la configuración de aceptación de pedidos para detectar diferencias de valor en la sección de autorización de pedidos dentro de la gestión de pedidos.",
+      "key": "ViewConfiguration",
+      "resourceId": 600082,
+      "productId": 74
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Edit",
+      "resource": "BIN Manager Edit Permission",
+      "description": "Permite editar a qué banco o institución financiera pertenece un BIN determinado.",
+      "key": "binManagerEditPermission",
+      "resourceId": 631530,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-MakePayments",
+      "resource": "Process payments",
+      "description": "Representa las operaciones transaccionales de la pasarela de pago.",
+      "key": "MakePayments",
+      "resourceId": 1052,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ManageInfrastructure",
+      "resource": "Manage Infrastructure",
+      "description": "Realizar configuraciones críticas en la infraestructura de Gateway. Disponible solo para administradores.",
+      "key": "ManageInfrastructure",
+      "resourceId": 1157,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ManageStore",
+      "resource": "Manage Store",
+      "description": "Cambia la configuración.",
+      "key": "ManageStore",
+      "resourceId": 1097,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ManageStore",
+      "resource": "Manage Store Rules",
+      "description": "Permiso para gestionar los métodos de pago de la tienda.",
+      "key": "ManageStoreRules",
+      "resourceId": 1684986,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ManageStore",
+      "resource": "Manage Store Affiliations",
+      "description": "Permiso para gestionar las afiliaciones de Gateway de la tienda.",
+      "key": "ManageStoreAffiliations",
+      "resourceId": 1684987,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ManageStore",
+      "resource": "Manage Store AntiFraud",
+      "description": "Permiso para gestionar las funciones antifraude de los métodos de pago de la tienda.",
+      "key": "ManageStoreAntiFraud ",
+      "resourceId": 1684988,
+      "productId": ""
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-NotifyPayments",
+      "resource": "Notify Payments",
+      "description": "Notificación de aprobación de pago.",
+      "key": "NotifyPayments",
+      "resourceId": 1512,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-NotifyPayments",
+      "resource": "Payments Notification",
+      "description": "Notificación de aprobación de pago mediante la API de la pasarela de pagos.",
+      "key": "PaymentsNotification",
+      "resourceId": 2061772,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ViewPaymentData",
+      "resource": "View Payment Data",
+      "description": "Recuperar una transacción.",
+      "key": "ViewPayments",
+      "resourceId": 1096,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ViewPaymentData",
+      "resource": "View Payments Sensitive Data",
+      "description": "Visualización de información de identificación personal (PII) para tiendas que utilizan un entorno de cumplimiento de privacidad de datos.",
+      "key": "ViewPaymentsSensitiveData",
+      "resourceId": 1515091,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "View",
+      "resource": "BIN Manager View Permission",
+      "description": "Le permite buscar y ver a qué banco o institución financiera pertenece un BIN determinado.",
+      "key": "binManagerViewPermission",
+      "resourceId": 631529,
+      "productId": 6
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "View Card Tokens",
+      "description": "Permite visualizar los datos de la tarjeta tokenizada.",
+      "key": "ViewCardTokens",
+      "resourceId": 2078628,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Edit Card Tokens",
+      "description": "Permite editar datos de tarjetas tokenizadas creadas previamente en la Bóveda de Tokens de Tarjetas.",
+      "key": "ManageCardTokens",
+      "resourceId": 2078744,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Create Card Tokens",
+      "description": "Permite almacenar tarjetas tokenizadas.",
+      "key": "CreateCardTokens",
+      "resourceId": 2078845,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Delete Card Token",
+      "description": "Permite eliminar una tarjeta tokenizada almacenada previamente.",
+      "key": "DeleteCardToken",
+      "resourceId": 2078846,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Import Card Token",
+      "description": "Permite iniciar la importación de tokens de tarjetas de crédito.",
+      "key": "ImportCardToken",
+      "resourceId": 2078847,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Get Import Card Token Status ",
+      "description": "Permite ver el estado de importación del token.",
+      "key": "GetImportCardTokenStatus",
+      "resourceId": 2078848,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Get Import Card Tokens Report",
+      "description": "Descargue el informe de errores para conocer los errores de importación que se hayan producido.",
+      "key": "GetImportCardTokensReport",
+      "resourceId": 2078849,
+      "productId": 114
+    },
+    {
+      "product": "PersonalShopper App",
+      "category": "Analytics",
+      "resource": "View Analytics",
+      "description": "Consulta las estadísticas de la aplicación Personal Shopper.",
+      "key": "view-analytics",
+      "resourceId": 1639728,
+      "productId": 100
+    },
+    {
+      "product": "PersonalShopper App",
+      "category": "Call",
+      "resource": "View List Call",
+      "description": "Consulta la página de la convocatoria.",
+      "key": "view-list-call",
+      "resourceId": 1639430,
+      "productId": 100
+    },
+    {
+      "product": "PersonalShopper App",
+      "category": "Setting",
+      "resource": "View Setting",
+      "description": "Edita la configuración de la aplicación Personal Shopper.",
+      "key": "view-setting",
+      "resourceId": 1643056,
+      "productId": 100
+    },
+    {
+      "product": "Portal",
+      "category": "API",
+      "resource": "Manage portal",
+      "description": "Cree y edite plantillas, estantes y páginas en el CMS (Portal) y edite la configuración de pago.",
+      "key": "AdminPortal",
+      "resourceId": 1299,
+      "productId": 27
+    },
+    {
+      "product": "Pricing",
+      "category": "Price List",
+      "resource": "Read prices",
+      "description": "Ver todos los precios de un artículo.",
+      "key": "read_prices",
+      "resourceId": 152730,
+      "productId": 65
+    },
+    {
+      "product": "Pricing",
+      "category": "Price List",
+      "resource": "Modify prices",
+      "description": "Cambiar o crear un precio para un SKU.",
+      "key": "modify_prices",
+      "resourceId": 152731,
+      "productId": 65
+    },
+    {
+      "product": "Pricing",
+      "category": "Price List",
+      "resource": "Read trade policy configurations",
+      "description": "Consulte todas las políticas comerciales de la cuenta.",
+      "key": "read_tradePolicySettings",
+      "resourceId": 152732,
+      "productId": 65
+    },
+    {
+      "product": "Pricing",
+      "category": "Price List",
+      "resource": "Modify trade policy configurations",
+      "description": "Elimine todas las políticas comerciales de la cuenta.",
+      "key": "modify_tradePolicySettings",
+      "resourceId": 152733,
+      "productId": 65
+    },
+    {
+      "product": "Pricing",
+      "category": "Price List",
+      "resource": "Delete all prices from account",
+      "description": "Eliminar todos los precios de la cuenta.",
+      "key": "modify_prices_delete_all",
+      "resourceId": 152736,
+      "productId": 65
+    },
+    {
+      "product": "Promotions Policy Engine",
+      "category": "Policies",
+      "resource": "Evaluate Policy",
+      "description": "Obtenga una evaluación de la política.",
+      "key": "EvaluatePolicy",
+      "resourceId": 1212434,
+      "productId": 89
+    },
+    {
+      "product": "Promotions Policy Engine",
+      "category": "Policies",
+      "resource": "Create or Update Policy",
+      "description": "Crear o actualizar una política.",
+      "key": "CreateOrUpdatePolicy",
+      "resourceId": 1212435,
+      "productId": 89
+    },
+    {
+      "product": "Promotions Policy Engine",
+      "category": "Policies",
+      "resource": "Get Policy",
+      "description": "Para lograr el objetivo político.",
+      "key": "GetPolicy",
+      "resourceId": 1212492,
+      "productId": 89
+    },
+    {
+      "product": "Promotions Policy Engine",
+      "category": "Policies",
+      "resource": "Delete Policy",
+      "description": "Eliminar una política.",
+      "key": "DeletePolicy",
+      "resourceId": 1212493,
+      "productId": 89
+    },
+    {
+      "product": "Promotions Policy Engine",
+      "category": "Policies",
+      "resource": "List Policies",
+      "description": "Enumere las políticas existentes.",
+      "key": "ListPolicies",
+      "resourceId": 1212494,
+      "productId": 89
+    },
+    {
+      "product": "Rates and Benefits",
+      "category": "Promotions",
+      "resource": "Manage benefits and rates",
+      "description": "Crea, edita o archiva promociones, cupones, campañas y tarifas.",
+      "key": "GerenciarPromocoesETarifas",
+      "resourceId": 98201,
+      "productId": 16
+    },
+    {
+      "product": "Rates and Benefits",
+      "category": "Promotions",
+      "resource": "Manage Policies",
+      "description": "Permitir la gestión de pólizas comerciales.",
+      "key": "GerenciarPolicies",
+      "resourceId": 1118700,
+      "productId": 16
+    },
+    {
+      "product": "Releases",
+      "category": "Releases",
+      "resource": "Edit Release",
+      "description": "Crear, programar, reprogramar y eliminar entradas.",
+      "key": "edit-release",
+      "resourceId": 1257521,
+      "productId": 91
+    },
+    {
+      "product": "Releases",
+      "category": "Releases",
+      "resource": "Visualize Releases",
+      "description": "Consulta la lista de versiones y actualizaciones para cada versión.",
+      "key": "get-release",
+      "resourceId": 1257551,
+      "productId": 91
+    },
+    {
+      "product": "Sales App",
+      "category": "Reports",
+      "resource": "View Sales Performance",
+      "description": "Permite al vendedor ver la página de rendimiento de ventas en la aplicación VTEX Sales relacionada con una operación de punto de venta (tienda física).",
+      "key": "ViewSalesPerformance",
+      "resourceId": 2126563,
+      "productId": 132
+    },
+    {
+      "product": "Search",
+      "category": "Search Settings",
+      "resource": "General Settings",
+      "description": "Editar la configuración general de Intelligent Search.",
+      "key": "general-settings",
+      "resourceId": 719379,
+      "productId": 76
+    },
+    {
+      "product": "Security Monitor",
+      "category": "findings",
+      "resource": "View Findings",
+      "description": "Obtener, enumerar y ver información sobre hallazgos y tipos de hallazgos en Security Monitor.",
+      "key": "ViewFindings",
+      "resourceId": 2000228,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "findings",
+      "resource": "Edit Findings",
+      "description": "Posponer o reactivar alerta para un hallazgo en Security Monitor.",
+      "key": "EditFindings",
+      "resourceId": 2000236,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "notifications settings",
+      "resource": "Edit Notification Settings",
+      "description": "Editar la configuración de los destinatarios de las notificaciones sobre alertas de seguridad en Security Monitor.",
+      "key": "EditNotificationSettings",
+      "resourceId": 2000244,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-read",
+      "resource": "List/Describe reports",
+      "description": "Consulte un informe o una lista de informes en Security Monitor.",
+      "key": "read-reports",
+      "resourceId": 1858423,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-read",
+      "resource": "List/Describe Sensors",
+      "description": "Ver detalles de sensores.",
+      "key": "read-sensors",
+      "resourceId": 1880664,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-read",
+      "resource": "Read Notifications Settings",
+      "description": "Lea la configuración de notificaciones del Monitor de seguridad.",
+      "key": "read-notifications-settings",
+      "resourceId": 1980709,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-write",
+      "resource": "Create Reports",
+      "description": "Cree nuevos informes en Security Monitor.",
+      "key": "write-reports",
+      "resourceId": 1858424,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-write",
+      "resource": "Update Sensors",
+      "description": "Habilitar o deshabilitar sensores en el Monitor de seguridad.",
+      "key": "update-sensors",
+      "resourceId": 1880649,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-write",
+      "resource": "Write Notifications Settings",
+      "description": "Editar la configuración de notificaciones del Monitor de seguridad.",
+      "key": "write-notifications-settings",
+      "resourceId": 1980710,
+      "productId": 103
+    },
+    {
+      "product": "Seller Register",
+      "category": "Seller Administration",
+      "resource": "View Seller",
+      "description": "Podrá ver todos los vendedores vinculados a la cuenta de la plataforma descrita en la página de Gestión de vendedores, incluyendo la posibilidad de recuperar datos de los vendedores, ya sea de la lista de vendedores o de un vendedor específico.",
+      "key": "view-seller",
+      "resourceId": 575457,
+      "productId": 73
+    },
+    {
+      "product": "Seller Register",
+      "category": "Seller Administration",
+      "resource": "Save Seller",
+      "description": "Crea nuevos vendedores y edita los datos de todos los vendedores vinculados a la cuenta del marketplace desde la página de Gestión de vendedores.",
+      "key": "save-seller",
+      "resourceId": 575458,
+      "productId": 73
+    },
+    {
+      "product": "Subscriptions",
+      "category": "ApplicationAccess",
+      "resource": "Subscription view only",
+      "description": "Ver datos de suscripción de la tienda.",
+      "key": "SubscriptionViewer",
+      "resourceId": 592030,
+      "productId": ""
+    },
+    {
+      "product": "Subscriptions",
+      "category": "ApplicationAccess",
+      "resource": "Subscription admin",
+      "description": "Acción y vista del Admin de subscripciones. Acces al botón de prueba novamente.",
+      "key": "SubscriptionAdmin",
+      "resourceId": 592031,
+      "productId": ""
+    },
+    {
+      "product": "Subscriptions",
+      "category": "ApplicationAccess",
+      "resource": "Subscription view and edit",
+      "description": "Visualización y edición de firmas.",
+      "key": "SubscriptionManager",
+      "resourceId": 592033,
+      "productId": ""
+    },
+    {
+      "product": "Subscriptions",
+      "category": "ApplicationAccess",
+      "resource": "Subscription metrics and reports",
+      "description": "Consulta las métricas y los informes en el panel de suscripción.",
+      "key": "SubscriptionMetrics",
+      "resourceId": 592032,
+      "productId": ""
+    },
+    {
+      "product": "Suggestion",
+      "category": "Suggestion Resources",
+      "resource": "Main Access",
+      "description": "Acceso sin restricciones a todos los componentes de la página de SKU recibidos, incluyendo la visualización de los datos de la página y las acciones de aprobación de anuncios. Para obtener más información, consulte [Catalogación de SKU recibidos](https://help.vtex.com/pt/tutorial/sugerindo-e-aprovando-skus/).",
+      "key": "suggestions",
+      "resourceId": 109448,
+      "productId": 50
+    },
+    {
+      "product": "User Rights",
+      "category": "applications",
+      "resource": "Read Applications",
+      "description": "Visualice las operaciones en las aplicaciones de derechos de usuario, ya sea en vista de lista o en vista detallada.",
+      "key": "applications_read",
+      "resourceId": 1634515,
+      "productId": ""
+    },
+    {
+      "product": "User Rights",
+      "category": "applications",
+      "resource": "Write Applications",
+      "description": "Crear, actualizar o eliminar solicitudes de derechos de usuario.",
+      "key": "applications_write",
+      "resourceId": 1634523,
+      "productId": ""
+    },
+    {
+      "product": "User Rights",
+      "category": "user-rights-request",
+      "resource": "Read user rights requests",
+      "description": "Consulte las solicitudes de derechos de usuario, ya sea en formato de lista o en formato detallado.",
+      "key": "user_rights_request_read",
+      "resourceId": 1634546,
+      "productId": 99
+    },
+    {
+      "product": "User Rights",
+      "category": "user-rights-request",
+      "resource": "Write user rights requests",
+      "description": "Crear, actualizar o eliminar solicitudes de derechos de usuario.",
+      "key": "user_rights_request_write",
+      "resourceId": 1634554,
+      "productId": 99
+    },
+    {
+      "product": "User Rights",
+      "category": "user-rights-request",
+      "resource": "Process User Rights Removal Request",
+      "description": "Tramitar las solicitudes de derechos de usuario de tipo eliminación.",
+      "key": "removal-request-process",
+      "resourceId": 1705138,
+      "productId": 99
+    },
+    {
+      "product": "VTEX Ad Network",
+      "category": "Advertisers",
+      "resource": "View Advertiser's details",
+      "description": "Ver informaciones de un anunciante relacionada con VTEX Ad Network.",
+      "key": "view-advertiser-details",
+      "resourceId": 2012197,
+      "productId": 106
+    },
+    {
+      "product": "VTEX Ad Network",
+      "category": "Advertisers",
+      "resource": "View Advertiser's campaigns",
+      "description": "Ver informaciones de la campaña de un anunciante de VTEX Ad Network.",
+      "key": "view-advertiser-campaigns",
+      "resourceId": 2012200,
+      "productId": 106
+    },
+    {
+      "product": "VTEX Ad Network",
+      "category": "Advertisers",
+      "resource": "Edit Advertiser's campaigns",
+      "description": "Editar informaciones de campañas de un anunciante de VTEX Ad Network.",
+      "key": "edit-advertiser-campaigns",
+      "resourceId": 2012201,
+      "productId": 106
+    },
+    {
+      "product": "VTEX Ad Network",
+      "category": "Publishers",
+      "resource": "View Publisher's details",
+      "description": "Ver información del retailer sobre la entrega de anuncios de VTEX Ad Network.",
+      "key": "view-publisher-details",
+      "resourceId": 2012196,
+      "productId": 106
+    },
+    {
+      "product": "VTEX Bridge",
+      "category": "Items",
+      "resource": "List Itens",
+      "description": "Visualización de documentos del puente.",
+      "key": "listItems",
+      "resourceId": 106704,
+      "productId": 48
+    },
+    {
+      "product": "VTEX Bridge",
+      "category": "Items",
+      "resource": "Execute Actions",
+      "description": "Realizar acciones sobre un elemento del registro. Por ejemplo, reprocesar el envío de un elemento en particular.",
+      "key": "executeActions",
+      "resourceId": 106965,
+      "productId": 48
+    },
+    {
+      "product": "VTEX Bridge",
+      "category": "Settings",
+      "resource": "View Configs",
+      "description": "Visualización de la configuración de cada integración.",
+      "key": "viewConfig",
+      "resourceId": 106706,
+      "productId": 48
+    },
+    {
+      "product": "VTEX Bridge",
+      "category": "Settings",
+      "resource": "Manage Configs",
+      "description": "Edita la configuración de una integración.",
+      "key": "editConfig",
+      "resourceId": 106707,
+      "productId": 48
+    },
+    {
+      "product": "VTEX IO",
+      "category": "A/B Test",
+      "resource": "Manage A/B Test",
+      "description": "Iniciar, finalizar u obtener el estado de una prueba A/B.",
+      "key": "manage-abtest",
+      "resourceId": 664798,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Read Workspace Apps",
+      "description": "Lectura de las aplicaciones instaladas en el espacio de trabajo y sus dependencias.",
+      "key": "read-workspace-apps",
+      "resourceId": 253175,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Link App",
+      "description": "Vincular y desvincular aplicaciones, así como listar los enlaces existentes dentro de una aplicación determinada.",
+      "key": "link-app",
+      "resourceId": 253206,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Install App",
+      "description": "Instalación y desinstalación de aplicaciones sin opciones de facturación.",
+      "key": "install-apps",
+      "resourceId": 253207,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Vbase Read Only",
+      "description": "VBase de solo lectura.",
+      "key": "vbase-read-only",
+      "resourceId": 253582,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Vbase Read Write",
+      "description": "Lectura y escritura en VBase.",
+      "key": "vbase-read-write",
+      "resourceId": 253583,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Read Workspace Services",
+      "description": "Lectura de la infraestructura de las aplicaciones instaladas en el escritorio.",
+      "key": "read-workspace-services",
+      "resourceId": 257862,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Install Service",
+      "description": "Instalación y desinstalación de servicios de infraestructura.",
+      "key": "install-services",
+      "resourceId": 257864,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Log Access - Read-only",
+      "description": "Leyendo los registros de todas las aplicaciones.",
+      "key": "colossus-read-logs",
+      "resourceId": 259184,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Read Published Service",
+      "description": "Lectura de datos procedentes de los servicios de registro de infraestructura.",
+      "key": "read-infra-service",
+      "resourceId": 259251,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Debug App",
+      "description": "Conecta un depurador a una aplicación vinculada.",
+      "key": "debug-app",
+      "resourceId": 377794,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Workspace CRUD",
+      "description": "Creación, eliminación y modificación de espacios de trabajo.",
+      "key": "workspace-read-write",
+      "resourceId": 379639,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Buy App",
+      "description": "Instalación y desinstalación de todo tipo de aplicaciones, incluidas aquellas con opciones de facturación.",
+      "key": "buy-app",
+      "resourceId": 382623,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Import Redirects",
+      "description": "Gestione las redirecciones mediante la interfaz de línea de comandos de VTEX IO.",
+      "key": "import-redirects",
+      "resourceId": 661667,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Workspace Manipulation",
+      "description": "Crear, modificar y eliminar un espacio de trabajo.",
+      "key": "workspace-read-write-v2",
+      "resourceId": 794788,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Workspace Promotion",
+      "description": "Para promover un espacio de trabajo.",
+      "key": "workspace-promote",
+      "resourceId": 794789,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Read Edition",
+      "description": "Leer la versión editada de una cuenta o espacio de trabajo.",
+      "key": "read-edition",
+      "resourceId": 797718,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Allow APP configuration",
+      "description": "Configurar aplicaciones.",
+      "key": "read-write-apps-settings",
+      "resourceId": 808001,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Change sponsored tenant edition",
+      "description": "Defina la edición de un inquilino que está patrocinado por la cuenta donde se otorga este permiso.",
+      "key": "change-edition-of-sponsored-tenant",
+      "resourceId": 945388,
+      "productId": 66
+    },
+    {
+      "product": "VTEX Support",
+      "category": "Ticket",
+      "resource": "Open Support Ticket",
+      "description": "Abrir un ticket de soporte para VTEX. Solo válido para cuentas en Brasil.",
+      "key": "open-support-ticket",
+      "resourceId": 1945378,
+      "productId": 104
+    },
+    {
+      "product": "VTable",
+      "category": "VTable",
+      "resource": "View apps",
+      "description": "Visualización de la aplicación VTable.",
+      "key": "view-apps",
+      "resourceId": 257872,
+      "productId": 67
+    },
+    {
+      "product": "VTable",
+      "category": "VTable",
+      "resource": "Main access",
+      "description": "Punto de acceso principal de la VTable.",
+      "key": "main_access_old",
+      "resourceId": 258007,
+      "productId": 67
+    },
+    {
+      "product": "Vtex ID",
+      "category": "Identity Providers",
+      "resource": "Write Identity Providers",
+      "description": "Cree y actualice los proveedores de identidad (administrador y tienda web) para una cuenta.",
+      "key": "write_identity_providers",
+      "resourceId": 631952,
+      "productId": 64
+    },
+    {
+      "product": "Vtex ID",
+      "category": "Identity Providers",
+      "resource": "Read Identity Providers",
+      "description": "Lee los proveedores de identidad (administrador y tienda web) de una cuenta.",
+      "key": "read_identity_providers",
+      "resourceId": 631953,
+      "productId": 64
+    },
+    {
+      "product": "Vtex ID",
+      "category": "Identity Providers",
+      "resource": "Can Punchout",
+      "description": "Permitir que las claves API autentiquen a los usuarios mediante Punchout.",
+      "key": "CanPunchout",
+      "resourceId": 2074726,
+      "productId": 64
+    },
+    {
+      "product": "Vtex ID",
+      "category": "User Management",
+      "resource": "Expire User Password",
+      "description": "Defina la contraseña de un usuario como nulo.",
+      "key": "expire_user_password",
+      "resourceId": 1844857,
+      "productId": 64
+    },
+    {
+      "product": "Vtex ID",
+      "category": "User Management",
+      "resource": "Create User",
+      "description": "Crea un usuario de interfaz.",
+      "key": "CreateUser",
+      "resourceId": 2117393,
+      "productId": 64
+    },
+    {
+      "product": "WebService",
+      "category": "Web service",
+      "resource": "Webservice access",
+      "description": "Cree, edite y elimine información del catálogo mediante el servicio web.",
+      "key": "orders",
+      "resourceId": 136106,
+      "productId": 61
+    }
+  ],
+  "pt": [
+    {
+      "product": "Application Logs Stream",
+      "category": "Logs",
+      "resource": "Read logs stream",
+      "description": "Ler registros de aplicativos VTEX IO pertencentes a esta conta.",
+      "key": "read_logs",
+      "resourceId": 728560,
+      "productId": 81
+    },
+    {
+      "product": "Audit",
+      "category": "General",
+      "resource": "Save Event",
+      "description": "Salvar eventos de auditoria.",
+      "key": "SaveEvent",
+      "resourceId": 1353337,
+      "productId": 55
+    },
+    {
+      "product": "B2B",
+      "category": "B2B General",
+      "resource": "B2BBulkExport",
+      "description": "Permite que as lojas B2B exportem seus dados em massa para arquivos.",
+      "key": "B2BBulkExport",
+      "resourceId": 2045795,
+      "productId": 105
+    },
+    {
+      "product": "B2B",
+      "category": "Import",
+      "resource": "B2BBulkImport",
+      "description": "Permite que as lojas B2B importem em massa várias organizações compradoras para a solução VTEX B2B.",
+      "key": "B2BBulkImport",
+      "resourceId": 1954299,
+      "productId": 105
+    },
+    {
+      "product": "B2B",
+      "category": "Import",
+      "resource": "BulkImportTest",
+      "description": "Permite que as lojas B2B importem em massa várias organizações compradoras para a solução VTEX B2B.",
+      "key": "BulkImportTest",
+      "resourceId": 1957237,
+      "productId": 105
+    },
+    {
+      "product": "Billing",
+      "category": "Company",
+      "resource": "Edit Company Information",
+      "description": "Editar as informações de registro de um cliente, são elas: razão social, nome fantasia, branch, sales region, tier, status de cobrança e endereço.",
+      "key": "edit_company",
+      "resourceId": 118281,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Company",
+      "resource": "Display Company info",
+      "description": "Visualizar as informações de registro de um cliente, são elas: razão social, nome fantasia, branch, sales region, tier, status de cobrança e endereço.",
+      "key": "get_company",
+      "resourceId": 118283,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Company",
+      "resource": "Edit Company's Document",
+      "description": "Editar documentos e informações da company.",
+      "key": "edit_companys_document",
+      "resourceId": 131970,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Company",
+      "resource": "Merge companies",
+      "description": "Realizar a fusão de dois accounts, de forma que todas as informações de faturas e contratos de um account são transferidas para o outro account.",
+      "key": "company_merge",
+      "resourceId": 277452,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Company",
+      "resource": "Split companies",
+      "description": "Separar dois accounts, sendo que informações de faturas e contratos são registradas em um deles, e outro fica nulo.",
+      "key": "company_split",
+      "resourceId": 277453,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Contacts",
+      "resource": "Contacts List ",
+      "description": "Visualizar quais são os contatos que recebem notificação por email quando uma fatura de determinado cliente é gerada.",
+      "key": "list_contacts",
+      "resourceId": 118284,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Contacts",
+      "resource": "Edit Contacts",
+      "description": "Adicionar ou editar um contato.",
+      "key": "edit_contact",
+      "resourceId": 118285,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Contracts",
+      "resource": "Contracts List ",
+      "description": "Visualizar contratos e condições de cobrança cadastrados no módulo Faturas da plataforma VTEX.",
+      "key": "list_contracts",
+      "resourceId": 118282,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Contracts",
+      "resource": "Save contracts",
+      "description": "Editar contratos no módulo Faturas da plataforma VTEX, incluindo o cadastro de manifesto de qualquer valor e cobrança de take rate em qualquer percentual.",
+      "key": "put_contract",
+      "resourceId": 134738,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Invoices List ",
+      "description": "Visualização da listagem de faturas do cliente, bem como o detalhamento da fatura, que inclui informações como GMV e take rate.",
+      "key": "list_invoices",
+      "resourceId": 105015,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Generate new Invoice",
+      "description": "Criar a fatura para um cliente, mas somente quando um contrato já está criado e tem um valor definido. O recurso não autoriza o usuário definir o valor da fatura.",
+      "key": "put_invoices",
+      "resourceId": 120233,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Cancel Invoice Document",
+      "description": "Cancelar o documento fiscal gerado pelo emissor.",
+      "key": "cancel_nfe",
+      "resourceId": 134739,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Issue Invoice Document",
+      "description": "Gerar o documento fiscal, mas somente no emissor.",
+      "key": "issue_nfe",
+      "resourceId": 134740,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Invoice reconciliation",
+      "description": "Informar ao sistema a data e valor pago de uma fatura.",
+      "key": "conciliate_invoice",
+      "resourceId": 134741,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Generate Invoice for overdue payment without added interest fees",
+      "description": "Alterar a data de vencimento de uma fatura, sem o acréscimo de multa e juros padrão.",
+      "key": "generate_invoice_overdue_without_interest",
+      "resourceId": 134743,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Cancel Invoice",
+      "description": "Cancelamento de uma fatura no módulo Faturas da plataforma VTEX e no emissor.",
+      "key": "cancel_invoice",
+      "resourceId": 134744,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Change payment status",
+      "description": "Alterar o status de pagamento da company para: Alert, Blocked, Timer ou Ok.",
+      "key": "set_paymentstatus",
+      "resourceId": 138192,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Unpaid invoices",
+      "description": "Resetar uma fatura para o status \"opened\". Anula a data de pagamento e o valor pago.",
+      "key": "unpaid_invoices",
+      "resourceId": 525925,
+      "productId": 43
+    },
+    {
+      "product": "Billing",
+      "category": "Invoice",
+      "resource": "Simulate Invoices Creation",
+      "description": "Simular faturas, sem de fato criá-las.",
+      "key": "simulate_invoices",
+      "resourceId": 1362361,
+      "productId": 43
+    },
+    {
+      "product": "Buyer Organizations",
+      "category": "Management",
+      "resource": "Buyer Organization View",
+      "description": "Visualizar a lista de organizações de compras.",
+      "key": "buyer_organization_view",
+      "resourceId": 1522234,
+      "productId": 97
+    },
+    {
+      "product": "Buyer Organizations",
+      "category": "Management",
+      "resource": "Buyer Organization Edit",
+      "description": "Criar ou editar organizações de compras.",
+      "key": "buyer_organization_edit",
+      "resourceId": 1522235,
+      "productId": 97
+    },
+    {
+      "product": "CDN API",
+      "category": "Certificate management",
+      "resource": "View certificate",
+      "description": "Visualizar os detalhes dos certificados CDN.",
+      "key": "ViewCertificate",
+      "resourceId": 2022646,
+      "productId": 108
+    },
+    {
+      "product": "CDN API",
+      "category": "Certificate management",
+      "resource": "Update certificate",
+      "description": "Substituir os certificados CDN existentes.",
+      "key": "UpdateCertificate",
+      "resourceId": 2022647,
+      "productId": 108
+    },
+    {
+      "product": "CDN API",
+      "category": "WAF Control",
+      "resource": "View WafControl Metrics",
+      "description": "Visualizar métricas do WAF.",
+      "key": "ViewWafControlMetrics",
+      "resourceId": 2142573,
+      "productId": 108
+    },
+    {
+      "product": "CDN Service",
+      "category": "Domain Management",
+      "resource": "Query status of domains",
+      "description": "Permite ao usuário consultar o status dos domínios da loja em produção.",
+      "key": "query-domain",
+      "resourceId": 1271517,
+      "productId": 84
+    },
+    {
+      "product": "CMS",
+      "category": "cms",
+      "resource": "See CMS menu on the top-bar",
+      "description": "Ver o menu do CMS na barra superior.",
+      "key": "topbar_visualizar",
+      "resourceId": 111439,
+      "productId": 38
+    },
+    {
+      "product": "CMS",
+      "category": "cms",
+      "resource": "Settings",
+      "description": "Editar configurações do CMS.",
+      "key": "cms_settings",
+      "resourceId": 1434680,
+      "productId": 38
+    },
+    {
+      "product": "CMS",
+      "category": "GraphQL",
+      "resource": "CMS GraphQL API",
+      "description": "Usar a API CMS GraphQL da VTEX IO.",
+      "key": "access-cms-graphql-api",
+      "resourceId": 1032772,
+      "productId": 38
+    },
+    {
+      "product": "CMS",
+      "category": "GraphQL",
+      "resource": "Read CMS GraphQL API",
+      "description": "Concede acesso somente de leitura à API GraphQL do CMS do VTEX IO.",
+      "key": "read-cms-graphql-api",
+      "resourceId": 2143073,
+      "productId": 38
+    },
+    {
+      "product": "Catalog",
+      "category": "Admin",
+      "resource": "Admin list",
+      "description": "Lista os administradores do sistema",
+      "key": "Administrador.aspx",
+      "resourceId": 882,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Admin",
+      "resource": "Homepage",
+      "description": "Página Inicial",
+      "key": "Home.aspx",
+      "resourceId": 1047,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Admin",
+      "resource": "Help page",
+      "description": "Página inicial de ajuda",
+      "key": "Help.aspx",
+      "resourceId": 1048,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Collection",
+      "resource": "Read Collections",
+      "description": "Permite visualizar coleções",
+      "key": "collections-read",
+      "resourceId": 627875,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Collection",
+      "resource": "Write Collections",
+      "description": "Permite criar uma nova coleção de produtos",
+      "key": "collections-write",
+      "resourceId": 627876,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "Expert Reviews Management",
+      "description": "Formulário de cadastro de opinião de especialistas",
+      "key": "EspecialistaOpiniaoForm.aspx",
+      "resourceId": 928,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "Similar product category",
+      "description": "Adicionar uma categoria similar ao produto",
+      "key": "ProdutoCategoriaSimilar.aspx",
+      "resourceId": 981,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "Similar category product management",
+      "description": "Cadastro de produto categoria similar",
+      "key": "ProdutoCategoriaSimilarForm.aspx",
+      "resourceId": 982,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "SKU management",
+      "description": "Formulário de cadastro de sku",
+      "key": "SkuForm.aspx",
+      "resourceId": 1001,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "SKU Services",
+      "description": "Serviços de SKU",
+      "key": "SkuServicoForm.aspx",
+      "resourceId": 1004,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "Prices for SKU Services",
+      "description": "Lista de valores de serviços SKU",
+      "key": "SkuServicoValor.aspx",
+      "resourceId": 1005,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "SKU service price management",
+      "description": "Formulário para cadastro de valor para serviço SKU",
+      "key": "SkuServicoValorForm.aspx",
+      "resourceId": 1006,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "Commercial condition",
+      "description": "Definição das políticas comerciais",
+      "key": "SkuCondicaoComercial.aspx",
+      "resourceId": 1019,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Commercial",
+      "resource": "SKU type management",
+      "description": "Formulário para cadastro de tipos de serviços de SKU",
+      "key": "SkuServicoTipo.aspx",
+      "resourceId": 1045,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "Configuration Management",
+      "description": "Formulário de cadastro de configuração",
+      "key": "ConfigForm.aspx",
+      "resourceId": 917,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "File types list",
+      "description": "Lista de tipos de arquivos",
+      "key": "TipoArquivo.aspx",
+      "resourceId": 1009,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "File types management",
+      "description": "Formulário para cadastro de tamanhos padrão de imagem e demais arquivos",
+      "key": "TipoArquivoForm.aspx",
+      "resourceId": 1010,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "Store Texts",
+      "description": "Ferramenta do desenvolvedor com todos os textos base da loja",
+      "key": "TextoSite.aspx",
+      "resourceId": 1034,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "CMS Management",
+      "description": "Configurações do CMS (Portal)",
+      "key": "PortalManagement",
+      "resourceId": 1202,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "SEO Configurations",
+      "description": "Configurações de Conteudos SEO (Robots.txt)",
+      "key": "ConfigSEOContents.aspx",
+      "resourceId": 1222,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "Gift Registry Types List",
+      "description": "Listagem de Tipos de Listas",
+      "key": "GiftListType.aspx",
+      "resourceId": 1631,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "Gift Registry Lists Management",
+      "description": "Formulário de criação e edição de tipos de lista (GiftList)",
+      "key": "GiftListTypeForm.aspx",
+      "resourceId": 1633,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "Geographic Region Management",
+      "description": "Gerenciar a página de listagem de regiões geográficas.",
+      "key": "GeographicRegion.aspx",
+      "resourceId": 2138652,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "Geographic Region Form",
+      "description": "Gerenciar o formulário de criação e edição de regiões geográficas.",
+      "key": "GeographicRegionForm.aspx",
+      "resourceId": 2138653,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "StoreForm.aspx",
+      "description": "Visualizar a tela de detalhes de políticas comerciais.",
+      "key": "StoreForm.aspx",
+      "resourceId": 2142219,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Configuration",
+      "resource": "InsertOrUpdateStoreForm.aspx",
+      "description": "Criar e alterar políticas comerciais (sujeito à cobrança recorrente).",
+      "key": "InsertOrUpdateStoreForm.aspx",
+      "resourceId": 2142347,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Product management",
+      "description": "Visualizar a tela de cadastro e alteração de produto",
+      "key": "ProdutoForm.aspx",
+      "resourceId": 873,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Product Form",
+      "description": "Acesso à tela do produto",
+      "key": "Produto.aspx",
+      "resourceId": 874,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Change SKU Pricing",
+      "description": "Alterar preços de SKUs",
+      "key": "AlterarPrecoSku",
+      "resourceId": 877,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "SKU images management",
+      "description": "Inserir e alterar imagens de SKU",
+      "key": "ManterImagemProdutoSku",
+      "resourceId": 880,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Product and SKU Management",
+      "description": "Alteração e inclusão de produto e SKU",
+      "key": "ManterFormularioProdutoSku",
+      "resourceId": 881,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Reviews list",
+      "description": "Lista todas as avaliações",
+      "key": "Avaliacao.aspx",
+      "resourceId": 885,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Reviews management",
+      "description": "Formulário de cadastro de avaliação",
+      "key": "AvaliacaoForm.aspx",
+      "resourceId": 886,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Fields list",
+      "description": "Lista todos os campos do sistema",
+      "key": "Campo.aspx",
+      "resourceId": 891,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Attributes Management",
+      "description": "Formulário para cadastro de campos",
+      "key": "CampoForm.aspx",
+      "resourceId": 896,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Value fields list",
+      "description": "Lista de valores de um campo",
+      "key": "CampoValor.aspx",
+      "resourceId": 897,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Attribute values management",
+      "description": "Formulário de cadastro de um campo",
+      "key": "CampoValorForm.aspx",
+      "resourceId": 898,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Category ",
+      "description": "Lista todas as categorias",
+      "key": "Categoria.aspx",
+      "resourceId": 899,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Categories Management",
+      "description": "Formulário de cadastro de categoria",
+      "key": "CategoriaForm.aspx",
+      "resourceId": 900,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Similar Category ",
+      "description": "Lista todas as categorias similares",
+      "key": "CategoriaSimilar.aspx",
+      "resourceId": 901,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Similar Categories Management",
+      "description": "Formulário de categorias similares",
+      "key": "CategoriaSimilarForm.aspx",
+      "resourceId": 902,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Price range",
+      "description": "Lista todas as faixas de preços",
+      "key": "FaixaPreco.aspx",
+      "resourceId": 933,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Price Range Management",
+      "description": "Formulário para cadastro de preços",
+      "key": "FaixaPrecoForm.aspx",
+      "resourceId": 934,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Providers",
+      "description": "Lista os fornecedores cadastrados no sistema",
+      "key": "Fornecedor.aspx",
+      "resourceId": 938,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Supplier management",
+      "description": "Formulário de cadastro de fornecedor",
+      "key": "FornecedorForm.aspx",
+      "resourceId": 939,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Groups",
+      "description": "Lista todos os grupos de categoria",
+      "key": "Grupo.aspx",
+      "resourceId": 944,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Group Management ",
+      "description": "Formulário de cadastro de grupos de categoria",
+      "key": "GrupoForm.aspx",
+      "resourceId": 945,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Brands",
+      "description": "Lista todas as marcas cadastradas",
+      "key": "Marca.aspx",
+      "resourceId": 955,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Brands Management",
+      "description": "Formulário para cadastro de marcas",
+      "key": "MarcaForm.aspx",
+      "resourceId": 956,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "SKUs",
+      "description": "Lista todos os SKUs cadastrados",
+      "key": "Sku.aspx",
+      "resourceId": 996,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Enable Product and SKU",
+      "description": "Ativação de produto e de SKU",
+      "key": "Ativar Produto Sku",
+      "resourceId": 1013,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Category Management",
+      "description": "Verificação de acesso para inclusão ou alteração de nova categoria",
+      "key": "InsertOrUpdateCategoriaFromCategoriaForm.aspx",
+      "resourceId": 1216,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Similar Category Management",
+      "description": "Verificação de acesso para inclusão ou alteração de nova categoria similar",
+      "key": "InsertOrUpdateCategoriaFromCategoriaSimilarForm.aspx",
+      "resourceId": 1217,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Brand Management",
+      "description": "Validação para inserção ou alteração de marca",
+      "key": "InsertOrUpdateMarcaFromMarcaForm.aspx",
+      "resourceId": 1218,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Insert or Update Group",
+      "description": "Inserir ou alterar dentro da grupo de categoria",
+      "key": "InsertOrUpdateGrupoFromGrupoForm.aspx",
+      "resourceId": 1219,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Field validation",
+      "description": "Validação de campo",
+      "key": "InsertOrUpdateCampoFromCampoForm.aspx",
+      "resourceId": 1220,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Content",
+      "resource": "Value field validation",
+      "description": "Validação de campo valor",
+      "key": "InsertOrUpdateCampoValorFromCampoValorForm.aspx",
+      "resourceId": 1221,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketing",
+      "resource": "Buy Together Management",
+      "description": "Formulário de cadastro de compre junto",
+      "key": "CompreJuntoForm.aspx",
+      "resourceId": 915,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketing",
+      "resource": "Reviews",
+      "description": "Banco de avaliações de SKU",
+      "key": "Resenha.aspx",
+      "resourceId": 988,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketing",
+      "resource": "Gift/Refund Vouchers",
+      "description": "Cria Vale Compra",
+      "key": "Vale.aspx",
+      "resourceId": 1016,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketing",
+      "resource": "Product Collections XML",
+      "description": "XML de Coleções",
+      "key": "Xml.aspx",
+      "resourceId": 1026,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketing",
+      "resource": "Tags management",
+      "description": "Controle de Palavras - Tags",
+      "key": "Tag.aspx",
+      "resourceId": 1027,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketplace",
+      "resource": "Sales channels management",
+      "description": "Lista de políticas comerciais",
+      "key": "Store.aspx",
+      "resourceId": 1226,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketplace",
+      "resource": "Sellers",
+      "description": "Lista de Sellers (Lojas)",
+      "key": "Seller.aspx",
+      "resourceId": 1227,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Marketplace",
+      "resource": "Seller SKUs",
+      "description": "Lista SKU Sellers",
+      "key": "SkuSeller.aspx",
+      "resourceId": 1229,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Miscellaneous",
+      "resource": "SKU Bundles",
+      "description": "Interface dos Kits com os SKUs",
+      "key": "SkuKit.aspx",
+      "resourceId": 1002,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Miscellaneous",
+      "resource": "Product Bundle Management",
+      "description": "Formulário para cadastro de kits",
+      "key": "SkuKitForm.aspx",
+      "resourceId": 1003,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "News Report",
+      "description": "Relatório de Newsletter",
+      "key": "RelatorioNews.aspx",
+      "resourceId": 1020,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "SKUs Report",
+      "description": "Relatório SKUs",
+      "key": "Relatorio_Skus.aspx",
+      "resourceId": 1022,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "Out of stock notification",
+      "description": "Relatório Solicitação de Avise-Me",
+      "key": "Relatorio_AviseMeSku.aspx",
+      "resourceId": 1025,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "Full-text Search",
+      "description": "Relatório de buscas Full-text",
+      "key": "RelatorioFullText.aspx",
+      "resourceId": 1028,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "Security Monitoring",
+      "description": "Monitoramento de Segurança",
+      "key": "Relatorio_Seguranca.aspx",
+      "resourceId": 1031,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "Gift Registry List",
+      "description": "Ver todas as listas (GiftList)",
+      "key": "GiftList.aspx",
+      "resourceId": 1632,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Reports",
+      "resource": "Assisted Sales Gift Registry List Management",
+      "description": "Permite ao administrador gerenciar listas de um usuário no Site, como se fosse o próprio.",
+      "key": "GiftListImpersonation",
+      "resourceId": 1634,
+      "productId": 2
+    },
+    {
+      "product": "Catalog",
+      "category": "Telesales",
+      "resource": "Assisted Sales",
+      "description": "Funcionalidades de televendas. Após o login, o usuário é redirecionado para o site de televendas www.{nomedaloja}.com.br/a/televendas. Dessa forma, o operador pode utilizar as funcionalidades de televendas, como navegar na loja em nome do cliente. Como este recurso causa o redirecionamento automático para a loja, o usuário que fizer login em uma conta com esse perfil não terá acesso a recursos importantes do Admin. Portanto, recomendamos a utilização de duas contas separadas (com emails distintos) para usuários de televendas: uma conta para o perfil Call center operator (com este recurso e o recurso View order) e outra conta para realizar operações no menu administrativo, se necessário.",
+      "key": "Televendas",
+      "resourceId": 1046,
+      "productId": 2
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "View Product",
+      "description": "Visualizar detalhes de produtos e SKUs.",
+      "key": "ViewProduct",
+      "resourceId": 2017533,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "Edit Product",
+      "description": "Editar detalhes de produtos e SKUs.",
+      "key": "EditProduct",
+      "resourceId": 2038155,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "View Category",
+      "description": "Visualizar detalhes de categorias.",
+      "key": "ViewCategory",
+      "resourceId": 2038156,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "Edit Category",
+      "description": "Editar detalhes de categorias.",
+      "key": "EditCategory",
+      "resourceId": 2038157,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "View Collection",
+      "description": "Visualizar detalhes de coleções.",
+      "key": "ViewCollection",
+      "resourceId": 2038158,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "Edit Collection",
+      "description": "Editar detalhes de coleções.",
+      "key": "EditCollection",
+      "resourceId": 2038159,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "View Brand",
+      "description": "Visualizar detalhes de marcas.",
+      "key": "ViewBrand",
+      "resourceId": 2038160,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "Edit Brand",
+      "description": "Editar detalhes de marcas.",
+      "key": "EditBrand",
+      "resourceId": 2038161,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "Import Spreadsheet",
+      "description": "Importar produtos e SKUs por planilha.",
+      "key": "ImportSpreadsheet",
+      "resourceId": 2038162,
+      "productId": 107
+    },
+    {
+      "product": "Catalog API",
+      "category": "General",
+      "resource": "Export Spreadsheet",
+      "description": "Exportar planilha de informações do catálogo.",
+      "key": "ExportSpreadsheet",
+      "resourceId": 2038163,
+      "productId": 107
+    },
+    {
+      "product": "Channels",
+      "category": "UI resources",
+      "resource": "Send Marketplace Suggestions",
+      "description": "Permite que sellers enviem anúncios ao marketplace, que serão revisados e aprovados pelo marketplace por meio da página SKUs Recebidos ou pela API Match Received SKUs.  ",
+      "key": "EnviaSugestao",
+      "resourceId": 1139,
+      "productId": 13
+    },
+    {
+      "product": "Channels",
+      "category": "UI resources",
+      "resource": "Sellers SKUs List",
+      "description": "Permite que sellers visualizem a lista de SKUs enviados para os marketplaces em que vendem seus produtos. No Admin VTEX, a lista pode ser acessada em MARKETPLACE > Integrações > Produtos. ",
+      "key": "Consulta",
+      "resourceId": 1154,
+      "productId": 13
+    },
+    {
+      "product": "Channels",
+      "category": "UI resources",
+      "resource": "Save Suggestion Rules",
+      "description": "Permite que marketplaces criem e alterem regras do VTEX Matcher para a aprovação de SKUs Recebidos. Essa configuração é feita por meio da API SKU Approval Settings.",
+      "key": "SalvaRegras",
+      "resourceId": 1155,
+      "productId": 13
+    },
+    {
+      "product": "Channels",
+      "category": "UI resources",
+      "resource": "Marketplace seller setup",
+      "description": "Permite associar o seller a um novo marketplace ou alterar uma configuração existente. Sellers incluídos no Seller Portal só poderão ter suas configurações alteradas, mas não associados a mais de um marketplace. Já sellers VTEX podem ser associados a outros marketplaces e terem suas configurações alteradas, ao habilitar esse recurso. Essa ação pode ser feita via Admin VTEX, ou via API Rest.",
+      "key": "ConfiguraSeller",
+      "resourceId": 1156,
+      "productId": 13
+    },
+    {
+      "product": "Channels",
+      "category": "UI resources",
+      "resource": "Access the Marketplace Network",
+      "description": "Crie, edite e liste o perfil da sua loja disponível no Marketplace Network e envie mensagens para outras lojas.",
+      "key": "MarketplaceNetwork",
+      "resourceId": 1107285,
+      "productId": 13
+    },
+    {
+      "product": "Checkout",
+      "category": "CheckoutResources",
+      "resource": "Shopping Cart Full Access",
+      "description": "Leitura e escrita para todos os carrinhos de compras. Permite que os dados do carrinho venham abertos (não mascarados). Permite também requisição privada de simulação de carrinho.",
+      "key": "AcessaTodosCarrinhos",
+      "resourceId": 1091,
+      "productId": 5
+    },
+    {
+      "product": "Checkout",
+      "category": "CheckoutResources",
+      "resource": "Orders Full Access",
+      "description": "Leitura e escrita para todos os pedidos via API do Checkout. Não permite acesso a pedidos pelo fluxo do módulo de gerenciamento de pedidos.",
+      "key": "AcessaTodosPedidos",
+      "resourceId": 1092,
+      "productId": 5
+    },
+    {
+      "product": "Checkout",
+      "category": "CheckoutResources",
+      "resource": "Save Order Configuration",
+      "description": "Salvar configuração de pedidos.",
+      "key": "SaveOrderConfiguration",
+      "resourceId": 600072,
+      "productId": 5
+    },
+    {
+      "product": "Checkout",
+      "category": "CheckoutResources",
+      "resource": "Save OrderForm Configuration",
+      "description": "Salvar configuração de carrinhos de compras.",
+      "key": "SaveOrderFormConfiguration",
+      "resourceId": 600073,
+      "productId": 5
+    },
+    {
+      "product": "Checkout",
+      "category": "CheckoutResources",
+      "resource": "Read Shopping Cart",
+      "description": "Leitura e listagem de todos os carrinhos de compras. Não permite acesso a dados de carrinho não mascarados.",
+      "key": "GetOrderForm",
+      "resourceId": 1949421,
+      "productId": 5
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Branch",
+      "resource": "Save to main branch",
+      "description": "Adiciona alterações diretamente na branch main.",
+      "key": "SaveToMainBranch",
+      "resourceId": 2086248,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Branch",
+      "resource": "Remove from main branch",
+      "description": "Remover alterações da branch main.",
+      "key": "RemoveFromMainBranch",
+      "resourceId": 2086250,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Branch",
+      "resource": "Merge branch",
+      "description": "Mescla alterações de uma branch para a main.",
+      "key": "MergeBranch",
+      "resourceId": 2086251,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Branch",
+      "resource": "Delete Branch",
+      "description": "Permite excluir uma branch e todo o conteúdo versionado associado a ela.",
+      "key": "DeleteBranch",
+      "resourceId": 2153203,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Branch",
+      "resource": "Create Branch",
+      "description": "Permite criar uma nova branch para desenvolver, testar e salvar novas versões de conteúdo de forma isolada.",
+      "key": "CreateBranch",
+      "resourceId": 2153204,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Entry",
+      "resource": "Delete entry",
+      "description": "Exclui permanentemente uma entrada de todo o histórico e branches.",
+      "key": "DeleteEntry",
+      "resourceId": 2086249,
+      "productId": 115
+    },
+    {
+      "product": "Commerce Content",
+      "category": "Stores",
+      "resource": "Create Store",
+      "description": "Cria nova loja Commerce Content na conta.",
+      "key": "CreateStore",
+      "resourceId": 2086252,
+      "productId": 115
+    },
+    {
+      "product": "Credit Control",
+      "category": "Checking Accounts",
+      "resource": "Read Checking Accounts",
+      "description": "Visualização de informações de contas.",
+      "key": "read_checkingaccounts",
+      "resourceId": 170921,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Checking Accounts",
+      "resource": "Create Checking Accounts",
+      "description": "Criação de contas.",
+      "key": "create_checkingaccounts",
+      "resourceId": 170929,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Checking Accounts",
+      "resource": "Edit credits",
+      "description": "Alterar o limite de crédito de uma conta.",
+      "key": "edit_credits",
+      "resourceId": 197575,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Invoices",
+      "resource": "Read Invoices",
+      "description": "Visualização de faturas.",
+      "key": "read_invoices",
+      "resourceId": 170930,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Invoices",
+      "resource": "Create Invoices",
+      "description": "Emissão de notas fiscais.",
+      "key": "create_invoices",
+      "resourceId": 170931,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Invoices",
+      "resource": "Pay Invoice",
+      "description": "Pagamento de faturas.",
+      "key": "pay_invoice",
+      "resourceId": 200613,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Main",
+      "resource": "Main Access",
+      "description": "Permite acesso principal",
+      "key": "suggestions",
+      "resourceId": 109448,
+      "productId": 50
+    },
+    {
+      "product": "Credit Control",
+      "category": "Statements",
+      "resource": "Read Statements",
+      "description": "Leitura aos extratos de conta.",
+      "key": "read_statements",
+      "resourceId": 170918,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Statements",
+      "resource": "Create Statements",
+      "description": "Criação de extratos de conta.",
+      "key": "create_statements",
+      "resourceId": 170920,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Store Configuration",
+      "resource": "Edit Configuration",
+      "description": "Alterar as configurações da loja.",
+      "key": "edit_config",
+      "resourceId": 198649,
+      "productId": 58
+    },
+    {
+      "product": "Credit Control",
+      "category": "Store Configuration",
+      "resource": "Read Configuration",
+      "description": "Visualização das configurações da loja.",
+      "key": "read_config",
+      "resourceId": 198650,
+      "productId": 58
+    },
+    {
+      "product": "Delivery Promises",
+      "category": "ProductAvailability",
+      "resource": "Notify Product Availability Change",
+      "description": "Atualizar a disponibilidade de itens de sellers externos no contexto da Delivery Promise.",
+      "key": "NotifyProductAvailabilityChange",
+      "resourceId": 2032871,
+      "productId": 111
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Data entity",
+      "resource": "List data entity",
+      "description": "Listar entidades de dados.",
+      "key": "2_dataentity_list",
+      "resourceId": 69077,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Data entity",
+      "resource": "Create data entity",
+      "description": "Criar entidade de dados.",
+      "key": "1_dataentity_create",
+      "resourceId": 69078,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Data entity",
+      "resource": "Edit schema",
+      "description": "Editar schema.",
+      "key": "1_dataentity_edit",
+      "resourceId": 69079,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Data entity",
+      "resource": "Remove data entity",
+      "description": "Excluir entidade de dados.",
+      "key": "1_dataentity_delete",
+      "resourceId": 69080,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Data entity",
+      "resource": "View data entity details",
+      "description": "Ver detalhes de entidade de dados.",
+      "key": "2_dataentity_view",
+      "resourceId": 69081,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Data entity",
+      "resource": "Publish index",
+      "description": "Publicar índice.",
+      "key": "1_dataentity_publish",
+      "resourceId": 69082,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Dynamic storage generic resources",
+      "resource": "Master Data administrator",
+      "description": "Gerenciar Master Data.",
+      "key": "ADMIN_DS",
+      "resourceId": 69073,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Dynamic storage generic resources",
+      "resource": "Full access to all documents",
+      "description": "Acesso total a todos os documentos.",
+      "key": "POWER_USER_DS",
+      "resourceId": 69074,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Dynamic storage generic resources",
+      "resource": "Insert or update document (not remove)",
+      "description": "Criação e atualização de documentos, mas não remoção.",
+      "key": "NOREMOVE_USER_DS",
+      "resourceId": 69075,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Dynamic storage generic resources",
+      "resource": "Read only documents",
+      "description": "Apenas leitura de documentos.",
+      "key": "READONLY_USER_DS",
+      "resourceId": 69076,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Index",
+      "resource": "List index",
+      "description": "Listar índices.",
+      "key": "1_Index_list",
+      "resourceId": 105916,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Index",
+      "resource": "Create index",
+      "description": "Criar índice.",
+      "key": "1_Index_create",
+      "resourceId": 105917,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Index",
+      "resource": "Edit index",
+      "description": "Editar índice.",
+      "key": "1_Index_edit",
+      "resourceId": 105918,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Index",
+      "resource": "Remove index",
+      "description": "Remover índice.",
+      "key": "1_Index_delete",
+      "resourceId": 105919,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Index",
+      "resource": "View index details",
+      "description": "Ver detalhes do índice.",
+      "key": "1_Index_view",
+      "resourceId": 105920,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Internal-Log",
+      "resource": "List internal logs",
+      "description": "Listar logs internos.",
+      "key": "1_internallog_list",
+      "resourceId": 105921,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "internal-warning",
+      "resource": "List internal alerts",
+      "description": "Listar alertas internos.",
+      "key": "1_internalwarning_list",
+      "resourceId": 106143,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Schemas",
+      "resource": "View detail schema",
+      "description": "Ver detalhes do schema.",
+      "key": "1_dataentity_list",
+      "resourceId": 137232,
+      "productId": ""
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Triggers",
+      "resource": "List trigger",
+      "description": "Listar triggers.",
+      "key": "2_datarule_list",
+      "resourceId": 69083,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Triggers",
+      "resource": "Create trigger",
+      "description": "Criar triggers.",
+      "key": "1_datarule_create",
+      "resourceId": 69084,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Triggers",
+      "resource": "Edit trigger",
+      "description": "Editar triggers.",
+      "key": "1_datarule_edit",
+      "resourceId": 69085,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Triggers",
+      "resource": "Remove trigger",
+      "description": "Excluir triggers.",
+      "key": "1_datarule_delete",
+      "resourceId": 69086,
+      "productId": 25
+    },
+    {
+      "product": "Dynamic Storage",
+      "category": "Triggers",
+      "resource": "View trigger details",
+      "description": "Ver detalhes de triggers.",
+      "key": "2_datarule_view",
+      "resourceId": 69087,
+      "productId": 25
+    },
+    {
+      "product": "FastStore",
+      "category": "Secrets",
+      "resource": "View Secrets",
+      "description": "Permite visualizar os segredos configurados no WebOps.",
+      "key": "ViewSecrets",
+      "resourceId": 2100329,
+      "productId": 129
+    },
+    {
+      "product": "FastStore",
+      "category": "Secrets",
+      "resource": "Edit Secrets",
+      "description": "Permite criar, deletar e editar segredos no WebOps.",
+      "key": "EditSecrets",
+      "resourceId": 2100330,
+      "productId": 129
+    },
+    {
+      "product": "Fraud Prevention",
+      "category": "Transaction Attempts",
+      "resource": "View transaction attempts",
+      "description": "Visualizar tentativas de transações na página Prevenção de Fraudes.",
+      "key": "ViewTransactionAttempts",
+      "resourceId": 2134012,
+      "productId": 127
+    },
+    {
+      "product": "Fraud Prevention",
+      "category": "Transaction Attempts",
+      "resource": "Edit transaction attempt action settings",
+      "description": "Ativar ou desativar ações relacionadas a tentativas de transações na página Prevenção de Fraudes.",
+      "key": "EditTransactionAttemptActionSettings",
+      "resourceId": 2134013,
+      "productId": 127
+    },
+    {
+      "product": "Fraud Prevention",
+      "category": "Transaction Attempts",
+      "resource": "Edit transaction attempt score settings",
+      "description": "Modificar configurações de pontuação para tentativas de transações na página Prevenção de Fraudes.",
+      "key": "EditTransactionAttemptScoreSettings",
+      "resourceId": 2134014,
+      "productId": 127
+    },
+    {
+      "product": "GiftCard",
+      "category": "GiftCard",
+      "resource": "Gift card full access",
+      "description": "Criar e editar todas as funções relacionadas aos cartões-presentes, seus fornecedores e transações.",
+      "key": "GiftCardAdmin",
+      "resourceId": 472959,
+      "productId": 70
+    },
+    {
+      "product": "GiftCard",
+      "category": "GiftCard",
+      "resource": "Gift card viewer",
+      "description": "Leitura para todas as funções do cartões-presentes, seus fornecedores e transações.",
+      "key": "GiftCardReadOnly",
+      "resourceId": 472961,
+      "productId": 70
+    },
+    {
+      "product": "GiftCard",
+      "category": "GiftCard",
+      "resource": "View Gift Cards",
+      "description": "Habilite operações de leitura em cartões-presente e transações.",
+      "key": "view_giftcards",
+      "resourceId": 994855,
+      "productId": 70
+    },
+    {
+      "product": "GiftCard",
+      "category": "GiftCard",
+      "resource": "Edit Gift Cards",
+      "description": "Ative para ler e gravar cartões-presente e transações.",
+      "key": "edit_giftcards",
+      "resourceId": 994919,
+      "productId": 70
+    },
+    {
+      "product": "GiftCard",
+      "category": "GiftCard",
+      "resource": "View Gift Card providers",
+      "description": "Leitura de fornecedores de cartões-presente e seus cartões-presente.",
+      "key": "view_giftcard_providers",
+      "resourceId": 994983,
+      "productId": 70
+    },
+    {
+      "product": "GiftCard",
+      "category": "GiftCard",
+      "resource": "Edit Gift Card providers",
+      "description": "Leitura e edição de fornecedores de cartões-presente e seus cartões-presente.",
+      "key": "edit_giftcard_providers",
+      "resourceId": 994991,
+      "productId": 70
+    },
+    {
+      "product": "Insights",
+      "category": "Analysis",
+      "resource": "Insights Metrics",
+      "description": "Permite visualizar de forma irrestrita todas as métricas e dados presentes nos dashboards do Admin VTEX, incluindo as páginas: Performance de Vendas, Home page do Admin, Insights e Audit.",
+      "key": "view_metrics",
+      "resourceId": 129814,
+      "productId": 57
+    },
+    {
+      "product": "License Manager",
+      "category": "Admin User Management",
+      "resource": "Edit Admin Users",
+      "description": "Permite criar, editar e remover usuários administrativos.",
+      "key": "EditAdminUsers",
+      "resourceId": 2099310,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Admin User Management",
+      "resource": "View Admin Users",
+      "description": "Permite visualizar informações de usuários e perfis de acesso.",
+      "key": "ViewAdminUsers",
+      "resourceId": 2099311,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "API Key Management",
+      "resource": "View API keys",
+      "description": "Visualizar, filtrar, buscar, ordenar e exportar chaves de API geradas e terceiras.",
+      "key": "ViewApiKeys",
+      "resourceId": 2042457,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "API Key Management",
+      "resource": "Edit API keys",
+      "description": "Criar, excluir, mudar o status e adicionar ou remover permissões de chaves de API.",
+      "key": "EditApiKeys",
+      "resourceId": 2042458,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "API Key Management",
+      "resource": "Edit API keys settings",
+      "description": "Modificar configurações relacionadas a chaves de API, como a duração de tokens de chaves geradas.",
+      "key": "EditApiKeysSettings",
+      "resourceId": 2042466,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "API Key Management",
+      "resource": "Renew API Token",
+      "description": "Visualizar e renovar tokens de chaves geradas.",
+      "key": "RenewApiToken",
+      "resourceId": 2042467,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Save account",
+      "description": "Salva uma conta (muda os sites, bindings, hosts, etc. endereço de contato).",
+      "key": "Save_Account",
+      "resourceId": 1057,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get account by identifier",
+      "description": "Consulta que retorna conta pelo identificador, que pode ser o id da conta ou a host ou nome da aplicação da conta.",
+      "key": "Get_Account_By_Identifier",
+      "resourceId": 1064,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Save user",
+      "description": "Criar usuários, atribuir ou remover perfis de acesso para usuários, editar dados de usuários, criar e alterar chaves de aplicação.",
+      "key": "Save_User",
+      "resourceId": 1074,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Remove user",
+      "description": "Revogar acesso de usuários.",
+      "key": "Remove_User",
+      "resourceId": 1075,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Save access profile",
+      "description": "Criar ou modificar um perfil de acesso.",
+      "key": "Create_Role",
+      "resourceId": 1083,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Find account resources",
+      "description": "Listar todos recursos que uma conta tem acesso.",
+      "key": "Get_Resources_By_Account",
+      "resourceId": 1086,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get role",
+      "description": "Listar os recursos associados a um ID de perfil de acesso e os usuários associados a esse perfil de acesso.",
+      "key": "Get_Role",
+      "resourceId": 1088,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get paged roles",
+      "description": "Listar todos os perfis de acesso de uma conta.",
+      "key": "Get_Roles_Paged",
+      "resourceId": 1178,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get paged users",
+      "description": "Listar todos os usuários administrativos de uma conta.",
+      "key": "Get_Users_Paged",
+      "resourceId": 1179,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Upload account logo",
+      "description": "Acesso ao upload da imagem do logotipo da conta.",
+      "key": "Upload_Logo",
+      "resourceId": 1183,
+      "productId": 1
+    },
+    {
+      "product": "License Manager",
+      "category": "Services access control",
+      "resource": "Get account by host",
+      "description": "[Interno] Retorna todos os hosts autorizados de uma conta e hosts de contas que ele autorizou",
+      "key": "Get_Hosts_By_Account",
+      "resourceId": 1210,
+      "productId": 1
+    },
+    {
+      "product": "Live Shopping",
+      "category": "General",
+      "resource": "view_live_shopping",
+      "description": "Destinado a usuários convidados no aplicativo Live Shopping, como influenciadores, que não necessitam de acesso às informações da conta.",
+      "key": "view_live_shopping",
+      "resourceId": 1532000,
+      "productId": 98
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Logistics full access",
+      "description": "Acesso pleno a todos os recursos de logística (visualização, criação, edição e cancelamento de configurações).",
+      "key": "LogisticsAdmin",
+      "resourceId": 1158,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Logistics viewer",
+      "description": "Visualização da área inicial do módulo de logistica. ",
+      "key": "LogisticsViewer",
+      "resourceId": 1926,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Logistics inventory full access",
+      "description": "Acesso pleno ao inventário logístico (visualização, criação, edição e cancelamento de configurações).",
+      "key": "InventoryAdmin",
+      "resourceId": 475811,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Logistics inventory read only",
+      "description": "Visualizar módulo de inventário.",
+      "key": "InventoryViewer",
+      "resourceId": 475812,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Logistics shipping full access",
+      "description": "Acesso pleno a todas as funções de envio do módulo de logística (criação, edição e cancelamento de configurações). ",
+      "key": "ShippingAdmin",
+      "resourceId": 475813,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Request Logistics Reports",
+      "description": "Solicitar relatórios de logística.",
+      "key": "RequestLogisticsReports",
+      "resourceId": 881768,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Transportation full access",
+      "description": "Acesso total ao transporte.",
+      "key": "TransportationAdmin",
+      "resourceId": 885164,
+      "productId": 9
+    },
+    {
+      "product": "Logistics",
+      "category": "Logistics access",
+      "resource": "Transportation read only",
+      "description": "Visualizar pedidos, pacotes e etiquetas de envio do VTEX Shipping Network.",
+      "key": "TransportationViewer",
+      "resourceId": 1881967,
+      "productId": 9
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "List Applications",
+      "description": "Listar aplicações.",
+      "key": "1_application_list",
+      "resourceId": 52286,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "Create Applications",
+      "description": "Criar aplicações.",
+      "key": "1_application_create",
+      "resourceId": 52287,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "Edit Applications",
+      "description": "Editar aplicações.",
+      "key": "1_application_edit",
+      "resourceId": 52288,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "Remove Applications",
+      "description": "Excluir aplicações.",
+      "key": "1_application_delete",
+      "resourceId": 52289,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "Create custom search",
+      "description": "Criar busca customizada.",
+      "key": "3_application_searchcreate",
+      "resourceId": 52290,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "Allow data export",
+      "description": "Exportação de dados.",
+      "key": "3_application_export",
+      "resourceId": 52291,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Application",
+      "resource": "View logs",
+      "description": "Visualização de logs.",
+      "key": "4_application_logview",
+      "resourceId": 52292,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Comment",
+      "resource": "List Comments",
+      "description": "Listar comentários.",
+      "key": "1_commentmanager_list",
+      "resourceId": 52293,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Comment",
+      "resource": "Remove Comment",
+      "description": "Excluir comentários.",
+      "key": "1_commentmanager_delete",
+      "resourceId": 52294,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Customized Search",
+      "resource": "List Custom Search",
+      "description": "Listar busca customizada.",
+      "key": "1_customsearch_list",
+      "resourceId": 52295,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Customized Search",
+      "resource": "Exclude Custom Search",
+      "description": "Remover busca customizada.",
+      "key": "1_customsearch_delete",
+      "resourceId": 52296,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Form",
+      "resource": "List Forms",
+      "description": "Listar formulários.",
+      "key": "1_form_list",
+      "resourceId": 52297,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Form",
+      "resource": "Create Forms",
+      "description": "Criar formulários.",
+      "key": "1_form_create",
+      "resourceId": 52298,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Form",
+      "resource": "Edit Forms",
+      "description": "Editar formulários.",
+      "key": "1_form_edit",
+      "resourceId": 52299,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Form",
+      "resource": "Remove Form",
+      "description": "Excluir formulários.",
+      "key": "1_form_delete",
+      "resourceId": 52300,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Generic resources",
+      "resource": "CRM administrator",
+      "description": "Gerenciar informações de CRM.",
+      "key": "ADMIN_CRM",
+      "resourceId": 25786,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Generic resources",
+      "resource": "Full access to forms",
+      "description": "Acesso total a formulários.",
+      "key": "POWER_USER_CRM",
+      "resourceId": 52283,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Generic resources",
+      "resource": "Access to insert and edit but not to delete",
+      "description": "Acesso de leitura e edição, mas não remoção.",
+      "key": "NOREMOVE_USER_CRM",
+      "resourceId": 52284,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Generic resources",
+      "resource": "Read-only form access",
+      "description": "Somente leitura de formulários.",
+      "key": "READONLY_USER_CRM",
+      "resourceId": 52285,
+      "productId": 3
+    },
+    {
+      "product": "Master Data",
+      "category": "Import",
+      "resource": "Run import",
+      "description": "Rodar importação.",
+      "key": "3_import_run",
+      "resourceId": 52306,
+      "productId": 3
+    },
+    {
+      "product": "Message Center",
+      "category": "Messages",
+      "resource": "Send Message ",
+      "description": "Enviar uma mensagem na Central de Mensagens.",
+      "key": "send-message",
+      "resourceId": 1026939,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Providers",
+      "resource": "View provider list",
+      "description": "Visualização da lista de remetentes da Central de Mensagens. ",
+      "key": "provider-listar",
+      "resourceId": 52282,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Providers",
+      "resource": "Add or edit provider",
+      "description": "Criar ou editar remetentes (providers) criados na área de remetentes da Central de Mensagens.",
+      "key": "provider-salvar",
+      "resourceId": 52325,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Providers",
+      "resource": "Remove provider",
+      "description": "Remover remetentes criados na área de remetentes da Central de Mensagens (providers).",
+      "key": "provider-excluir",
+      "resourceId": 52326,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Templates",
+      "resource": "View template list",
+      "description": "Visualização da lista de templates disponíveis da Central de Mensagens.",
+      "key": "template-listar",
+      "resourceId": 1203,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Templates",
+      "resource": "Add new template",
+      "description": "Adicionar novos templates à lista de templates da Central de Mensagens.",
+      "key": "template-criar",
+      "resourceId": 1204,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Templates",
+      "resource": "Remove template",
+      "description": "Remover novos templates da lista de templates da Central de Mensagens. ",
+      "key": "template-excluir",
+      "resourceId": 1205,
+      "productId": 23
+    },
+    {
+      "product": "Message Center",
+      "category": "Templates",
+      "resource": "Edit template",
+      "description": "Edição e customização de templates na Central de Mensagens. ",
+      "key": "template-editar",
+      "resourceId": 1207,
+      "productId": 23
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Change order workflow status",
+      "description": "Ações dentro do fluxo de pedidos pra mudança de status de pedido, através do botão de Ações no fluxo.",
+      "key": "WorkflowAction",
+      "resourceId": 1150,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Notify payment",
+      "description": "Acesso ao botão que notifica pagamento ao gateway manualmente na área de pagamento dentro do pedido.",
+      "key": "PaymentAction",
+      "resourceId": 1151,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Notify invoice",
+      "description": "Permite informar faturas (NF) e dados para rastreio manualmente no OMS. ",
+      "key": "ShippingAction",
+      "resourceId": 1152,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "View order",
+      "description": "Visualizar todos os pedidos da conta.",
+      "key": "OMSViewer",
+      "resourceId": 1153,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Notify refund",
+      "description": "Permite notificar uma nota fiscal (invoice) de entrada.",
+      "key": "RefundAction",
+      "resourceId": 1407,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Cancel order",
+      "description": "Permite Cancelar pedido no OMS.",
+      "key": "CancelAction",
+      "resourceId": 1408,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Order feed subscription",
+      "description": "Permite que o usuário se inscreva para receber atualizações dos status dos pedidos no Feed de pedidos.",
+      "key": "FeedSubscription",
+      "resourceId": 1409,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Change order",
+      "description": "Permite registrar mudanças no pedido (descontos e/ou trocas)",
+      "key": "Changes",
+      "resourceId": 1621,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "View store sales stats",
+      "description": "Exibe totalizadores dentro da seção Todos os pedidos do Gerenciamento de pedidos. Exibe total de vendas além dos detalhes dos pedidos. ",
+      "key": "ShowTotalizers",
+      "resourceId": 98200,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Only show orders created by the user (via call center)",
+      "description": "Os pedidos serão ajustados pelo email cadastrado pelo callcenteroperatoremail.",
+      "key": "callCenterOperatorFilter",
+      "resourceId": 428968,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Feed v3 and Hook Admin",
+      "description": "Criar, editar e deletar configurações de Feed v3/hook.",
+      "key": "FeedHookV3Admin",
+      "resourceId": 592028,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Feed v3 and Hook view only",
+      "description": "Visualizar os dados de Feed v3/hook.",
+      "key": "FeedHookV3Viewer",
+      "resourceId": 592029,
+      "productId": 19
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Subscription view only",
+      "description": "Visualizar os dados das Assinaturas da loja.",
+      "key": "SubscriptionViewer",
+      "resourceId": 592030,
+      "productId": ""
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Subscription admin",
+      "description": "Ação e visualização do Admin de Assinaturas. Acesso ao botão de tentar novamente.",
+      "key": "SubscriptionAdmin",
+      "resourceId": 592031,
+      "productId": ""
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Subscription metrics and reports",
+      "description": "Acesso à visualização de metricas e relatórios no dashboard de Assinaturas. ",
+      "key": "SubscriptionMetrics",
+      "resourceId": 592032,
+      "productId": ""
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "Subscription view and edit",
+      "description": "Permite visualização e edição de assinaturas. ",
+      "key": "SubscriptionManager",
+      "resourceId": 592033,
+      "productId": ""
+    },
+    {
+      "product": "OMS",
+      "category": "OMS access",
+      "resource": "List Orders",
+      "description": "Listar todos os pedidos da conta.",
+      "key": "ListOrders",
+      "resourceId": 1860145,
+      "productId": 19
+    },
+    {
+      "product": "Order Authorization",
+      "category": "Order Authorization Admin",
+      "resource": "Save Configuration",
+      "description": "Visualizar e alterar as configurações de aceite de pedidos com diferença de valor, na seção de autorização de pedidos, dentro do gerenciamento de pedidos.",
+      "key": "SaveConfiguration",
+      "resourceId": 600081,
+      "productId": 74
+    },
+    {
+      "product": "Order Authorization",
+      "category": "Order Authorization Admin",
+      "resource": "View Configuration",
+      "description": "Visualizar as configurações de aceite de pedidos com diferença de valor, na seção de autorização de pedidos, dentro do gerenciamento de pedidos.",
+      "key": "ViewConfiguration",
+      "resourceId": 600082,
+      "productId": 74
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Edit",
+      "resource": "BIN Manager Edit Permission",
+      "description": "Permite editar a qual banco ou instituição financeira pertence determinado BIN",
+      "key": "binManagerEditPermission",
+      "resourceId": 631530,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-MakePayments",
+      "resource": "Process payments",
+      "description": "Representa as operações transacionais do gateway de pagamento.",
+      "key": "MakePayments",
+      "resourceId": 1052,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ManageInfrastructure",
+      "resource": "Manage Infrastructure",
+      "description": "Realizar configurações críticas na infraestrutura do Gateway. Disponível somente para administradores.",
+      "key": "ManageInfrastructure",
+      "resourceId": 1157,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ManageStore",
+      "resource": "Manage Store",
+      "description": "Modificar as configurações.",
+      "key": "ManageStore",
+      "resourceId": 1097,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ManageStore",
+      "resource": "Manage Store Rules",
+      "description": "Permissão para gerenciar os meios de pagamento da loja.",
+      "key": "ManageStoreRules",
+      "resourceId": 1684986,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ManageStore",
+      "resource": "Manage Store Affiliations",
+      "description": "Permissão para gerenciar as afiliações de Gateway da loja.",
+      "key": "ManageStoreAffiliations",
+      "resourceId": 1684987,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ManageStore",
+      "resource": "Manage Store AntiFraud",
+      "description": "Permissão para gerenciar o anti-fraude dos meios de pagamento da loja.",
+      "key": "ManageStoreAntiFraud ",
+      "resourceId": 1684988,
+      "productId": ""
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-NotifyPayments",
+      "resource": "Notify Payments",
+      "description": "Notificação de aprovação de pagamento.",
+      "key": "NotifyPayments",
+      "resourceId": 1512,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-NotifyPayments",
+      "resource": "Payments Notification",
+      "description": "Notificação de aprovação de pagamento, utilizando a Payments Gateway API.",
+      "key": "PaymentsNotification",
+      "resourceId": 2061772,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ViewPaymentData",
+      "resource": "View Payment Data",
+      "description": "Recuperar uma transação.",
+      "key": "ViewPayments",
+      "resourceId": 1096,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "Payment-ViewPaymentData",
+      "resource": "View Payments Sensitive Data",
+      "description": "Visualização de informações pessoalmente identificáveis (PII), para lojas que utilizam o ambiente de conformidade de privacidade de dados.",
+      "key": "ViewPaymentsSensitiveData",
+      "resourceId": 1515091,
+      "productId": 6
+    },
+    {
+      "product": "PCI Gateway",
+      "category": "View",
+      "resource": "BIN Manager View Permission",
+      "description": "Permite pesquisar e visualizar a qual banco ou instituição financeira pertence determinado BIN",
+      "key": "binManagerViewPermission",
+      "resourceId": 631529,
+      "productId": 6
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "View Card Tokens",
+      "description": "Permite a visualização dos dados de cartões tokenizados",
+      "key": "ViewCardTokens",
+      "resourceId": 2078628,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Edit Card Tokens",
+      "description": "Permite a edição dos dados de cartões tokenizados previamente criados no Card Token Vault.",
+      "key": "ManageCardTokens",
+      "resourceId": 2078744,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Create Card Tokens",
+      "description": "Permite que cartão tokenizado seja armazenado",
+      "key": "CreateCardTokens",
+      "resourceId": 2078845,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Delete Card Token",
+      "description": "Permite deletar cartão tokenizado armazenado previamente",
+      "key": "DeleteCardToken",
+      "resourceId": 2078846,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Import Card Token",
+      "description": "Permite iniciar importação de tokens de cartões de crédito",
+      "key": "ImportCardToken",
+      "resourceId": 2078847,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Get Import Card Token Status ",
+      "description": "Permite visualizar status da importação de tokens",
+      "key": "GetImportCardTokenStatus",
+      "resourceId": 2078848,
+      "productId": 114
+    },
+    {
+      "product": "Payments",
+      "category": "Card Token Vault",
+      "resource": "Get Import Card Tokens Report",
+      "description": "Baixar relatório de erros que ocorreram na importação",
+      "key": "GetImportCardTokensReport",
+      "resourceId": 2078849,
+      "productId": 114
+    },
+    {
+      "product": "PersonalShopper App",
+      "category": "Analytics",
+      "resource": "View Analytics",
+      "description": "Visualizar Analytics do app Personal Shopper.",
+      "key": "view-analytics",
+      "resourceId": 1639728,
+      "productId": 100
+    },
+    {
+      "product": "PersonalShopper App",
+      "category": "Call",
+      "resource": "View List Call",
+      "description": "Visualizar a página de chamadas.",
+      "key": "view-list-call",
+      "resourceId": 1639430,
+      "productId": 100
+    },
+    {
+      "product": "PersonalShopper App",
+      "category": "Setting",
+      "resource": "View Setting",
+      "description": "Editar configurações do app Personal Shopper.",
+      "key": "view-setting",
+      "resourceId": 1643056,
+      "productId": 100
+    },
+    {
+      "product": "Portal",
+      "category": "API",
+      "resource": "Manage portal",
+      "description": "Criar e editar templates, prateleiras e páginas no CMS (Portal) e editar configurações do Checkout.",
+      "key": "AdminPortal",
+      "resourceId": 1299,
+      "productId": 27
+    },
+    {
+      "product": "Pricing",
+      "category": "Price List",
+      "resource": "Read prices",
+      "description": "Visualizar todos os preços de um SKU.",
+      "key": "read_prices",
+      "resourceId": 152730,
+      "productId": 65
+    },
+    {
+      "product": "Pricing",
+      "category": "Price List",
+      "resource": "Modify prices",
+      "description": "Alterar ou criar um preço para um SKU.",
+      "key": "modify_prices",
+      "resourceId": 152731,
+      "productId": 65
+    },
+    {
+      "product": "Pricing",
+      "category": "Price List",
+      "resource": "Read trade policy configurations",
+      "description": "Visualizar todas as políticas comerciais da conta.",
+      "key": "read_tradePolicySettings",
+      "resourceId": 152732,
+      "productId": 65
+    },
+    {
+      "product": "Pricing",
+      "category": "Price List",
+      "resource": "Modify trade policy configurations",
+      "description": "Deletar todas as políticas comerciais da conta.",
+      "key": "modify_tradePolicySettings",
+      "resourceId": 152733,
+      "productId": 65
+    },
+    {
+      "product": "Pricing",
+      "category": "Price List",
+      "resource": "Delete all prices from account",
+      "description": "Deletar todos os preços da conta.",
+      "key": "modify_prices_delete_all",
+      "resourceId": 152736,
+      "productId": 65
+    },
+    {
+      "product": "Promotions Policy Engine",
+      "category": "Policies",
+      "resource": "Evaluate Policy",
+      "description": "Obter a avaliação da política.",
+      "key": "EvaluatePolicy",
+      "resourceId": 1212434,
+      "productId": 89
+    },
+    {
+      "product": "Promotions Policy Engine",
+      "category": "Policies",
+      "resource": "Create or Update Policy",
+      "description": "Criar ou atualizar uma política.",
+      "key": "CreateOrUpdatePolicy",
+      "resourceId": 1212435,
+      "productId": 89
+    },
+    {
+      "product": "Promotions Policy Engine",
+      "category": "Policies",
+      "resource": "Get Policy",
+      "description": "Obter o objeto de política.",
+      "key": "GetPolicy",
+      "resourceId": 1212492,
+      "productId": 89
+    },
+    {
+      "product": "Promotions Policy Engine",
+      "category": "Policies",
+      "resource": "Delete Policy",
+      "description": "Excluir uma política.",
+      "key": "DeletePolicy",
+      "resourceId": 1212493,
+      "productId": 89
+    },
+    {
+      "product": "Promotions Policy Engine",
+      "category": "Policies",
+      "resource": "List Policies",
+      "description": "Listar as políticas existentes.",
+      "key": "ListPolicies",
+      "resourceId": 1212494,
+      "productId": 89
+    },
+    {
+      "product": "Rates and Benefits",
+      "category": "Promotions",
+      "resource": "Manage benefits and rates",
+      "description": "Criar, editar ou arquivar promoções, cupons, campanhas e taxas.",
+      "key": "GerenciarPromocoesETarifas",
+      "resourceId": 98201,
+      "productId": 16
+    },
+    {
+      "product": "Rates and Benefits",
+      "category": "Promotions",
+      "resource": "Manage Policies",
+      "description": "Habilitar o gerenciamento de políticas comerciais.",
+      "key": "GerenciarPolicies",
+      "resourceId": 1118700,
+      "productId": 16
+    },
+    {
+      "product": "Releases",
+      "category": "Releases",
+      "resource": "Edit Release",
+      "description": "Criação, agendamento, reprogramação e exclusão de lançamentos.",
+      "key": "edit-release",
+      "resourceId": 1257521,
+      "productId": 91
+    },
+    {
+      "product": "Releases",
+      "category": "Releases",
+      "resource": "Visualize Releases",
+      "description": "Visualizar a lista de lançamentos e atualizações de cada lançamento",
+      "key": "get-release",
+      "resourceId": 1257551,
+      "productId": 91
+    },
+    {
+      "product": "Sales App",
+      "category": "Reports",
+      "resource": "View Sales Performance",
+      "description": "Permite que o vendedor visualize a página de desempenho de vendas no VTEX Sales App relacionado um ponto de operação de vendas (loja física)",
+      "key": "ViewSalesPerformance",
+      "resourceId": 2126563,
+      "productId": 132
+    },
+    {
+      "product": "Search",
+      "category": "Search Settings",
+      "resource": "General Settings",
+      "description": "Editar configurações gerais do VTEX Intelligent Search.",
+      "key": "general-settings",
+      "resourceId": 719379,
+      "productId": 76
+    },
+    {
+      "product": "Security Monitor",
+      "category": "findings",
+      "resource": "View Findings",
+      "description": "Obter, listar e visualizar as informações sobre descobertas e tipos de descobertas no Security Monitor.",
+      "key": "ViewFindings",
+      "resourceId": 2000228,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "findings",
+      "resource": "Edit Findings",
+      "description": "Silenciar ou voltar a alertar sobre uma descoberta no Security Monitor.",
+      "key": "EditFindings",
+      "resourceId": 2000236,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "notifications settings",
+      "resource": "Edit Notification Settings",
+      "description": "Editar as configurações de destinatários de notificações sobre alertas de segurança no Security Monitor.",
+      "key": "EditNotificationSettings",
+      "resourceId": 2000244,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-read",
+      "resource": "List/Describe reports",
+      "description": "Visualizar um relatório ou lista de relatórios no Security Monitor.",
+      "key": "read-reports",
+      "resourceId": 1858423,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-read",
+      "resource": "List/Describe Sensors",
+      "description": "Visualizar detalhes de sensores no Security Monitor.",
+      "key": "read-sensors",
+      "resourceId": 1880664,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-read",
+      "resource": "Read Notifications Settings",
+      "description": "Ler configurações de notificações do Security Monitor.",
+      "key": "read-notifications-settings",
+      "resourceId": 1980709,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-write",
+      "resource": "Create Reports",
+      "description": "Criar novos relatórios no Security Monitor.",
+      "key": "write-reports",
+      "resourceId": 1858424,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-write",
+      "resource": "Update Sensors",
+      "description": "Habilitar ou desabilitar sensores no Security Monitor.",
+      "key": "update-sensors",
+      "resourceId": 1880649,
+      "productId": 103
+    },
+    {
+      "product": "Security Monitor",
+      "category": "security-center-write",
+      "resource": "Write Notifications Settings",
+      "description": "Editar configurações de notificações do Security Monitor.",
+      "key": "write-notifications-settings",
+      "resourceId": 1980710,
+      "productId": 103
+    },
+    {
+      "product": "Seller Register",
+      "category": "Seller Administration",
+      "resource": "View Seller",
+      "description": "Visualizar todos os sellers vinculados à conta do marketplace descritos na página Gerenciamento de Sellers, incluindo recuperar dados de seller, seja da listagem de sellers, ou um seller específico. ",
+      "key": "view-seller",
+      "resourceId": 575457,
+      "productId": 73
+    },
+    {
+      "product": "Seller Register",
+      "category": "Seller Administration",
+      "resource": "Save Seller",
+      "description": "Criar sellers novos e editar dados de todos os sellers vinculados à conta do marketplace, a partir da página Gerenciamento de Sellers.",
+      "key": "save-seller",
+      "resourceId": 575458,
+      "productId": 73
+    },
+    {
+      "product": "Subscriptions",
+      "category": "ApplicationAccess",
+      "resource": "Subscription view only",
+      "description": "Visualizar os dados das assinaturas da loja.",
+      "key": "SubscriptionViewer",
+      "resourceId": 592030,
+      "productId": ""
+    },
+    {
+      "product": "Subscriptions",
+      "category": "ApplicationAccess",
+      "resource": "Subscription admin",
+      "description": "Ação e visualização do Admin de Assinaturas. Acesso ao botão de tentar novamente.",
+      "key": "SubscriptionAdmin",
+      "resourceId": 592031,
+      "productId": ""
+    },
+    {
+      "product": "Subscriptions",
+      "category": "ApplicationAccess",
+      "resource": "Subscription view and edit",
+      "description": "Visualização e edição de assinaturas. ",
+      "key": "SubscriptionManager",
+      "resourceId": 592033,
+      "productId": ""
+    },
+    {
+      "product": "Subscriptions",
+      "category": "ApplicationAccess",
+      "resource": "Subscription metrics and reports",
+      "description": "Visualização de metricas e relatórios no dashboard de Assinatura. ",
+      "key": "SubscriptionMetrics",
+      "resourceId": 592032,
+      "productId": ""
+    },
+    {
+      "product": "Suggestion",
+      "category": "Suggestion Resources",
+      "resource": "Main Access",
+      "description": "Acesso irrestrito a todos os componentes da página SKUs Recebidos, incluindo visualização dos dados da página, além de ações de aprovação de anúncios. Saiba mais em [Catalogação de SKUs recebidos](https://help.vtex.com/pt/tutorial/sugerindo-e-aprovando-skus/).",
+      "key": "suggestions",
+      "resourceId": 109448,
+      "productId": 50
+    },
+    {
+      "product": "User Rights",
+      "category": "applications",
+      "resource": "Read Applications",
+      "description": "Visualizar operações em aplicações de direitos de usuários, seja em lista ou detalhadas.",
+      "key": "applications_read",
+      "resourceId": 1634515,
+      "productId": ""
+    },
+    {
+      "product": "User Rights",
+      "category": "applications",
+      "resource": "Write Applications",
+      "description": "Criar, atualizar ou remover aplicações de direitos de usuários.",
+      "key": "applications_write",
+      "resourceId": 1634523,
+      "productId": ""
+    },
+    {
+      "product": "User Rights",
+      "category": "user-rights-request",
+      "resource": "Read user rights requests",
+      "description": "Visualizar solicitações de direitos de usuários, seja em lista ou detalhadas.",
+      "key": "user_rights_request_read",
+      "resourceId": 1634546,
+      "productId": 99
+    },
+    {
+      "product": "User Rights",
+      "category": "user-rights-request",
+      "resource": "Write user rights requests",
+      "description": "Criar, atualizar ou remover solicitações de direitos de usuários.",
+      "key": "user_rights_request_write",
+      "resourceId": 1634554,
+      "productId": 99
+    },
+    {
+      "product": "User Rights",
+      "category": "user-rights-request",
+      "resource": "Process User Rights Removal Request",
+      "description": "Processar solicitações de direitos de usuários do tipo remoção.",
+      "key": "removal-request-process",
+      "resourceId": 1705138,
+      "productId": 99
+    },
+    {
+      "product": "VTEX Ad Network",
+      "category": "Advertisers",
+      "resource": "View Advertiser's details",
+      "description": "Visualizar informações do anunciante relativas ao VTEX Ad Network.",
+      "key": "view-advertiser-details",
+      "resourceId": 2012197,
+      "productId": 106
+    },
+    {
+      "product": "VTEX Ad Network",
+      "category": "Advertisers",
+      "resource": "View Advertiser's campaigns",
+      "description": "Visualizar informações de campanhas de um anunciante do VTEX Ad Network.",
+      "key": "view-advertiser-campaigns",
+      "resourceId": 2012200,
+      "productId": 106
+    },
+    {
+      "product": "VTEX Ad Network",
+      "category": "Advertisers",
+      "resource": "Edit Advertiser's campaigns",
+      "description": "Editar informações de campanhas de um anunciante do VTEX Ad Network.",
+      "key": "edit-advertiser-campaigns",
+      "resourceId": 2012201,
+      "productId": 106
+    },
+    {
+      "product": "VTEX Ad Network",
+      "category": "Publishers",
+      "resource": "View Publisher's details",
+      "description": "Visualizar informações de loja relativas a exibição de anúncios do VTEX Ad Network.",
+      "key": "view-publisher-details",
+      "resourceId": 2012196,
+      "productId": 106
+    },
+    {
+      "product": "VTEX Bridge",
+      "category": "Items",
+      "resource": "List Itens",
+      "description": "Visualização dos documentos do Brigde.",
+      "key": "listItems",
+      "resourceId": 106704,
+      "productId": 48
+    },
+    {
+      "product": "VTEX Bridge",
+      "category": "Items",
+      "resource": "Execute Actions",
+      "description": "Tomar ação sobre algum log. Por exemplo, reprocessar o envio de algum item.",
+      "key": "executeActions",
+      "resourceId": 106965,
+      "productId": 48
+    },
+    {
+      "product": "VTEX Bridge",
+      "category": "Settings",
+      "resource": "View Configs",
+      "description": "Visualização das configurações de cada integração.",
+      "key": "viewConfig",
+      "resourceId": 106706,
+      "productId": 48
+    },
+    {
+      "product": "VTEX Bridge",
+      "category": "Settings",
+      "resource": "Manage Configs",
+      "description": "Editar as configurações de uma integração",
+      "key": "editConfig",
+      "resourceId": 106707,
+      "productId": 48
+    },
+    {
+      "product": "VTEX IO",
+      "category": "A/B Test",
+      "resource": "Manage A/B Test",
+      "description": "Iniciar, terminar ou obter o status de um Teste A / B.",
+      "key": "manage-abtest",
+      "resourceId": 664798,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Read Workspace Apps",
+      "description": "Leitura dos aplicativos instalados no espaço de trabalho e suas dependências.",
+      "key": "read-workspace-apps",
+      "resourceId": 253175,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Link App",
+      "description": "Vincular e desvincular aplicativos, além de listar links já existentes em um determinado aplicativo.",
+      "key": "link-app",
+      "resourceId": 253206,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Install App",
+      "description": "Instalação e desinstalação de aplicativos sem opções de faturamento.",
+      "key": "install-apps",
+      "resourceId": 253207,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Vbase Read Only",
+      "description": "Somente leitura do VBase.",
+      "key": "vbase-read-only",
+      "resourceId": 253582,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Vbase Read Write",
+      "description": "Leitura e gravação ao VBase.",
+      "key": "vbase-read-write",
+      "resourceId": 253583,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Read Workspace Services",
+      "description": "Leitura de infra aplicativos instalados na área de trabalho.",
+      "key": "read-workspace-services",
+      "resourceId": 257862,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Install Service",
+      "description": "Instalação e desinstalação de serviços de infraestrutura.",
+      "key": "install-services",
+      "resourceId": 257864,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Log Access - Read-only",
+      "description": "Leitura de registros de todos os aplicativos.",
+      "key": "colossus-read-logs",
+      "resourceId": 259184,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Read Published Service",
+      "description": "Leitura dos dados dos serviços do cadastro infra.",
+      "key": "read-infra-service",
+      "resourceId": 259251,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Debug App",
+      "description": "Conectar um depurador a um aplicativo vinculado.",
+      "key": "debug-app",
+      "resourceId": 377794,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Workspace CRUD",
+      "description": "Criação, exclusão e modificação de espaços de trabalho.",
+      "key": "workspace-read-write",
+      "resourceId": 379639,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Buy App",
+      "description": "Instalação e desinstalação de todos os tipos de aplicativos, incluindo aqueles com opções de faturamento.",
+      "key": "buy-app",
+      "resourceId": 382623,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Import Redirects",
+      "description": "Gerenciar redirecionamentos com a interface de linha de comando do VTEX IO.",
+      "key": "import-redirects",
+      "resourceId": 661667,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Workspace Manipulation",
+      "description": "Criar, modificar e deletar um espaço de trabalho.",
+      "key": "workspace-read-write-v2",
+      "resourceId": 794788,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Workspace Promotion",
+      "description": "Promover um espaço de trabalho.",
+      "key": "workspace-promote",
+      "resourceId": 794789,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Read Edition",
+      "description": "Leitura da edição de uma conta ou de um espaço de trabalho.",
+      "key": "read-edition",
+      "resourceId": 797718,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Allow APP configuration",
+      "description": "Configurar aplicativos.",
+      "key": "read-write-apps-settings",
+      "resourceId": 808001,
+      "productId": 66
+    },
+    {
+      "product": "VTEX IO",
+      "category": "Infrastructure",
+      "resource": "Change sponsored tenant edition",
+      "description": "Definir a edição de um inquilino que é patrocinado pela conta onde esta permissão é concedida.",
+      "key": "change-edition-of-sponsored-tenant",
+      "resourceId": 945388,
+      "productId": 66
+    },
+    {
+      "product": "VTEX Support",
+      "category": "Ticket",
+      "resource": "Open Support Ticket",
+      "description": "Abrir ticket de suporte para a VTEX. Válido somente para contas no Brasil.",
+      "key": "open-support-ticket",
+      "resourceId": 1945378,
+      "productId": 104
+    },
+    {
+      "product": "VTable",
+      "category": "VTable",
+      "resource": "View apps",
+      "description": "Visualização de apps do VTable.",
+      "key": "view-apps",
+      "resourceId": 257872,
+      "productId": 67
+    },
+    {
+      "product": "VTable",
+      "category": "VTable",
+      "resource": "Main access",
+      "description": "Acesso principal do VTable.",
+      "key": "main_access_old",
+      "resourceId": 258007,
+      "productId": 67
+    },
+    {
+      "product": "Vtex ID",
+      "category": "Identity Providers",
+      "resource": "Write Identity Providers",
+      "description": "Criar e atualizar os provedores de identidade (admin e webstore) para uma conta.",
+      "key": "write_identity_providers",
+      "resourceId": 631952,
+      "productId": 64
+    },
+    {
+      "product": "Vtex ID",
+      "category": "Identity Providers",
+      "resource": "Read Identity Providers",
+      "description": "Ler os provedores de identidade (admin e webstore) de uma conta.",
+      "key": "read_identity_providers",
+      "resourceId": 631953,
+      "productId": 64
+    },
+    {
+      "product": "Vtex ID",
+      "category": "Identity Providers",
+      "resource": "Can Punchout",
+      "description": "Permitir chaves de API a autenticar usuários via punchout.",
+      "key": "CanPunchout",
+      "resourceId": 2074726,
+      "productId": 64
+    },
+    {
+      "product": "Vtex ID",
+      "category": "User Management",
+      "resource": "Expire User Password",
+      "description": "Definir como nula a senha de um dado usuário.",
+      "key": "expire_user_password",
+      "resourceId": 1844857,
+      "productId": 64
+    },
+    {
+      "product": "Vtex ID",
+      "category": "User Management",
+      "resource": "Create User",
+      "description": "Criar usuário de frente de loja.",
+      "key": "CreateUser",
+      "resourceId": 2117393,
+      "productId": 64
+    },
+    {
+      "product": "WebService",
+      "category": "Web service",
+      "resource": "Webservice access",
+      "description": "Criar, editar e deletar informações do catálogo por meio do WebService.",
+      "key": "orders",
+      "resourceId": 136106,
+      "productId": 61
+    }
+  ]
+}

--- a/data-tables/license-manager-resources.json
+++ b/data-tables/license-manager-resources.json
@@ -6,8 +6,8 @@
       "resource": "Read logs stream",
       "description": "Read VTEX IO application logs belonging to this account.",
       "key": "read_logs",
-      "resourceId": 728560,
-      "productId": 81
+      "resourceId": "728560",
+      "productId": "81"
     },
     {
       "product": "Audit",
@@ -15,8 +15,8 @@
       "resource": "Save Event",
       "description": "Save audit events.",
       "key": "SaveEvent",
-      "resourceId": 1353337,
-      "productId": 55
+      "resourceId": "1353337",
+      "productId": "55"
     },
     {
       "product": "B2B",
@@ -24,8 +24,8 @@
       "resource": "B2BBulkExport",
       "description": "It allows B2B stores to export their data in bulk to files.",
       "key": "B2BBulkExport",
-      "resourceId": 2045795,
-      "productId": 105
+      "resourceId": "2045795",
+      "productId": "105"
     },
     {
       "product": "B2B",
@@ -33,8 +33,8 @@
       "resource": "B2BBulkImport",
       "description": "Allows B2B stores to bulk import multiple buyer organizations into VTEX B2B solution.",
       "key": "B2BBulkImport",
-      "resourceId": 1954299,
-      "productId": 105
+      "resourceId": "1954299",
+      "productId": "105"
     },
     {
       "product": "B2B",
@@ -42,8 +42,8 @@
       "resource": "BulkImportTest",
       "description": "Allows B2B stores to bulk import multiple buyer organizations into VTEX B2B solution.",
       "key": "BulkImportTest",
-      "resourceId": 1957237,
-      "productId": 105
+      "resourceId": "1957237",
+      "productId": "105"
     },
     {
       "product": "Billing",
@@ -51,8 +51,8 @@
       "resource": "Edit Company Information",
       "description": "Edit a customer's registration information, including: company name, trade name, branch, sales region, tier, billing status, and address.",
       "key": "edit_company",
-      "resourceId": 118281,
-      "productId": 43
+      "resourceId": "118281",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -60,8 +60,8 @@
       "resource": "Display Company info",
       "description": "View a customer's registration information, which includes: company name, trade name, branch, sales region, tier, billing status, and address.",
       "key": "get_company",
-      "resourceId": 118283,
-      "productId": 43
+      "resourceId": "118283",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -69,8 +69,8 @@
       "resource": "Edit Company's Document",
       "description": "Edit company documents and information.",
       "key": "edit_companys_document",
-      "resourceId": 131970,
-      "productId": 43
+      "resourceId": "131970",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -78,8 +78,8 @@
       "resource": "Merge companies",
       "description": "To perform a merger of two accounts, so that all invoice and contract information from one account is transferred to the other account.",
       "key": "company_merge",
-      "resourceId": 277452,
-      "productId": 43
+      "resourceId": "277452",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -87,8 +87,8 @@
       "resource": "Split companies",
       "description": "Separate two accounts, with invoice and contract information recorded in one, and the other remaining blank.",
       "key": "company_split",
-      "resourceId": 277453,
-      "productId": 43
+      "resourceId": "277453",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -96,8 +96,8 @@
       "resource": "Contacts List ",
       "description": "View which contacts receive email notifications when a specific customer's invoice is generated.",
       "key": "list_contacts",
-      "resourceId": 118284,
-      "productId": 43
+      "resourceId": "118284",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -105,8 +105,8 @@
       "resource": "Edit Contacts",
       "description": "Add or edit a contact.",
       "key": "edit_contact",
-      "resourceId": 118285,
-      "productId": 43
+      "resourceId": "118285",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -114,8 +114,8 @@
       "resource": "Contracts List ",
       "description": "View contracts and billing terms registered in the Invoices module of the VTEX platform.",
       "key": "list_contracts",
-      "resourceId": 118282,
-      "productId": 43
+      "resourceId": "118282",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -123,8 +123,8 @@
       "resource": "Save contracts",
       "description": "Edit contracts in the VTEX platform's Invoices module, including registering invoices of any value and charging take rates at any percentage.",
       "key": "put_contract",
-      "resourceId": 134738,
-      "productId": 43
+      "resourceId": "134738",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -132,8 +132,8 @@
       "resource": "Invoices List ",
       "description": "Viewing the customer's invoice list, as well as the invoice details, which includes information such as GMV and take rate.",
       "key": "list_invoices",
-      "resourceId": 105015,
-      "productId": 43
+      "resourceId": "105015",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -141,8 +141,8 @@
       "resource": "Generate new Invoice",
       "description": "Create an invoice for a client, but only when a contract has already been created and has a defined value. The feature does not allow the user to set the invoice amount.",
       "key": "put_invoices",
-      "resourceId": 120233,
-      "productId": 43
+      "resourceId": "120233",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -150,8 +150,8 @@
       "resource": "Cancel Invoice Document",
       "description": "Cancel the tax document generated by the issuer.",
       "key": "cancel_nfe",
-      "resourceId": 134739,
-      "productId": 43
+      "resourceId": "134739",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -159,8 +159,8 @@
       "resource": "Issue Invoice Document",
       "description": "Generate the tax document, but only on the issuer's platform.",
       "key": "issue_nfe",
-      "resourceId": 134740,
-      "productId": 43
+      "resourceId": "134740",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -168,8 +168,8 @@
       "resource": "Invoice reconciliation",
       "description": "Inform the system of the date and amount paid for an invoice.",
       "key": "conciliate_invoice",
-      "resourceId": 134741,
-      "productId": 43
+      "resourceId": "134741",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -177,8 +177,8 @@
       "resource": "Generate Invoice for overdue payment without added interest fees",
       "description": "Change the due date of an invoice without incurring standard late fees and interest.",
       "key": "generate_invoice_overdue_without_interest",
-      "resourceId": 134743,
-      "productId": 43
+      "resourceId": "134743",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -186,8 +186,8 @@
       "resource": "Cancel Invoice",
       "description": "Canceling an invoice in the Invoices module of the VTEX platform and in the issuer.",
       "key": "cancel_invoice",
-      "resourceId": 134744,
-      "productId": 43
+      "resourceId": "134744",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -195,8 +195,8 @@
       "resource": "Change payment status",
       "description": "Change the company's payment status to: Alert, Blocked, Timer, or Ok.",
       "key": "set_paymentstatus",
-      "resourceId": 138192,
-      "productId": 43
+      "resourceId": "138192",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -204,8 +204,8 @@
       "resource": "Unpaid invoices",
       "description": "Resetting an invoice to the \"opened\" status will cancel the payment date and the amount paid.",
       "key": "unpaid_invoices",
-      "resourceId": 525925,
-      "productId": 43
+      "resourceId": "525925",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -213,8 +213,8 @@
       "resource": "Simulate Invoices Creation",
       "description": "Simulating invoices without actually creating them.",
       "key": "simulate_invoices",
-      "resourceId": 1362361,
-      "productId": 43
+      "resourceId": "1362361",
+      "productId": "43"
     },
     {
       "product": "Buyer Organizations",
@@ -222,8 +222,8 @@
       "resource": "Buyer Organization View",
       "description": "View the list of purchasing organizations.",
       "key": "buyer_organization_view",
-      "resourceId": 1522234,
-      "productId": 97
+      "resourceId": "1522234",
+      "productId": "97"
     },
     {
       "product": "Buyer Organizations",
@@ -231,8 +231,8 @@
       "resource": "Buyer Organization Edit",
       "description": "Create or edit purchasing organizations.",
       "key": "buyer_organization_edit",
-      "resourceId": 1522235,
-      "productId": 97
+      "resourceId": "1522235",
+      "productId": "97"
     },
     {
       "product": "CDN API",
@@ -240,8 +240,8 @@
       "resource": "View certificate",
       "description": "View the details of the CDN certificates.",
       "key": "ViewCertificate",
-      "resourceId": 2022646,
-      "productId": 108
+      "resourceId": "2022646",
+      "productId": "108"
     },
     {
       "product": "CDN API",
@@ -249,8 +249,8 @@
       "resource": "Update certificate",
       "description": "Replace the existing CDN certificates.",
       "key": "UpdateCertificate",
-      "resourceId": 2022647,
-      "productId": 108
+      "resourceId": "2022647",
+      "productId": "108"
     },
     {
       "product": "CDN API",
@@ -258,8 +258,8 @@
       "resource": "View WafControl Metrics",
       "description": "View WAF metrics.",
       "key": "ViewWafControlMetrics",
-      "resourceId": 2142573,
-      "productId": 108
+      "resourceId": "2142573",
+      "productId": "108"
     },
     {
       "product": "CDN Service",
@@ -267,8 +267,8 @@
       "resource": "Query status of domains",
       "description": "Allows the user to check the status of the store's domains in production.",
       "key": "query-domain",
-      "resourceId": 1271517,
-      "productId": 84
+      "resourceId": "1271517",
+      "productId": "84"
     },
     {
       "product": "CMS",
@@ -276,8 +276,8 @@
       "resource": "See CMS menu on the top-bar",
       "description": "View the CMS menu in the top bar.",
       "key": "topbar_visualizar",
-      "resourceId": 111439,
-      "productId": 38
+      "resourceId": "111439",
+      "productId": "38"
     },
     {
       "product": "CMS",
@@ -285,8 +285,8 @@
       "resource": "Settings",
       "description": "Edit CMS settings.",
       "key": "cms_settings",
-      "resourceId": 1434680,
-      "productId": 38
+      "resourceId": "1434680",
+      "productId": "38"
     },
     {
       "product": "CMS",
@@ -294,8 +294,8 @@
       "resource": "CMS GraphQL API",
       "description": "Use the VTEX IO CMS GraphQL API.",
       "key": "access-cms-graphql-api",
-      "resourceId": 1032772,
-      "productId": 38
+      "resourceId": "1032772",
+      "productId": "38"
     },
     {
       "product": "CMS",
@@ -303,8 +303,8 @@
       "resource": "Read CMS GraphQL API",
       "description": "Grants read-only access to the GraphQL API of the VTEX IO CMS.",
       "key": "read-cms-graphql-api",
-      "resourceId": 2143073,
-      "productId": 38
+      "resourceId": "2143073",
+      "productId": "38"
     },
     {
       "product": "Catalog",
@@ -312,8 +312,8 @@
       "resource": "Admin list",
       "description": "List the system administrators.",
       "key": "Administrador.aspx",
-      "resourceId": 882,
-      "productId": 2
+      "resourceId": "882",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -321,8 +321,8 @@
       "resource": "Homepage",
       "description": "Homepage",
       "key": "Home.aspx",
-      "resourceId": 1047,
-      "productId": 2
+      "resourceId": "1047",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -330,8 +330,8 @@
       "resource": "Help page",
       "description": "Help homepage",
       "key": "Help.aspx",
-      "resourceId": 1048,
-      "productId": 2
+      "resourceId": "1048",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -339,8 +339,8 @@
       "resource": "Read Collections",
       "description": "Allows you to view collections.",
       "key": "collections-read",
-      "resourceId": 627875,
-      "productId": 2
+      "resourceId": "627875",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -348,8 +348,8 @@
       "resource": "Write Collections",
       "description": "Allows you to create a new product collection.",
       "key": "collections-write",
-      "resourceId": 627876,
-      "productId": 2
+      "resourceId": "627876",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -357,8 +357,8 @@
       "resource": "Expert Reviews Management",
       "description": "Expert opinion registration form",
       "key": "EspecialistaOpiniaoForm.aspx",
-      "resourceId": 928,
-      "productId": 2
+      "resourceId": "928",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -366,8 +366,8 @@
       "resource": "Similar product category",
       "description": "Add a category similar to the product.",
       "key": "ProdutoCategoriaSimilar.aspx",
-      "resourceId": 981,
-      "productId": 2
+      "resourceId": "981",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -375,8 +375,8 @@
       "resource": "Similar category product management",
       "description": "Product registration for a similar category",
       "key": "ProdutoCategoriaSimilarForm.aspx",
-      "resourceId": 982,
-      "productId": 2
+      "resourceId": "982",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -384,8 +384,8 @@
       "resource": "SKU management",
       "description": "SKU registration form",
       "key": "SkuForm.aspx",
-      "resourceId": 1001,
-      "productId": 2
+      "resourceId": "1001",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -393,8 +393,8 @@
       "resource": "SKU Services",
       "description": "SKU Services",
       "key": "SkuServicoForm.aspx",
-      "resourceId": 1004,
-      "productId": 2
+      "resourceId": "1004",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -402,8 +402,8 @@
       "resource": "Prices for SKU Services",
       "description": "List of SKU service prices",
       "key": "SkuServicoValor.aspx",
-      "resourceId": 1005,
-      "productId": 2
+      "resourceId": "1005",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -411,8 +411,8 @@
       "resource": "SKU service price management",
       "description": "Form for registering a value for a SKU service.",
       "key": "SkuServicoValorForm.aspx",
-      "resourceId": 1006,
-      "productId": 2
+      "resourceId": "1006",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -420,8 +420,8 @@
       "resource": "Commercial condition",
       "description": "Definition of trade policies",
       "key": "SkuCondicaoComercial.aspx",
-      "resourceId": 1019,
-      "productId": 2
+      "resourceId": "1019",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -429,8 +429,8 @@
       "resource": "SKU type management",
       "description": "Form for registering SKU service types.",
       "key": "SkuServicoTipo.aspx",
-      "resourceId": 1045,
-      "productId": 2
+      "resourceId": "1045",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -438,8 +438,8 @@
       "resource": "Configuration Management",
       "description": "Configuration registration form",
       "key": "ConfigForm.aspx",
-      "resourceId": 917,
-      "productId": 2
+      "resourceId": "917",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -447,8 +447,8 @@
       "resource": "File types list",
       "description": "List of file types",
       "key": "TipoArquivo.aspx",
-      "resourceId": 1009,
-      "productId": 2
+      "resourceId": "1009",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -456,8 +456,8 @@
       "resource": "File types management",
       "description": "Form for registering standard image sizes and other file types.",
       "key": "TipoArquivoForm.aspx",
-      "resourceId": 1010,
-      "productId": 2
+      "resourceId": "1010",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -465,8 +465,8 @@
       "resource": "Store Texts",
       "description": "Developer tool with all the base texts for the store.",
       "key": "TextoSite.aspx",
-      "resourceId": 1034,
-      "productId": 2
+      "resourceId": "1034",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -474,8 +474,8 @@
       "resource": "CMS Management",
       "description": "CMS (Portal) Settings",
       "key": "PortalManagement",
-      "resourceId": 1202,
-      "productId": 2
+      "resourceId": "1202",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -483,8 +483,8 @@
       "resource": "SEO Configurations",
       "description": "SEO Content Settings (Robots.txt)",
       "key": "ConfigSEOContents.aspx",
-      "resourceId": 1222,
-      "productId": 2
+      "resourceId": "1222",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -492,8 +492,8 @@
       "resource": "Gift Registry Types List",
       "description": "List of List Types",
       "key": "GiftListType.aspx",
-      "resourceId": 1631,
-      "productId": 2
+      "resourceId": "1631",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -501,8 +501,8 @@
       "resource": "Gift Registry Lists Management",
       "description": "Form for creating and editing list types (GiftList)",
       "key": "GiftListTypeForm.aspx",
-      "resourceId": 1633,
-      "productId": 2
+      "resourceId": "1633",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -510,8 +510,8 @@
       "resource": "Geographic Region Management",
       "description": "Manage the geographic region listing page.",
       "key": "GeographicRegion.aspx",
-      "resourceId": 2138652,
-      "productId": 2
+      "resourceId": "2138652",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -519,8 +519,8 @@
       "resource": "Geographic Region Form",
       "description": "Manage the form for creating and editing geographic regions.",
       "key": "GeographicRegionForm.aspx",
-      "resourceId": 2138653,
-      "productId": 2
+      "resourceId": "2138653",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -528,8 +528,8 @@
       "resource": "StoreForm.aspx",
       "description": "View the commercial policy details screen.",
       "key": "StoreForm.aspx",
-      "resourceId": 2142219,
-      "productId": 2
+      "resourceId": "2142219",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -537,8 +537,8 @@
       "resource": "InsertOrUpdateStoreForm.aspx",
       "description": "Create and modify business policies (subject to recurring charges).",
       "key": "InsertOrUpdateStoreForm.aspx",
-      "resourceId": 2142347,
-      "productId": 2
+      "resourceId": "2142347",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -546,8 +546,8 @@
       "resource": "Product management",
       "description": "View the product registration and modification screen",
       "key": "ProdutoForm.aspx",
-      "resourceId": 873,
-      "productId": 2
+      "resourceId": "873",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -555,8 +555,8 @@
       "resource": "Product Form",
       "description": "Access to the product screen",
       "key": "Produto.aspx",
-      "resourceId": 874,
-      "productId": 2
+      "resourceId": "874",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -564,8 +564,8 @@
       "resource": "Change SKU Pricing",
       "description": "Change SKU prices",
       "key": "AlterarPrecoSku",
-      "resourceId": 877,
-      "productId": 2
+      "resourceId": "877",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -573,8 +573,8 @@
       "resource": "SKU images management",
       "description": "Insert and modify SKU images",
       "key": "ManterImagemProdutoSku",
-      "resourceId": 880,
-      "productId": 2
+      "resourceId": "880",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -582,8 +582,8 @@
       "resource": "Product and SKU Management",
       "description": "Product and SKU modification and addition",
       "key": "ManterFormularioProdutoSku",
-      "resourceId": 881,
-      "productId": 2
+      "resourceId": "881",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -591,8 +591,8 @@
       "resource": "Reviews list",
       "description": "List all reviews",
       "key": "Avaliacao.aspx",
-      "resourceId": 885,
-      "productId": 2
+      "resourceId": "885",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -600,8 +600,8 @@
       "resource": "Reviews management",
       "description": "Evaluation registration form",
       "key": "AvaliacaoForm.aspx",
-      "resourceId": 886,
-      "productId": 2
+      "resourceId": "886",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -609,8 +609,8 @@
       "resource": "Fields list",
       "description": "Lists all fields in the system.",
       "key": "Campo.aspx",
-      "resourceId": 891,
-      "productId": 2
+      "resourceId": "891",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -618,8 +618,8 @@
       "resource": "Attributes Management",
       "description": "Form for registering fields.",
       "key": "CampoForm.aspx",
-      "resourceId": 896,
-      "productId": 2
+      "resourceId": "896",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -627,8 +627,8 @@
       "resource": "Value fields list",
       "description": "List of values ​​for a field",
       "key": "CampoValor.aspx",
-      "resourceId": 897,
-      "productId": 2
+      "resourceId": "897",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -636,8 +636,8 @@
       "resource": "Attribute values management",
       "description": "Field registration form",
       "key": "CampoValorForm.aspx",
-      "resourceId": 898,
-      "productId": 2
+      "resourceId": "898",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -645,8 +645,8 @@
       "resource": "Category ",
       "description": "List all categories",
       "key": "Categoria.aspx",
-      "resourceId": 899,
-      "productId": 2
+      "resourceId": "899",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -654,8 +654,8 @@
       "resource": "Categories Management",
       "description": "Category registration form",
       "key": "CategoriaForm.aspx",
-      "resourceId": 900,
-      "productId": 2
+      "resourceId": "900",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -663,8 +663,8 @@
       "resource": "Similar Category ",
       "description": "List all similar categories",
       "key": "CategoriaSimilar.aspx",
-      "resourceId": 901,
-      "productId": 2
+      "resourceId": "901",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -672,8 +672,8 @@
       "resource": "Similar Categories Management",
       "description": "Similar categories form",
       "key": "CategoriaSimilarForm.aspx",
-      "resourceId": 902,
-      "productId": 2
+      "resourceId": "902",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -681,8 +681,8 @@
       "resource": "Price range",
       "description": "List all price ranges",
       "key": "FaixaPreco.aspx",
-      "resourceId": 933,
-      "productId": 2
+      "resourceId": "933",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -690,8 +690,8 @@
       "resource": "Price Range Management",
       "description": "Price registration form",
       "key": "FaixaPrecoForm.aspx",
-      "resourceId": 934,
-      "productId": 2
+      "resourceId": "934",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -699,8 +699,8 @@
       "resource": "Providers",
       "description": "Lists the suppliers registered in the system.",
       "key": "Fornecedor.aspx",
-      "resourceId": 938,
-      "productId": 2
+      "resourceId": "938",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -708,8 +708,8 @@
       "resource": "Supplier management",
       "description": "Supplier registration form",
       "key": "FornecedorForm.aspx",
-      "resourceId": 939,
-      "productId": 2
+      "resourceId": "939",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -717,8 +717,8 @@
       "resource": "Groups",
       "description": "List all category groups",
       "key": "Grupo.aspx",
-      "resourceId": 944,
-      "productId": 2
+      "resourceId": "944",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -726,8 +726,8 @@
       "resource": "Group Management ",
       "description": "Category group registration form",
       "key": "GrupoForm.aspx",
-      "resourceId": 945,
-      "productId": 2
+      "resourceId": "945",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -735,8 +735,8 @@
       "resource": "Brands",
       "description": "List of all registered brands",
       "key": "Marca.aspx",
-      "resourceId": 955,
-      "productId": 2
+      "resourceId": "955",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -744,8 +744,8 @@
       "resource": "Brands Management",
       "description": "Brand registration form",
       "key": "MarcaForm.aspx",
-      "resourceId": 956,
-      "productId": 2
+      "resourceId": "956",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -753,8 +753,8 @@
       "resource": "SKUs",
       "description": "List all registered SKUs.",
       "key": "Sku.aspx",
-      "resourceId": 996,
-      "productId": 2
+      "resourceId": "996",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -762,8 +762,8 @@
       "resource": "Enable Product and SKU",
       "description": "Product and SKU activation",
       "key": "Ativar Produto Sku",
-      "resourceId": 1013,
-      "productId": 2
+      "resourceId": "1013",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -771,8 +771,8 @@
       "resource": "Category Management",
       "description": "Access verification for adding or changing a new category.",
       "key": "InsertOrUpdateCategoriaFromCategoriaForm.aspx",
-      "resourceId": 1216,
-      "productId": 2
+      "resourceId": "1216",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -780,8 +780,8 @@
       "resource": "Similar Category Management",
       "description": "Access verification for adding or changing a new similar category.",
       "key": "InsertOrUpdateCategoriaFromCategoriaSimilarForm.aspx",
-      "resourceId": 1217,
-      "productId": 2
+      "resourceId": "1217",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -789,8 +789,8 @@
       "resource": "Brand Management",
       "description": "Validation for adding or changing a brand.",
       "key": "InsertOrUpdateMarcaFromMarcaForm.aspx",
-      "resourceId": 1218,
-      "productId": 2
+      "resourceId": "1218",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -798,8 +798,8 @@
       "resource": "Insert or Update Group",
       "description": "Insert or modify within the category group.",
       "key": "InsertOrUpdateGrupoFromGrupoForm.aspx",
-      "resourceId": 1219,
-      "productId": 2
+      "resourceId": "1219",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -807,8 +807,8 @@
       "resource": "Field validation",
       "description": "Field validation",
       "key": "InsertOrUpdateCampoFromCampoForm.aspx",
-      "resourceId": 1220,
-      "productId": 2
+      "resourceId": "1220",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -816,8 +816,8 @@
       "resource": "Value field validation",
       "description": "Field value validation",
       "key": "InsertOrUpdateCampoValorFromCampoValorForm.aspx",
-      "resourceId": 1221,
-      "productId": 2
+      "resourceId": "1221",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -825,8 +825,8 @@
       "resource": "Buy Together Management",
       "description": "Registration form for \"Buy Together\"",
       "key": "CompreJuntoForm.aspx",
-      "resourceId": 915,
-      "productId": 2
+      "resourceId": "915",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -834,8 +834,8 @@
       "resource": "Reviews",
       "description": "SKU review database",
       "key": "Resenha.aspx",
-      "resourceId": 988,
-      "productId": 2
+      "resourceId": "988",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -843,8 +843,8 @@
       "resource": "Gift/Refund Vouchers",
       "description": "Create a Purchase Voucher",
       "key": "Vale.aspx",
-      "resourceId": 1016,
-      "productId": 2
+      "resourceId": "1016",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -852,8 +852,8 @@
       "resource": "Product Collections XML",
       "description": "XML Collections",
       "key": "Xml.aspx",
-      "resourceId": 1026,
-      "productId": 2
+      "resourceId": "1026",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -861,8 +861,8 @@
       "resource": "Tags management",
       "description": "Keyword Control - Tags",
       "key": "Tag.aspx",
-      "resourceId": 1027,
-      "productId": 2
+      "resourceId": "1027",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -870,8 +870,8 @@
       "resource": "Sales channels management",
       "description": "List of trade policies",
       "key": "Store.aspx",
-      "resourceId": 1226,
-      "productId": 2
+      "resourceId": "1226",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -879,8 +879,8 @@
       "resource": "Sellers",
       "description": "List of Sellers (Stores)",
       "key": "Seller.aspx",
-      "resourceId": 1227,
-      "productId": 2
+      "resourceId": "1227",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -888,8 +888,8 @@
       "resource": "Seller SKUs",
       "description": "SKU List Sellers",
       "key": "SkuSeller.aspx",
-      "resourceId": 1229,
-      "productId": 2
+      "resourceId": "1229",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -897,8 +897,8 @@
       "resource": "SKU Bundles",
       "description": "Interface between Kits and SKUs",
       "key": "SkuKit.aspx",
-      "resourceId": 1002,
-      "productId": 2
+      "resourceId": "1002",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -906,8 +906,8 @@
       "resource": "Product Bundle Management",
       "description": "Kit registration form",
       "key": "SkuKitForm.aspx",
-      "resourceId": 1003,
-      "productId": 2
+      "resourceId": "1003",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -915,8 +915,8 @@
       "resource": "News Report",
       "description": "Newsletter Report",
       "key": "RelatorioNews.aspx",
-      "resourceId": 1020,
-      "productId": 2
+      "resourceId": "1020",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -924,8 +924,8 @@
       "resource": "SKUs Report",
       "description": "SKUs Report",
       "key": "Relatorio_Skus.aspx",
-      "resourceId": 1022,
-      "productId": 2
+      "resourceId": "1022",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -933,8 +933,8 @@
       "resource": "Out of stock notification",
       "description": "Notify Me Request Report",
       "key": "Relatorio_AviseMeSku.aspx",
-      "resourceId": 1025,
-      "productId": 2
+      "resourceId": "1025",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -942,8 +942,8 @@
       "resource": "Full-text Search",
       "description": "Full-text search report",
       "key": "RelatorioFullText.aspx",
-      "resourceId": 1028,
-      "productId": 2
+      "resourceId": "1028",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -951,8 +951,8 @@
       "resource": "Security Monitoring",
       "description": "Security Monitoring",
       "key": "Relatorio_Seguranca.aspx",
-      "resourceId": 1031,
-      "productId": 2
+      "resourceId": "1031",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -960,8 +960,8 @@
       "resource": "Gift Registry List",
       "description": "See all lists (GiftList)",
       "key": "GiftList.aspx",
-      "resourceId": 1632,
-      "productId": 2
+      "resourceId": "1632",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -969,8 +969,8 @@
       "resource": "Assisted Sales Gift Registry List Management",
       "description": "It allows the administrator to manage a user's lists on the Site, as if they were the user themselves.",
       "key": "GiftListImpersonation",
-      "resourceId": 1634,
-      "productId": 2
+      "resourceId": "1634",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -978,8 +978,8 @@
       "resource": "Assisted Sales",
       "description": "Telesales features. After the login, the user is redirected to the telesales site www.{storename} .com.br/a/telesales. This way, the operator can use telesales features such as navigating the store in the name of the customer. As this resource causes an automatic redirect to the store, the user who logs in an account with this resource in their role will not have access to important resources from Admin. Therefore, we recommend using two separate accounts (with distinct emails) for telesales users: a Call Center Operator role account (with this resource and the View Order resource) and another account to perform operations on the administrative menu if necessary.",
       "key": "Televendas",
-      "resourceId": 1046,
-      "productId": 2
+      "resourceId": "1046",
+      "productId": "2"
     },
     {
       "product": "Catalog API",
@@ -987,8 +987,8 @@
       "resource": "View Product",
       "description": "View product and SKU details.",
       "key": "ViewProduct",
-      "resourceId": 2017533,
-      "productId": 107
+      "resourceId": "2017533",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -996,8 +996,8 @@
       "resource": "Edit Product",
       "description": "Edit product details and SKUs.",
       "key": "EditProduct",
-      "resourceId": 2038155,
-      "productId": 107
+      "resourceId": "2038155",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -1005,8 +1005,8 @@
       "resource": "View Category",
       "description": "View category details.",
       "key": "ViewCategory",
-      "resourceId": 2038156,
-      "productId": 107
+      "resourceId": "2038156",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -1014,8 +1014,8 @@
       "resource": "Edit Category",
       "description": "Edit category details.",
       "key": "EditCategory",
-      "resourceId": 2038157,
-      "productId": 107
+      "resourceId": "2038157",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -1023,8 +1023,8 @@
       "resource": "View Collection",
       "description": "View collection details.",
       "key": "ViewCollection",
-      "resourceId": 2038158,
-      "productId": 107
+      "resourceId": "2038158",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -1032,8 +1032,8 @@
       "resource": "Edit Collection",
       "description": "Edit collection details.",
       "key": "EditCollection",
-      "resourceId": 2038159,
-      "productId": 107
+      "resourceId": "2038159",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -1041,8 +1041,8 @@
       "resource": "View Brand",
       "description": "View brand details.",
       "key": "ViewBrand",
-      "resourceId": 2038160,
-      "productId": 107
+      "resourceId": "2038160",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -1050,8 +1050,8 @@
       "resource": "Edit Brand",
       "description": "Edit brand details.",
       "key": "EditBrand",
-      "resourceId": 2038161,
-      "productId": 107
+      "resourceId": "2038161",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -1059,8 +1059,8 @@
       "resource": "Import Spreadsheet",
       "description": "Import products and SKUs via spreadsheet.",
       "key": "ImportSpreadsheet",
-      "resourceId": 2038162,
-      "productId": 107
+      "resourceId": "2038162",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -1068,8 +1068,8 @@
       "resource": "Export Spreadsheet",
       "description": "Export catalog information spreadsheet.",
       "key": "ExportSpreadsheet",
-      "resourceId": 2038163,
-      "productId": 107
+      "resourceId": "2038163",
+      "productId": "107"
     },
     {
       "product": "Channels",
@@ -1077,8 +1077,8 @@
       "resource": "Send Marketplace Suggestions",
       "description": "It allows sellers to submit listings to the marketplace, which will be reviewed and approved by the marketplace through the Received SKUs page or the Match Received SKUs API.",
       "key": "EnviaSugestao",
-      "resourceId": 1139,
-      "productId": 13
+      "resourceId": "1139",
+      "productId": "13"
     },
     {
       "product": "Channels",
@@ -1086,8 +1086,8 @@
       "resource": "Sellers SKUs List",
       "description": "Allows sellers to view the list of SKUs sent to the marketplaces where they sell their products. In the VTEX Admin, the list can be accessed under MARKETPLACE > Integrations > Products.",
       "key": "Consulta",
-      "resourceId": 1154,
-      "productId": 13
+      "resourceId": "1154",
+      "productId": "13"
     },
     {
       "product": "Channels",
@@ -1095,8 +1095,8 @@
       "resource": "Save Suggestion Rules",
       "description": "Allows marketplaces to create and modify VTEX Matcher rules for the approval of received SKUs. This configuration is done through the SKU Approval Settings API.",
       "key": "SalvaRegras",
-      "resourceId": 1155,
-      "productId": 13
+      "resourceId": "1155",
+      "productId": "13"
     },
     {
       "product": "Channels",
@@ -1104,8 +1104,8 @@
       "resource": "Marketplace seller setup",
       "description": "Allows you to associate a seller with a new marketplace or change an existing setting. Sellers included in the Seller Portal can only have their settings changed, but cannot be associated with more than one marketplace. VTEX sellers, however, can be associated with other marketplaces and have their settings changed by enabling this feature. This action can be done via VTEX Admin or via the REST API.",
       "key": "ConfiguraSeller",
-      "resourceId": 1156,
-      "productId": 13
+      "resourceId": "1156",
+      "productId": "13"
     },
     {
       "product": "Channels",
@@ -1113,8 +1113,8 @@
       "resource": "Access the Marketplace Network",
       "description": "Create, edit, and list your store's profile on the Marketplace Network and send messages to other stores.",
       "key": "MarketplaceNetwork",
-      "resourceId": 1107285,
-      "productId": 13
+      "resourceId": "1107285",
+      "productId": "13"
     },
     {
       "product": "Checkout",
@@ -1122,8 +1122,8 @@
       "resource": "Shopping Cart Full Access",
       "description": "Read and write access for all shopping carts. Allows cart data to be displayed in its entirety (not masked). Also allows private cart simulation requests.",
       "key": "AcessaTodosCarrinhos",
-      "resourceId": 1091,
-      "productId": 5
+      "resourceId": "1091",
+      "productId": "5"
     },
     {
       "product": "Checkout",
@@ -1131,8 +1131,8 @@
       "resource": "Orders Full Access",
       "description": "Read and write access to all orders via the Checkout API. Access to orders through the order management module flow is not permitted.",
       "key": "AcessaTodosPedidos",
-      "resourceId": 1092,
-      "productId": 5
+      "resourceId": "1092",
+      "productId": "5"
     },
     {
       "product": "Checkout",
@@ -1140,8 +1140,8 @@
       "resource": "Save Order Configuration",
       "description": "Save order settings.",
       "key": "SaveOrderConfiguration",
-      "resourceId": 600072,
-      "productId": 5
+      "resourceId": "600072",
+      "productId": "5"
     },
     {
       "product": "Checkout",
@@ -1149,8 +1149,8 @@
       "resource": "Save OrderForm Configuration",
       "description": "Save shopping cart settings.",
       "key": "SaveOrderFormConfiguration",
-      "resourceId": 600073,
-      "productId": 5
+      "resourceId": "600073",
+      "productId": "5"
     },
     {
       "product": "Checkout",
@@ -1158,8 +1158,8 @@
       "resource": "Read Shopping Cart",
       "description": "Reads and lists all shopping carts. Does not allow access to unmasked cart data.",
       "key": "GetOrderForm",
-      "resourceId": 1949421,
-      "productId": 5
+      "resourceId": "1949421",
+      "productId": "5"
     },
     {
       "product": "Commerce Content",
@@ -1167,8 +1167,8 @@
       "resource": "Save to main branch",
       "description": "Adds changes directly to the main branch.",
       "key": "SaveToMainBranch",
-      "resourceId": 2086248,
-      "productId": 115
+      "resourceId": "2086248",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
@@ -1176,8 +1176,8 @@
       "resource": "Remove from main branch",
       "description": "Remove changes from the main branch.",
       "key": "RemoveFromMainBranch",
-      "resourceId": 2086250,
-      "productId": 115
+      "resourceId": "2086250",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
@@ -1185,8 +1185,8 @@
       "resource": "Merge branch",
       "description": "Merges changes from one branch to the main branch.",
       "key": "MergeBranch",
-      "resourceId": 2086251,
-      "productId": 115
+      "resourceId": "2086251",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
@@ -1194,8 +1194,8 @@
       "resource": "Delete Branch",
       "description": "Allows you to delete a branch and all versioned content associated with it.",
       "key": "DeleteBranch",
-      "resourceId": 2153203,
-      "productId": 115
+      "resourceId": "2153203",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
@@ -1203,8 +1203,8 @@
       "resource": "Create Branch",
       "description": "It allows you to create a new branch to develop, test, and save new versions of content in isolation.",
       "key": "CreateBranch",
-      "resourceId": 2153204,
-      "productId": 115
+      "resourceId": "2153204",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
@@ -1212,8 +1212,8 @@
       "resource": "Delete entry",
       "description": "Permanently deletes an entry from all history and branches.",
       "key": "DeleteEntry",
-      "resourceId": 2086249,
-      "productId": 115
+      "resourceId": "2086249",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
@@ -1221,8 +1221,8 @@
       "resource": "Create Store",
       "description": "Create a new Commerce Content store in the account.",
       "key": "CreateStore",
-      "resourceId": 2086252,
-      "productId": 115
+      "resourceId": "2086252",
+      "productId": "115"
     },
     {
       "product": "Credit Control",
@@ -1230,8 +1230,8 @@
       "resource": "Read Checking Accounts",
       "description": "Viewing account information.",
       "key": "read_checkingaccounts",
-      "resourceId": 170921,
-      "productId": 58
+      "resourceId": "170921",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -1239,8 +1239,8 @@
       "resource": "Create Checking Accounts",
       "description": "Account creation.",
       "key": "create_checkingaccounts",
-      "resourceId": 170929,
-      "productId": 58
+      "resourceId": "170929",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -1248,8 +1248,8 @@
       "resource": "Edit credits",
       "description": "Change the credit limit of an account.",
       "key": "edit_credits",
-      "resourceId": 197575,
-      "productId": 58
+      "resourceId": "197575",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -1257,8 +1257,8 @@
       "resource": "Read Invoices",
       "description": "Viewing invoices.",
       "key": "read_invoices",
-      "resourceId": 170930,
-      "productId": 58
+      "resourceId": "170930",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -1266,8 +1266,8 @@
       "resource": "Create Invoices",
       "description": "Issuing invoices.",
       "key": "create_invoices",
-      "resourceId": 170931,
-      "productId": 58
+      "resourceId": "170931",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -1275,8 +1275,8 @@
       "resource": "Pay Invoice",
       "description": "Bill payment.",
       "key": "pay_invoice",
-      "resourceId": 200613,
-      "productId": 58
+      "resourceId": "200613",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -1284,8 +1284,8 @@
       "resource": "Main Access",
       "description": "Allows main access",
       "key": "suggestions",
-      "resourceId": 109448,
-      "productId": 50
+      "resourceId": "109448",
+      "productId": "50"
     },
     {
       "product": "Credit Control",
@@ -1293,8 +1293,8 @@
       "resource": "Read Statements",
       "description": "Reading account statements.",
       "key": "read_statements",
-      "resourceId": 170918,
-      "productId": 58
+      "resourceId": "170918",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -1302,8 +1302,8 @@
       "resource": "Create Statements",
       "description": "Creating account statements.",
       "key": "create_statements",
-      "resourceId": 170920,
-      "productId": 58
+      "resourceId": "170920",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -1311,8 +1311,8 @@
       "resource": "Edit Configuration",
       "description": "Change the store settings.",
       "key": "edit_config",
-      "resourceId": 198649,
-      "productId": 58
+      "resourceId": "198649",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -1320,8 +1320,8 @@
       "resource": "Read Configuration",
       "description": "Viewing store settings.",
       "key": "read_config",
-      "resourceId": 198650,
-      "productId": 58
+      "resourceId": "198650",
+      "productId": "58"
     },
     {
       "product": "Delivery Promises",
@@ -1329,8 +1329,8 @@
       "resource": "Notify Product Availability Change",
       "description": "Update the availability of items from external sellers within the context of Delivery Promise.",
       "key": "NotifyProductAvailabilityChange",
-      "resourceId": 2032871,
-      "productId": 111
+      "resourceId": "2032871",
+      "productId": "111"
     },
     {
       "product": "Dynamic Storage",
@@ -1338,8 +1338,8 @@
       "resource": "List data entity",
       "description": "List data entities.",
       "key": "2_dataentity_list",
-      "resourceId": 69077,
-      "productId": 25
+      "resourceId": "69077",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -1347,8 +1347,8 @@
       "resource": "Create data entity",
       "description": "Create a data entity.",
       "key": "1_dataentity_create",
-      "resourceId": 69078,
-      "productId": 25
+      "resourceId": "69078",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -1356,8 +1356,8 @@
       "resource": "Edit schema",
       "description": "Edit schema.",
       "key": "1_dataentity_edit",
-      "resourceId": 69079,
-      "productId": 25
+      "resourceId": "69079",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -1365,8 +1365,8 @@
       "resource": "Remove data entity",
       "description": "Delete data entity.",
       "key": "1_dataentity_delete",
-      "resourceId": 69080,
-      "productId": 25
+      "resourceId": "69080",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -1374,8 +1374,8 @@
       "resource": "View data entity details",
       "description": "View data entity details.",
       "key": "2_dataentity_view",
-      "resourceId": 69081,
-      "productId": 25
+      "resourceId": "69081",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -1383,8 +1383,8 @@
       "resource": "Publish index",
       "description": "Publish index.",
       "key": "1_dataentity_publish",
-      "resourceId": 69082,
-      "productId": 25
+      "resourceId": "69082",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -1392,8 +1392,8 @@
       "resource": "Master Data administrator",
       "description": "Manage Master Data.",
       "key": "ADMIN_DS",
-      "resourceId": 69073,
-      "productId": 25
+      "resourceId": "69073",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -1401,8 +1401,8 @@
       "resource": "Full access to all documents",
       "description": "Full access to all documents.",
       "key": "POWER_USER_DS",
-      "resourceId": 69074,
-      "productId": 25
+      "resourceId": "69074",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -1410,8 +1410,8 @@
       "resource": "Insert or update document (not remove)",
       "description": "Creating and updating documents, but not deleting them.",
       "key": "NOREMOVE_USER_DS",
-      "resourceId": 69075,
-      "productId": 25
+      "resourceId": "69075",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -1419,8 +1419,8 @@
       "resource": "Read only documents",
       "description": "Document reading only.",
       "key": "READONLY_USER_DS",
-      "resourceId": 69076,
-      "productId": 25
+      "resourceId": "69076",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -1428,7 +1428,7 @@
       "resource": "List index",
       "description": "List indexes.",
       "key": "1_Index_list",
-      "resourceId": 105916,
+      "resourceId": "105916",
       "productId": ""
     },
     {
@@ -1437,7 +1437,7 @@
       "resource": "Create index",
       "description": "Create index.",
       "key": "1_Index_create",
-      "resourceId": 105917,
+      "resourceId": "105917",
       "productId": ""
     },
     {
@@ -1446,7 +1446,7 @@
       "resource": "Edit index",
       "description": "Edit index.",
       "key": "1_Index_edit",
-      "resourceId": 105918,
+      "resourceId": "105918",
       "productId": ""
     },
     {
@@ -1455,7 +1455,7 @@
       "resource": "Remove index",
       "description": "Remove index.",
       "key": "1_Index_delete",
-      "resourceId": 105919,
+      "resourceId": "105919",
       "productId": ""
     },
     {
@@ -1464,7 +1464,7 @@
       "resource": "View index details",
       "description": "View index details.",
       "key": "1_Index_view",
-      "resourceId": 105920,
+      "resourceId": "105920",
       "productId": ""
     },
     {
@@ -1473,7 +1473,7 @@
       "resource": "List internal logs",
       "description": "List internal logs.",
       "key": "1_internallog_list",
-      "resourceId": 105921,
+      "resourceId": "105921",
       "productId": ""
     },
     {
@@ -1482,7 +1482,7 @@
       "resource": "List internal alerts",
       "description": "List internal alerts.",
       "key": "1_internalwarning_list",
-      "resourceId": 106143,
+      "resourceId": "106143",
       "productId": ""
     },
     {
@@ -1491,7 +1491,7 @@
       "resource": "View detail schema",
       "description": "View schema details.",
       "key": "1_dataentity_list",
-      "resourceId": 137232,
+      "resourceId": "137232",
       "productId": ""
     },
     {
@@ -1500,8 +1500,8 @@
       "resource": "List trigger",
       "description": "List triggers.",
       "key": "2_datarule_list",
-      "resourceId": 69083,
-      "productId": 25
+      "resourceId": "69083",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -1509,8 +1509,8 @@
       "resource": "Create trigger",
       "description": "Create triggers.",
       "key": "1_datarule_create",
-      "resourceId": 69084,
-      "productId": 25
+      "resourceId": "69084",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -1518,8 +1518,8 @@
       "resource": "Edit trigger",
       "description": "Edit triggers.",
       "key": "1_datarule_edit",
-      "resourceId": 69085,
-      "productId": 25
+      "resourceId": "69085",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -1527,8 +1527,8 @@
       "resource": "Remove trigger",
       "description": "Delete triggers.",
       "key": "1_datarule_delete",
-      "resourceId": 69086,
-      "productId": 25
+      "resourceId": "69086",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -1536,8 +1536,8 @@
       "resource": "View trigger details",
       "description": "View trigger details.",
       "key": "2_datarule_view",
-      "resourceId": 69087,
-      "productId": 25
+      "resourceId": "69087",
+      "productId": "25"
     },
     {
       "product": "FastStore",
@@ -1545,8 +1545,8 @@
       "resource": "View Secrets",
       "description": "Allows you to view the secrets configured in WebOps.",
       "key": "ViewSecrets",
-      "resourceId": 2100329,
-      "productId": 129
+      "resourceId": "2100329",
+      "productId": "129"
     },
     {
       "product": "FastStore",
@@ -1554,8 +1554,8 @@
       "resource": "Edit Secrets",
       "description": "Allows you to create, delete, and edit secrets in WebOps.",
       "key": "EditSecrets",
-      "resourceId": 2100330,
-      "productId": 129
+      "resourceId": "2100330",
+      "productId": "129"
     },
     {
       "product": "Fraud Prevention",
@@ -1563,8 +1563,8 @@
       "resource": "View transaction attempts",
       "description": "View transaction attempts on the Fraud Prevention page.",
       "key": "ViewTransactionAttempts",
-      "resourceId": 2134012,
-      "productId": 127
+      "resourceId": "2134012",
+      "productId": "127"
     },
     {
       "product": "Fraud Prevention",
@@ -1572,8 +1572,8 @@
       "resource": "Edit transaction attempt action settings",
       "description": "Enable or disable actions related to attempted transactions on the Fraud Prevention page.",
       "key": "EditTransactionAttemptActionSettings",
-      "resourceId": 2134013,
-      "productId": 127
+      "resourceId": "2134013",
+      "productId": "127"
     },
     {
       "product": "Fraud Prevention",
@@ -1581,8 +1581,8 @@
       "resource": "Edit transaction attempt score settings",
       "description": "Modify scoring settings for transaction attempts on the Fraud Prevention page.",
       "key": "EditTransactionAttemptScoreSettings",
-      "resourceId": 2134014,
-      "productId": 127
+      "resourceId": "2134014",
+      "productId": "127"
     },
     {
       "product": "GiftCard",
@@ -1590,8 +1590,8 @@
       "resource": "Gift card full access",
       "description": "Create and edit all functions related to gift cards, their providers, and transactions.",
       "key": "GiftCardAdmin",
-      "resourceId": 472959,
-      "productId": 70
+      "resourceId": "472959",
+      "productId": "70"
     },
     {
       "product": "GiftCard",
@@ -1599,8 +1599,8 @@
       "resource": "Gift card viewer",
       "description": "Reads all functions of gift cards, their providers and transactions.",
       "key": "GiftCardReadOnly",
-      "resourceId": 472961,
-      "productId": 70
+      "resourceId": "472961",
+      "productId": "70"
     },
     {
       "product": "GiftCard",
@@ -1608,8 +1608,8 @@
       "resource": "View Gift Cards",
       "description": "Enable card reading operations for gift cards and transactions.",
       "key": "view_giftcards",
-      "resourceId": 994855,
-      "productId": 70
+      "resourceId": "994855",
+      "productId": "70"
     },
     {
       "product": "GiftCard",
@@ -1617,8 +1617,8 @@
       "resource": "Edit Gift Cards",
       "description": "Enable to read and write gift cards and transactions.",
       "key": "edit_giftcards",
-      "resourceId": 994919,
-      "productId": 70
+      "resourceId": "994919",
+      "productId": "70"
     },
     {
       "product": "GiftCard",
@@ -1626,8 +1626,8 @@
       "resource": "View Gift Card providers",
       "description": "Reading about gift card providers and their gift cards.",
       "key": "view_giftcard_providers",
-      "resourceId": 994983,
-      "productId": 70
+      "resourceId": "994983",
+      "productId": "70"
     },
     {
       "product": "GiftCard",
@@ -1635,8 +1635,8 @@
       "resource": "Edit Gift Card providers",
       "description": "Reading and editing gift card vendors and their gift cards.",
       "key": "edit_giftcard_providers",
-      "resourceId": 994991,
-      "productId": 70
+      "resourceId": "994991",
+      "productId": "70"
     },
     {
       "product": "Insights",
@@ -1644,8 +1644,8 @@
       "resource": "Insights Metrics",
       "description": "Allows you to view all the metrics and data present in the VTEX Admin dashboards, including the following pages: Sales Performance, Admin Home page, Insights and Audit.",
       "key": "view_metrics",
-      "resourceId": 129814,
-      "productId": 57
+      "resourceId": "129814",
+      "productId": "57"
     },
     {
       "product": "License Manager",
@@ -1653,8 +1653,8 @@
       "resource": "Edit Admin Users",
       "description": "Allows you to create, edit, and remove administrative users.",
       "key": "EditAdminUsers",
-      "resourceId": 2099310,
-      "productId": 1
+      "resourceId": "2099310",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -1662,8 +1662,8 @@
       "resource": "View Admin Users",
       "description": "Allows you to view user information and access profiles.",
       "key": "ViewAdminUsers",
-      "resourceId": 2099311,
-      "productId": 1
+      "resourceId": "2099311",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -1671,8 +1671,8 @@
       "resource": "View API keys",
       "description": "View, filter, search, sort, and export generated and third-party API keys.",
       "key": "ViewApiKeys",
-      "resourceId": 2042457,
-      "productId": 1
+      "resourceId": "2042457",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -1680,8 +1680,8 @@
       "resource": "Edit API keys",
       "description": "Create, delete, change the status of, and add or remove permissions for API keys.",
       "key": "EditApiKeys",
-      "resourceId": 2042458,
-      "productId": 1
+      "resourceId": "2042458",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -1689,8 +1689,8 @@
       "resource": "Edit API keys settings",
       "description": "Modify API key configurations, such as token duration.",
       "key": "EditApiKeysSettings",
-      "resourceId": 2042466,
-      "productId": 1
+      "resourceId": "2042466",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -1698,8 +1698,8 @@
       "resource": "Renew API Token",
       "description": "View and renew tokens from generated keys.",
       "key": "RenewApiToken",
-      "resourceId": 2042467,
-      "productId": 1
+      "resourceId": "2042467",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -1707,8 +1707,8 @@
       "resource": "Save account",
       "description": "Save an account (change sites, bindings, hosts, etc., contact address).",
       "key": "Save_Account",
-      "resourceId": 1057,
-      "productId": 1
+      "resourceId": "1057",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -1716,8 +1716,8 @@
       "resource": "Get account by identifier",
       "description": "A query that returns an account by identifier, which can be the account ID, host, or application name associated with the account.",
       "key": "Get_Account_By_Identifier",
-      "resourceId": 1064,
-      "productId": 1
+      "resourceId": "1064",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -1725,8 +1725,8 @@
       "resource": "Save user",
       "description": "Create users, add or delete user roles, edit user data, create and edit application keys.",
       "key": "Save_User",
-      "resourceId": 1074,
-      "productId": 1
+      "resourceId": "1074",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -1734,8 +1734,8 @@
       "resource": "Remove user",
       "description": "Revoke user access.",
       "key": "Remove_User",
-      "resourceId": 1075,
-      "productId": 1
+      "resourceId": "1075",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -1743,8 +1743,8 @@
       "resource": "Save access profile",
       "description": "Create or modify an access profile.",
       "key": "Create_Role",
-      "resourceId": 1083,
-      "productId": 1
+      "resourceId": "1083",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -1752,8 +1752,8 @@
       "resource": "Find account resources",
       "description": "List all the resources that an account has access to.",
       "key": "Get_Resources_By_Account",
-      "resourceId": 1086,
-      "productId": 1
+      "resourceId": "1086",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -1761,8 +1761,8 @@
       "resource": "Get role",
       "description": "List the resources associated with an access profile ID and the users associated with that access profile.",
       "key": "Get_Role",
-      "resourceId": 1088,
-      "productId": 1
+      "resourceId": "1088",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -1770,8 +1770,8 @@
       "resource": "Get paged roles",
       "description": "List all access profiles for an account.",
       "key": "Get_Roles_Paged",
-      "resourceId": 1178,
-      "productId": 1
+      "resourceId": "1178",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -1779,8 +1779,8 @@
       "resource": "Get paged users",
       "description": "List all administrative users of an account.",
       "key": "Get_Users_Paged",
-      "resourceId": 1179,
-      "productId": 1
+      "resourceId": "1179",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -1788,8 +1788,8 @@
       "resource": "Upload account logo",
       "description": "Access to upload the account logo image.",
       "key": "Upload_Logo",
-      "resourceId": 1183,
-      "productId": 1
+      "resourceId": "1183",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -1797,8 +1797,8 @@
       "resource": "Get account by host",
       "description": "[Internal] Returns all authorized hosts for an account and the account hosts that it authorized.",
       "key": "Get_Hosts_By_Account",
-      "resourceId": 1210,
-      "productId": 1
+      "resourceId": "1210",
+      "productId": "1"
     },
     {
       "product": "Live Shopping",
@@ -1806,8 +1806,8 @@
       "resource": "view_live_shopping",
       "description": "Intended for invited users on the Live Shopping app, such as influencers, who do not need access to account information.",
       "key": "view_live_shopping",
-      "resourceId": 1532000,
-      "productId": 98
+      "resourceId": "1532000",
+      "productId": "98"
     },
     {
       "product": "Logistics",
@@ -1815,8 +1815,8 @@
       "resource": "Logistics full access",
       "description": "Full access to all logistics features (viewing, creating, editing, and canceling settings).",
       "key": "LogisticsAdmin",
-      "resourceId": 1158,
-      "productId": 9
+      "resourceId": "1158",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -1824,8 +1824,8 @@
       "resource": "Logistics viewer",
       "description": "Visualization of the initial area of ​​the logistics module.",
       "key": "LogisticsViewer",
-      "resourceId": 1926,
-      "productId": 9
+      "resourceId": "1926",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -1833,8 +1833,8 @@
       "resource": "Logistics inventory full access",
       "description": "Full access to the logistics inventory (viewing, creating, editing, and canceling settings).",
       "key": "InventoryAdmin",
-      "resourceId": 475811,
-      "productId": 9
+      "resourceId": "475811",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -1842,8 +1842,8 @@
       "resource": "Logistics inventory read only",
       "description": "View inventory module.",
       "key": "InventoryViewer",
-      "resourceId": 475812,
-      "productId": 9
+      "resourceId": "475812",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -1851,8 +1851,8 @@
       "resource": "Logistics shipping full access",
       "description": "Full access to all shipping functions of the logistics module (creation, editing, and cancellation of configurations).",
       "key": "ShippingAdmin",
-      "resourceId": 475813,
-      "productId": 9
+      "resourceId": "475813",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -1860,8 +1860,8 @@
       "resource": "Request Logistics Reports",
       "description": "Request logistics reports.",
       "key": "RequestLogisticsReports",
-      "resourceId": 881768,
-      "productId": 9
+      "resourceId": "881768",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -1869,8 +1869,8 @@
       "resource": "Transportation full access",
       "description": "Full access to transportation.",
       "key": "TransportationAdmin",
-      "resourceId": 885164,
-      "productId": 9
+      "resourceId": "885164",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -1878,8 +1878,8 @@
       "resource": "Transportation read only",
       "description": "View VTEX Shipping Network orders, packages, and shipping labels.",
       "key": "TransportationViewer",
-      "resourceId": 1881967,
-      "productId": 9
+      "resourceId": "1881967",
+      "productId": "9"
     },
     {
       "product": "Master Data",
@@ -1887,8 +1887,8 @@
       "resource": "List Applications",
       "description": "List applications.",
       "key": "1_application_list",
-      "resourceId": 52286,
-      "productId": 3
+      "resourceId": "52286",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -1896,8 +1896,8 @@
       "resource": "Create Applications",
       "description": "Create applications.",
       "key": "1_application_create",
-      "resourceId": 52287,
-      "productId": 3
+      "resourceId": "52287",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -1905,8 +1905,8 @@
       "resource": "Edit Applications",
       "description": "Edit applications.",
       "key": "1_application_edit",
-      "resourceId": 52288,
-      "productId": 3
+      "resourceId": "52288",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -1914,8 +1914,8 @@
       "resource": "Remove Applications",
       "description": "Delete applications.",
       "key": "1_application_delete",
-      "resourceId": 52289,
-      "productId": 3
+      "resourceId": "52289",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -1923,8 +1923,8 @@
       "resource": "Create custom search",
       "description": "Create a custom search.",
       "key": "3_application_searchcreate",
-      "resourceId": 52290,
-      "productId": 3
+      "resourceId": "52290",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -1932,8 +1932,8 @@
       "resource": "Allow data export",
       "description": "Data export.",
       "key": "3_application_export",
-      "resourceId": 52291,
-      "productId": 3
+      "resourceId": "52291",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -1941,8 +1941,8 @@
       "resource": "View logs",
       "description": "Viewing logs.",
       "key": "4_application_logview",
-      "resourceId": 52292,
-      "productId": 3
+      "resourceId": "52292",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -1950,8 +1950,8 @@
       "resource": "List Comments",
       "description": "List comments.",
       "key": "1_commentmanager_list",
-      "resourceId": 52293,
-      "productId": 3
+      "resourceId": "52293",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -1959,8 +1959,8 @@
       "resource": "Remove Comment",
       "description": "Delete comments.",
       "key": "1_commentmanager_delete",
-      "resourceId": 52294,
-      "productId": 3
+      "resourceId": "52294",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -1968,8 +1968,8 @@
       "resource": "List Custom Search",
       "description": "List custom search.",
       "key": "1_customsearch_list",
-      "resourceId": 52295,
-      "productId": 3
+      "resourceId": "52295",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -1977,8 +1977,8 @@
       "resource": "Exclude Custom Search",
       "description": "Remove custom search.",
       "key": "1_customsearch_delete",
-      "resourceId": 52296,
-      "productId": 3
+      "resourceId": "52296",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -1986,8 +1986,8 @@
       "resource": "List Forms",
       "description": "List forms.",
       "key": "1_form_list",
-      "resourceId": 52297,
-      "productId": 3
+      "resourceId": "52297",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -1995,8 +1995,8 @@
       "resource": "Create Forms",
       "description": "Create forms.",
       "key": "1_form_create",
-      "resourceId": 52298,
-      "productId": 3
+      "resourceId": "52298",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -2004,8 +2004,8 @@
       "resource": "Edit Forms",
       "description": "Edit forms.",
       "key": "1_form_edit",
-      "resourceId": 52299,
-      "productId": 3
+      "resourceId": "52299",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -2013,8 +2013,8 @@
       "resource": "Remove Form",
       "description": "Delete forms.",
       "key": "1_form_delete",
-      "resourceId": 52300,
-      "productId": 3
+      "resourceId": "52300",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -2022,8 +2022,8 @@
       "resource": "CRM administrator",
       "description": "Manage CRM information.",
       "key": "ADMIN_CRM",
-      "resourceId": 25786,
-      "productId": 3
+      "resourceId": "25786",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -2031,8 +2031,8 @@
       "resource": "Full access to forms",
       "description": "Full access to forms.",
       "key": "POWER_USER_CRM",
-      "resourceId": 52283,
-      "productId": 3
+      "resourceId": "52283",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -2040,8 +2040,8 @@
       "resource": "Access to insert and edit but not to delete",
       "description": "Read and edit access, but not removal.",
       "key": "NOREMOVE_USER_CRM",
-      "resourceId": 52284,
-      "productId": 3
+      "resourceId": "52284",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -2049,8 +2049,8 @@
       "resource": "Read-only form access",
       "description": "Read-only form access",
       "key": "READONLY_USER_CRM",
-      "resourceId": 52285,
-      "productId": 3
+      "resourceId": "52285",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -2058,8 +2058,8 @@
       "resource": "Run import",
       "description": "Run the import process.",
       "key": "3_import_run",
-      "resourceId": 52306,
-      "productId": 3
+      "resourceId": "52306",
+      "productId": "3"
     },
     {
       "product": "Message Center",
@@ -2067,8 +2067,8 @@
       "resource": "Send Message ",
       "description": "Send a message in the Message Center.",
       "key": "send-message",
-      "resourceId": 1026939,
-      "productId": 23
+      "resourceId": "1026939",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -2076,8 +2076,8 @@
       "resource": "View provider list",
       "description": "Viewing the list of senders in the Message Center.",
       "key": "provider-listar",
-      "resourceId": 52282,
-      "productId": 23
+      "resourceId": "52282",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -2085,8 +2085,8 @@
       "resource": "Add or edit provider",
       "description": "Create or edit senders (providers) created in the senders area of ​​the Message Center.",
       "key": "provider-salvar",
-      "resourceId": 52325,
-      "productId": 23
+      "resourceId": "52325",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -2094,8 +2094,8 @@
       "resource": "Remove provider",
       "description": "Remove senders created in the Message Center's senders area (providers).",
       "key": "provider-excluir",
-      "resourceId": 52326,
-      "productId": 23
+      "resourceId": "52326",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -2103,8 +2103,8 @@
       "resource": "View template list",
       "description": "View the list of available templates in the Message Center.",
       "key": "template-listar",
-      "resourceId": 1203,
-      "productId": 23
+      "resourceId": "1203",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -2112,8 +2112,8 @@
       "resource": "Add new template",
       "description": "Add new templates to the Message Center template list.",
       "key": "template-criar",
-      "resourceId": 1204,
-      "productId": 23
+      "resourceId": "1204",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -2121,8 +2121,8 @@
       "resource": "Remove template",
       "description": "Remove new templates from the Message Center template list.",
       "key": "template-excluir",
-      "resourceId": 1205,
-      "productId": 23
+      "resourceId": "1205",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -2130,8 +2130,8 @@
       "resource": "Edit template",
       "description": "Editing and customizing templates in the Message Center.",
       "key": "template-editar",
-      "resourceId": 1207,
-      "productId": 23
+      "resourceId": "1207",
+      "productId": "23"
     },
     {
       "product": "OMS",
@@ -2139,8 +2139,8 @@
       "resource": "Change order workflow status",
       "description": "Actions within the order flow to change the order status, via the Actions button in the flow.",
       "key": "WorkflowAction",
-      "resourceId": 1150,
-      "productId": 19
+      "resourceId": "1150",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -2148,8 +2148,8 @@
       "resource": "Notify payment",
       "description": "Access the button that manually notifies the payment gateway in the payment area within the order.",
       "key": "PaymentAction",
-      "resourceId": 1151,
-      "productId": 19
+      "resourceId": "1151",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -2157,8 +2157,8 @@
       "resource": "Notify invoice",
       "description": "Allows you to manually enter invoices (NF) and tracking data into the OMS.",
       "key": "ShippingAction",
-      "resourceId": 1152,
-      "productId": 19
+      "resourceId": "1152",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -2166,8 +2166,8 @@
       "resource": "View order",
       "description": "View all orders from the given account.",
       "key": "OMSViewer",
-      "resourceId": 1153,
-      "productId": 19
+      "resourceId": "1153",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -2175,8 +2175,8 @@
       "resource": "Notify refund",
       "description": "Allows you to notify us of an incoming invoice.",
       "key": "RefundAction",
-      "resourceId": 1407,
-      "productId": 19
+      "resourceId": "1407",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -2184,8 +2184,8 @@
       "resource": "Cancel order",
       "description": "Allows you to cancel an order in OMS.",
       "key": "CancelAction",
-      "resourceId": 1408,
-      "productId": 19
+      "resourceId": "1408",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -2193,8 +2193,8 @@
       "resource": "Order feed subscription",
       "description": "Allows the user to subscribe to receive order status updates in the Order Feed.",
       "key": "FeedSubscription",
-      "resourceId": 1409,
-      "productId": 19
+      "resourceId": "1409",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -2202,8 +2202,8 @@
       "resource": "Change order",
       "description": "Allows you to register changes to the order (discounts and/or exchanges).",
       "key": "Changes",
-      "resourceId": 1621,
-      "productId": 19
+      "resourceId": "1621",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -2211,8 +2211,8 @@
       "resource": "View store sales stats",
       "description": "Displays totals within the All Orders section of Order Management. Shows total sales in addition to order details.",
       "key": "ShowTotalizers",
-      "resourceId": 98200,
-      "productId": 19
+      "resourceId": "98200",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -2220,8 +2220,8 @@
       "resource": "Only show orders created by the user (via call center)",
       "description": "Orders will be processed via the email address registered with callcenteroperatoremail.",
       "key": "callCenterOperatorFilter",
-      "resourceId": 428968,
-      "productId": 19
+      "resourceId": "428968",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -2229,8 +2229,8 @@
       "resource": "Feed v3 and Hook Admin",
       "description": "Create, edit, and delete Feed v3/hook settings.",
       "key": "FeedHookV3Admin",
-      "resourceId": 592028,
-      "productId": 19
+      "resourceId": "592028",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -2238,8 +2238,8 @@
       "resource": "Feed v3 and Hook view only",
       "description": "View Feed v3/hook data.",
       "key": "FeedHookV3Viewer",
-      "resourceId": 592029,
-      "productId": 19
+      "resourceId": "592029",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -2247,7 +2247,7 @@
       "resource": "Subscription view only",
       "description": "View store subscription data.",
       "key": "SubscriptionViewer",
-      "resourceId": 592030,
+      "resourceId": "592030",
       "productId": ""
     },
     {
@@ -2256,7 +2256,7 @@
       "resource": "Subscription admin",
       "description": "Subscriptions Admin view and action. Access to the retry button.",
       "key": "SubscriptionAdmin",
-      "resourceId": 592031,
+      "resourceId": "592031",
       "productId": ""
     },
     {
@@ -2265,7 +2265,7 @@
       "resource": "Subscription metrics and reports",
       "description": "Access to metrics and report visualization on the Subscriptions dashboard.",
       "key": "SubscriptionMetrics",
-      "resourceId": 592032,
+      "resourceId": "592032",
       "productId": ""
     },
     {
@@ -2274,7 +2274,7 @@
       "resource": "Subscription view and edit",
       "description": "Allows viewing and editing of signatures.",
       "key": "SubscriptionManager",
-      "resourceId": 592033,
+      "resourceId": "592033",
       "productId": ""
     },
     {
@@ -2283,8 +2283,8 @@
       "resource": "List Orders",
       "description": "List all orders from the given account.",
       "key": "ListOrders",
-      "resourceId": 1860145,
-      "productId": 19
+      "resourceId": "1860145",
+      "productId": "19"
     },
     {
       "product": "Order Authorization",
@@ -2292,8 +2292,8 @@
       "resource": "Save Configuration",
       "description": "View and change the order acceptance settings for orders with value differences in the order authorization section within order management.",
       "key": "SaveConfiguration",
-      "resourceId": 600081,
-      "productId": 74
+      "resourceId": "600081",
+      "productId": "74"
     },
     {
       "product": "Order Authorization",
@@ -2301,8 +2301,8 @@
       "resource": "View Configuration",
       "description": "View the order acceptance settings for value differences in the order authorization section within order management.",
       "key": "ViewConfiguration",
-      "resourceId": 600082,
-      "productId": 74
+      "resourceId": "600082",
+      "productId": "74"
     },
     {
       "product": "PCI Gateway",
@@ -2310,8 +2310,8 @@
       "resource": "BIN Manager Edit Permission",
       "description": "Allows you to edit which bank or financial institution a given BIN belongs to.",
       "key": "binManagerEditPermission",
-      "resourceId": 631530,
-      "productId": 6
+      "resourceId": "631530",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -2319,8 +2319,8 @@
       "resource": "Process payments",
       "description": "It represents the transactional operations of the payment gateway.",
       "key": "MakePayments",
-      "resourceId": 1052,
-      "productId": 6
+      "resourceId": "1052",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -2328,8 +2328,8 @@
       "resource": "Manage Infrastructure",
       "description": "Perform critical configurations on the Gateway infrastructure. Available to administrators only.",
       "key": "ManageInfrastructure",
-      "resourceId": 1157,
-      "productId": 6
+      "resourceId": "1157",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -2337,8 +2337,8 @@
       "resource": "Manage Store",
       "description": "Change the settings.",
       "key": "ManageStore",
-      "resourceId": 1097,
-      "productId": 6
+      "resourceId": "1097",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -2346,8 +2346,8 @@
       "resource": "Manage Store Rules",
       "description": "Permission to manage the store's payment methods.",
       "key": "ManageStoreRules",
-      "resourceId": 1684986,
-      "productId": 6
+      "resourceId": "1684986",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -2355,8 +2355,8 @@
       "resource": "Manage Store Affiliations",
       "description": "Permission to manage the store's Gateway affiliations.",
       "key": "ManageStoreAffiliations",
-      "resourceId": 1684987,
-      "productId": 6
+      "resourceId": "1684987",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -2364,7 +2364,7 @@
       "resource": "Manage Store AntiFraud",
       "description": "Permission to manage the anti-fraud features of the store's payment methods.",
       "key": "ManageStoreAntiFraud ",
-      "resourceId": 1684988,
+      "resourceId": "1684988",
       "productId": ""
     },
     {
@@ -2373,8 +2373,8 @@
       "resource": "Notify Payments",
       "description": "Payment approval notification.",
       "key": "NotifyPayments",
-      "resourceId": 1512,
-      "productId": 6
+      "resourceId": "1512",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -2382,8 +2382,8 @@
       "resource": "Payments Notification",
       "description": "Payment approval notification using the Payments Gateway API.",
       "key": "PaymentsNotification",
-      "resourceId": 2061772,
-      "productId": 6
+      "resourceId": "2061772",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -2391,8 +2391,8 @@
       "resource": "View Payment Data",
       "description": "Retrieve a transaction.",
       "key": "ViewPayments",
-      "resourceId": 1096,
-      "productId": 6
+      "resourceId": "1096",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -2400,8 +2400,8 @@
       "resource": "View Payments Sensitive Data",
       "description": "Viewing personally identifiable information (PII) for stores that use a data privacy compliance environment.",
       "key": "ViewPaymentsSensitiveData",
-      "resourceId": 1515091,
-      "productId": 6
+      "resourceId": "1515091",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -2409,8 +2409,8 @@
       "resource": "BIN Manager View Permission",
       "description": "Allows you to search and view which bank or financial institution a given BIN belongs to.",
       "key": "binManagerViewPermission",
-      "resourceId": 631529,
-      "productId": 6
+      "resourceId": "631529",
+      "productId": "6"
     },
     {
       "product": "Payments",
@@ -2418,8 +2418,8 @@
       "resource": "View Card Tokens",
       "description": "Allows viewing of tokenized card data.",
       "key": "ViewCardTokens",
-      "resourceId": 2078628,
-      "productId": 114
+      "resourceId": "2078628",
+      "productId": "114"
     },
     {
       "product": "Payments",
@@ -2427,8 +2427,8 @@
       "resource": "Edit Card Tokens",
       "description": "Allows editing of data from tokenized cards previously created in the Card Token Vault.",
       "key": "ManageCardTokens",
-      "resourceId": 2078744,
-      "productId": 114
+      "resourceId": "2078744",
+      "productId": "114"
     },
     {
       "product": "Payments",
@@ -2436,8 +2436,8 @@
       "resource": "Create Card Tokens",
       "description": "Allows tokenized cards to be stored.",
       "key": "CreateCardTokens",
-      "resourceId": 2078845,
-      "productId": 114
+      "resourceId": "2078845",
+      "productId": "114"
     },
     {
       "product": "Payments",
@@ -2445,8 +2445,8 @@
       "resource": "Delete Card Token",
       "description": "Allows you to delete a previously stored tokenized card.",
       "key": "DeleteCardToken",
-      "resourceId": 2078846,
-      "productId": 114
+      "resourceId": "2078846",
+      "productId": "114"
     },
     {
       "product": "Payments",
@@ -2454,8 +2454,8 @@
       "resource": "Import Card Token",
       "description": "Allows you to initiate the import of credit card tokens.",
       "key": "ImportCardToken",
-      "resourceId": 2078847,
-      "productId": 114
+      "resourceId": "2078847",
+      "productId": "114"
     },
     {
       "product": "Payments",
@@ -2463,8 +2463,8 @@
       "resource": "Get Import Card Token Status ",
       "description": "Allows you to view the token import status.",
       "key": "GetImportCardTokenStatus",
-      "resourceId": 2078848,
-      "productId": 114
+      "resourceId": "2078848",
+      "productId": "114"
     },
     {
       "product": "Payments",
@@ -2472,8 +2472,8 @@
       "resource": "Get Import Card Tokens Report",
       "description": "Download the error report for the import errors that occurred.",
       "key": "GetImportCardTokensReport",
-      "resourceId": 2078849,
-      "productId": 114
+      "resourceId": "2078849",
+      "productId": "114"
     },
     {
       "product": "PersonalShopper App",
@@ -2481,8 +2481,8 @@
       "resource": "View Analytics",
       "description": "View Analytics for the Personal Shopper app.",
       "key": "view-analytics",
-      "resourceId": 1639728,
-      "productId": 100
+      "resourceId": "1639728",
+      "productId": "100"
     },
     {
       "product": "PersonalShopper App",
@@ -2490,8 +2490,8 @@
       "resource": "View List Call",
       "description": "View the call page.",
       "key": "view-list-call",
-      "resourceId": 1639430,
-      "productId": 100
+      "resourceId": "1639430",
+      "productId": "100"
     },
     {
       "product": "PersonalShopper App",
@@ -2499,8 +2499,8 @@
       "resource": "View Setting",
       "description": "Edit Personal Shopper app settings.",
       "key": "view-setting",
-      "resourceId": 1643056,
-      "productId": 100
+      "resourceId": "1643056",
+      "productId": "100"
     },
     {
       "product": "Portal",
@@ -2508,8 +2508,8 @@
       "resource": "Manage portal",
       "description": "Create and edit templates, shelves, and pages in the CMS (Portal) and edit Checkout settings.",
       "key": "AdminPortal",
-      "resourceId": 1299,
-      "productId": 27
+      "resourceId": "1299",
+      "productId": "27"
     },
     {
       "product": "Pricing",
@@ -2517,8 +2517,8 @@
       "resource": "Read prices",
       "description": "View all prices for a SKU.",
       "key": "read_prices",
-      "resourceId": 152730,
-      "productId": 65
+      "resourceId": "152730",
+      "productId": "65"
     },
     {
       "product": "Pricing",
@@ -2526,8 +2526,8 @@
       "resource": "Modify prices",
       "description": "Change or create a price for a SKU.",
       "key": "modify_prices",
-      "resourceId": 152731,
-      "productId": 65
+      "resourceId": "152731",
+      "productId": "65"
     },
     {
       "product": "Pricing",
@@ -2535,8 +2535,8 @@
       "resource": "Read trade policy configurations",
       "description": "View all commercial policies for the account.",
       "key": "read_tradePolicySettings",
-      "resourceId": 152732,
-      "productId": 65
+      "resourceId": "152732",
+      "productId": "65"
     },
     {
       "product": "Pricing",
@@ -2544,8 +2544,8 @@
       "resource": "Modify trade policy configurations",
       "description": "Delete all commercial policies from the account.",
       "key": "modify_tradePolicySettings",
-      "resourceId": 152733,
-      "productId": 65
+      "resourceId": "152733",
+      "productId": "65"
     },
     {
       "product": "Pricing",
@@ -2553,8 +2553,8 @@
       "resource": "Delete all prices from account",
       "description": "Delete all prices from the account.",
       "key": "modify_prices_delete_all",
-      "resourceId": 152736,
-      "productId": 65
+      "resourceId": "152736",
+      "productId": "65"
     },
     {
       "product": "Promotions Policy Engine",
@@ -2562,8 +2562,8 @@
       "resource": "Evaluate Policy",
       "description": "Obtain policy evaluation.",
       "key": "EvaluatePolicy",
-      "resourceId": 1212434,
-      "productId": 89
+      "resourceId": "1212434",
+      "productId": "89"
     },
     {
       "product": "Promotions Policy Engine",
@@ -2571,8 +2571,8 @@
       "resource": "Create or Update Policy",
       "description": "Create or update a policy.",
       "key": "CreateOrUpdatePolicy",
-      "resourceId": 1212435,
-      "productId": 89
+      "resourceId": "1212435",
+      "productId": "89"
     },
     {
       "product": "Promotions Policy Engine",
@@ -2580,8 +2580,8 @@
       "resource": "Get Policy",
       "description": "To obtain the policy objective.",
       "key": "GetPolicy",
-      "resourceId": 1212492,
-      "productId": 89
+      "resourceId": "1212492",
+      "productId": "89"
     },
     {
       "product": "Promotions Policy Engine",
@@ -2589,8 +2589,8 @@
       "resource": "Delete Policy",
       "description": "Delete a policy.",
       "key": "DeletePolicy",
-      "resourceId": 1212493,
-      "productId": 89
+      "resourceId": "1212493",
+      "productId": "89"
     },
     {
       "product": "Promotions Policy Engine",
@@ -2598,8 +2598,8 @@
       "resource": "List Policies",
       "description": "List the existing policies.",
       "key": "ListPolicies",
-      "resourceId": 1212494,
-      "productId": 89
+      "resourceId": "1212494",
+      "productId": "89"
     },
     {
       "product": "Rates and Benefits",
@@ -2607,8 +2607,8 @@
       "resource": "Manage benefits and rates",
       "description": "Create, edit, or archive promotions, coupons, campaigns, and fees.",
       "key": "GerenciarPromocoesETarifas",
-      "resourceId": 98201,
-      "productId": 16
+      "resourceId": "98201",
+      "productId": "16"
     },
     {
       "product": "Rates and Benefits",
@@ -2616,8 +2616,8 @@
       "resource": "Manage Policies",
       "description": "Enable the management of commercial policies.",
       "key": "GerenciarPolicies",
-      "resourceId": 1118700,
-      "productId": 16
+      "resourceId": "1118700",
+      "productId": "16"
     },
     {
       "product": "Releases",
@@ -2625,8 +2625,8 @@
       "resource": "Edit Release",
       "description": "Creating, scheduling, rescheduling, and deleting entries.",
       "key": "edit-release",
-      "resourceId": 1257521,
-      "productId": 91
+      "resourceId": "1257521",
+      "productId": "91"
     },
     {
       "product": "Releases",
@@ -2634,8 +2634,8 @@
       "resource": "Visualize Releases",
       "description": "View the list of releases and updates for each release.",
       "key": "get-release",
-      "resourceId": 1257551,
-      "productId": 91
+      "resourceId": "1257551",
+      "productId": "91"
     },
     {
       "product": "Sales App",
@@ -2643,8 +2643,8 @@
       "resource": "View Sales Performance",
       "description": "Allows the sales associate to view the sales performance page in the VTEX Sales App for a sales operation point (physical store).",
       "key": "ViewSalesPerformance",
-      "resourceId": 2126563,
-      "productId": 132
+      "resourceId": "2126563",
+      "productId": "132"
     },
     {
       "product": "Search",
@@ -2652,8 +2652,8 @@
       "resource": "General Settings",
       "description": "Edit general settings for VTEX Intelligent Search.",
       "key": "general-settings",
-      "resourceId": 719379,
-      "productId": 76
+      "resourceId": "719379",
+      "productId": "76"
     },
     {
       "product": "Security Monitor",
@@ -2661,8 +2661,8 @@
       "resource": "View Findings",
       "description": "Obtain, list and view information about findings and types of findings in the Security Monitor.",
       "key": "ViewFindings",
-      "resourceId": 2000228,
-      "productId": 103
+      "resourceId": "2000228",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -2670,8 +2670,8 @@
       "resource": "Edit Findings",
       "description": "Snooze or unsnooze a finding in the Security Monitor.",
       "key": "EditFindings",
-      "resourceId": 2000236,
-      "productId": 103
+      "resourceId": "2000236",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -2679,8 +2679,8 @@
       "resource": "Edit Notification Settings",
       "description": "Edit the notification recipient settings on Security Monitor alerts.",
       "key": "EditNotificationSettings",
-      "resourceId": 2000244,
-      "productId": 103
+      "resourceId": "2000244",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -2688,8 +2688,8 @@
       "resource": "List/Describe reports",
       "description": "View a report or list of reports in Security Monitor.",
       "key": "read-reports",
-      "resourceId": 1858423,
-      "productId": 103
+      "resourceId": "1858423",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -2697,8 +2697,8 @@
       "resource": "List/Describe Sensors",
       "description": "View sensor details in Security Monitor.",
       "key": "read-sensors",
-      "resourceId": 1880664,
-      "productId": 103
+      "resourceId": "1880664",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -2706,8 +2706,8 @@
       "resource": "Read Notifications Settings",
       "description": "Read Security Monitor notification settings.",
       "key": "read-notifications-settings",
-      "resourceId": 1980709,
-      "productId": 103
+      "resourceId": "1980709",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -2715,8 +2715,8 @@
       "resource": "Create Reports",
       "description": "Create new reports in Security Monitor.",
       "key": "write-reports",
-      "resourceId": 1858424,
-      "productId": 103
+      "resourceId": "1858424",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -2724,8 +2724,8 @@
       "resource": "Update Sensors",
       "description": "Enable or disable sensors in Security Monitor.",
       "key": "update-sensors",
-      "resourceId": 1880649,
-      "productId": 103
+      "resourceId": "1880649",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -2733,8 +2733,8 @@
       "resource": "Write Notifications Settings",
       "description": "Edit Security Monitor notification settings.",
       "key": "write-notifications-settings",
-      "resourceId": 1980710,
-      "productId": 103
+      "resourceId": "1980710",
+      "productId": "103"
     },
     {
       "product": "Seller Register",
@@ -2742,8 +2742,8 @@
       "resource": "View Seller",
       "description": "View all sellers linked to the marketplace account described on the Seller Management page, including retrieving seller data, either from the seller list or a specific seller.",
       "key": "view-seller",
-      "resourceId": 575457,
-      "productId": 73
+      "resourceId": "575457",
+      "productId": "73"
     },
     {
       "product": "Seller Register",
@@ -2751,8 +2751,8 @@
       "resource": "Save Seller",
       "description": "Create new sellers and edit data for all sellers linked to the marketplace account from the Seller Management page.",
       "key": "save-seller",
-      "resourceId": 575458,
-      "productId": 73
+      "resourceId": "575458",
+      "productId": "73"
     },
     {
       "product": "Subscriptions",
@@ -2760,7 +2760,7 @@
       "resource": "Subscription view only",
       "description": "View store subscription data.",
       "key": "SubscriptionViewer",
-      "resourceId": 592030,
+      "resourceId": "592030",
       "productId": ""
     },
     {
@@ -2769,7 +2769,7 @@
       "resource": "Subscription admin",
       "description": "Subscriptions Admin view and action. Access to the retry button.",
       "key": "SubscriptionAdmin",
-      "resourceId": 592031,
+      "resourceId": "592031",
       "productId": ""
     },
     {
@@ -2778,7 +2778,7 @@
       "resource": "Subscription view and edit",
       "description": "Viewing and editing signatures.",
       "key": "SubscriptionManager",
-      "resourceId": 592033,
+      "resourceId": "592033",
       "productId": ""
     },
     {
@@ -2787,7 +2787,7 @@
       "resource": "Subscription metrics and reports",
       "description": "View metrics and reports on the Subscription dashboard.",
       "key": "SubscriptionMetrics",
-      "resourceId": 592032,
+      "resourceId": "592032",
       "productId": ""
     },
     {
@@ -2796,8 +2796,8 @@
       "resource": "Main Access",
       "description": "Unrestricted access to all components of the Received SKUs page, including viewing page data, as well as ad approval actions. Learn more at [Received SKUs Cataloging](https://help.vtex.com/pt/tutorial/sugerindo-e-aprovando-skus/).",
       "key": "suggestions",
-      "resourceId": 109448,
-      "productId": 50
+      "resourceId": "109448",
+      "productId": "50"
     },
     {
       "product": "User Rights",
@@ -2805,7 +2805,7 @@
       "resource": "Read Applications",
       "description": "View operations in user rights applications, either in list or detailed view.",
       "key": "applications_read",
-      "resourceId": 1634515,
+      "resourceId": "1634515",
       "productId": ""
     },
     {
@@ -2814,7 +2814,7 @@
       "resource": "Write Applications",
       "description": "Create, update, or remove user rights applications.",
       "key": "applications_write",
-      "resourceId": 1634523,
+      "resourceId": "1634523",
       "productId": ""
     },
     {
@@ -2823,8 +2823,8 @@
       "resource": "Read user rights requests",
       "description": "View user rights requests, either in list or detailed format.",
       "key": "user_rights_request_read",
-      "resourceId": 1634546,
-      "productId": 99
+      "resourceId": "1634546",
+      "productId": "99"
     },
     {
       "product": "User Rights",
@@ -2832,8 +2832,8 @@
       "resource": "Write user rights requests",
       "description": "Create, update, or remove user rights requests.",
       "key": "user_rights_request_write",
-      "resourceId": 1634554,
-      "productId": 99
+      "resourceId": "1634554",
+      "productId": "99"
     },
     {
       "product": "User Rights",
@@ -2841,8 +2841,8 @@
       "resource": "Process User Rights Removal Request",
       "description": "Process user rights requests of the removal type.",
       "key": "removal-request-process",
-      "resourceId": 1705138,
-      "productId": 99
+      "resourceId": "1705138",
+      "productId": "99"
     },
     {
       "product": "VTEX Ad Network",
@@ -2850,8 +2850,8 @@
       "resource": "View Advertiser's details",
       "description": "View advertiser information relating to the VTEX Ad Network.",
       "key": "view-advertiser-details",
-      "resourceId": 2012197,
-      "productId": 106
+      "resourceId": "2012197",
+      "productId": "106"
     },
     {
       "product": "VTEX Ad Network",
@@ -2859,8 +2859,8 @@
       "resource": "View Advertiser's campaigns",
       "description": "View campaign information for a VTEX Ad Network advertiser.",
       "key": "view-advertiser-campaigns",
-      "resourceId": 2012200,
-      "productId": 106
+      "resourceId": "2012200",
+      "productId": "106"
     },
     {
       "product": "VTEX Ad Network",
@@ -2868,8 +2868,8 @@
       "resource": "Edit Advertiser's campaigns",
       "description": "Edit campaign information for a VTEX Ad Network advertiser.",
       "key": "edit-advertiser-campaigns",
-      "resourceId": 2012201,
-      "productId": 106
+      "resourceId": "2012201",
+      "productId": "106"
     },
     {
       "product": "VTEX Ad Network",
@@ -2877,8 +2877,8 @@
       "resource": "View Publisher's details",
       "description": "View merchant information regarding the publishing of VTEX Ad Network ads.",
       "key": "view-publisher-details",
-      "resourceId": 2012196,
-      "productId": 106
+      "resourceId": "2012196",
+      "productId": "106"
     },
     {
       "product": "VTEX Bridge",
@@ -2886,8 +2886,8 @@
       "resource": "List Itens",
       "description": "Viewing Bridge documents.",
       "key": "listItems",
-      "resourceId": 106704,
-      "productId": 48
+      "resourceId": "106704",
+      "productId": "48"
     },
     {
       "product": "VTEX Bridge",
@@ -2895,8 +2895,8 @@
       "resource": "Execute Actions",
       "description": "Take action on a log item. For example, reprocess the submission of a particular item.",
       "key": "executeActions",
-      "resourceId": 106965,
-      "productId": 48
+      "resourceId": "106965",
+      "productId": "48"
     },
     {
       "product": "VTEX Bridge",
@@ -2904,8 +2904,8 @@
       "resource": "View Configs",
       "description": "Viewing the settings for each integration.",
       "key": "viewConfig",
-      "resourceId": 106706,
-      "productId": 48
+      "resourceId": "106706",
+      "productId": "48"
     },
     {
       "product": "VTEX Bridge",
@@ -2913,8 +2913,8 @@
       "resource": "Manage Configs",
       "description": "Edit the settings of an integration.",
       "key": "editConfig",
-      "resourceId": 106707,
-      "productId": 48
+      "resourceId": "106707",
+      "productId": "48"
     },
     {
       "product": "VTEX IO",
@@ -2922,8 +2922,8 @@
       "resource": "Manage A/B Test",
       "description": "Start, finish, or obtain the status of an A/B test.",
       "key": "manage-abtest",
-      "resourceId": 664798,
-      "productId": 66
+      "resourceId": "664798",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -2931,8 +2931,8 @@
       "resource": "Read Workspace Apps",
       "description": "Reading the applications installed in the workspace and their dependencies.",
       "key": "read-workspace-apps",
-      "resourceId": 253175,
-      "productId": 66
+      "resourceId": "253175",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -2940,8 +2940,8 @@
       "resource": "Link App",
       "description": "Link and unlink applications, as well as list existing links within a given application.",
       "key": "link-app",
-      "resourceId": 253206,
-      "productId": 66
+      "resourceId": "253206",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -2949,8 +2949,8 @@
       "resource": "Install App",
       "description": "Installing and uninstalling applications without billing options.",
       "key": "install-apps",
-      "resourceId": 253207,
-      "productId": 66
+      "resourceId": "253207",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -2958,8 +2958,8 @@
       "resource": "Vbase Read Only",
       "description": "VBase read-only.",
       "key": "vbase-read-only",
-      "resourceId": 253582,
-      "productId": 66
+      "resourceId": "253582",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -2967,8 +2967,8 @@
       "resource": "Vbase Read Write",
       "description": "Reading and writing to VBase.",
       "key": "vbase-read-write",
-      "resourceId": 253583,
-      "productId": 66
+      "resourceId": "253583",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -2976,8 +2976,8 @@
       "resource": "Read Workspace Services",
       "description": "Reading the infrastructure of applications installed on the desktop.",
       "key": "read-workspace-services",
-      "resourceId": 257862,
-      "productId": 66
+      "resourceId": "257862",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -2985,8 +2985,8 @@
       "resource": "Install Service",
       "description": "Installation and uninstallation of infrastructure services.",
       "key": "install-services",
-      "resourceId": 257864,
-      "productId": 66
+      "resourceId": "257864",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -2994,8 +2994,8 @@
       "resource": "Log Access - Read-only",
       "description": "Reading logs from all applications.",
       "key": "colossus-read-logs",
-      "resourceId": 259184,
-      "productId": 66
+      "resourceId": "259184",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -3003,8 +3003,8 @@
       "resource": "Read Published Service",
       "description": "Reading data from the infra-registry services.",
       "key": "read-infra-service",
-      "resourceId": 259251,
-      "productId": 66
+      "resourceId": "259251",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -3012,8 +3012,8 @@
       "resource": "Debug App",
       "description": "Connect a debugger to a linked application.",
       "key": "debug-app",
-      "resourceId": 377794,
-      "productId": 66
+      "resourceId": "377794",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -3021,8 +3021,8 @@
       "resource": "Workspace CRUD",
       "description": "Creation, deletion, and modification of workspaces.",
       "key": "workspace-read-write",
-      "resourceId": 379639,
-      "productId": 66
+      "resourceId": "379639",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -3030,8 +3030,8 @@
       "resource": "Buy App",
       "description": "Installation and uninstallation of all types of applications, including those with billing options.",
       "key": "buy-app",
-      "resourceId": 382623,
-      "productId": 66
+      "resourceId": "382623",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -3039,8 +3039,8 @@
       "resource": "Import Redirects",
       "description": "Manage redirects using the VTEX IO command-line interface.",
       "key": "import-redirects",
-      "resourceId": 661667,
-      "productId": 66
+      "resourceId": "661667",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -3048,8 +3048,8 @@
       "resource": "Workspace Manipulation",
       "description": "Create, modify, and delete a workspace.",
       "key": "workspace-read-write-v2",
-      "resourceId": 794788,
-      "productId": 66
+      "resourceId": "794788",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -3057,8 +3057,8 @@
       "resource": "Workspace Promotion",
       "description": "To promote a workspace.",
       "key": "workspace-promote",
-      "resourceId": 794789,
-      "productId": 66
+      "resourceId": "794789",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -3066,8 +3066,8 @@
       "resource": "Read Edition",
       "description": "Reading the edited version of an account or workspace.",
       "key": "read-edition",
-      "resourceId": 797718,
-      "productId": 66
+      "resourceId": "797718",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -3075,8 +3075,8 @@
       "resource": "Allow APP configuration",
       "description": "Configure applications.",
       "key": "read-write-apps-settings",
-      "resourceId": 808001,
-      "productId": 66
+      "resourceId": "808001",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -3084,8 +3084,8 @@
       "resource": "Change sponsored tenant edition",
       "description": "Define the edition of a tenant that is sponsored by the account where this permission is granted.",
       "key": "change-edition-of-sponsored-tenant",
-      "resourceId": 945388,
-      "productId": 66
+      "resourceId": "945388",
+      "productId": "66"
     },
     {
       "product": "VTEX Support",
@@ -3093,8 +3093,8 @@
       "resource": "Open Support Ticket",
       "description": "Open support ticket for VTEX. Valid only for accounts in Brazil.",
       "key": "open-support-ticket",
-      "resourceId": 1945378,
-      "productId": 104
+      "resourceId": "1945378",
+      "productId": "104"
     },
     {
       "product": "VTable",
@@ -3102,8 +3102,8 @@
       "resource": "View apps",
       "description": "VTable app visualization.",
       "key": "view-apps",
-      "resourceId": 257872,
-      "productId": 67
+      "resourceId": "257872",
+      "productId": "67"
     },
     {
       "product": "VTable",
@@ -3111,8 +3111,8 @@
       "resource": "Main access",
       "description": "Main access point of the VTable.",
       "key": "main_access_old",
-      "resourceId": 258007,
-      "productId": 67
+      "resourceId": "258007",
+      "productId": "67"
     },
     {
       "product": "Vtex ID",
@@ -3120,8 +3120,8 @@
       "resource": "Write Identity Providers",
       "description": "Create and update the identity providers (admin and webstore) for an account.",
       "key": "write_identity_providers",
-      "resourceId": 631952,
-      "productId": 64
+      "resourceId": "631952",
+      "productId": "64"
     },
     {
       "product": "Vtex ID",
@@ -3129,8 +3129,8 @@
       "resource": "Read Identity Providers",
       "description": "Read the identity providers (admin and webstore) of an account.",
       "key": "read_identity_providers",
-      "resourceId": 631953,
-      "productId": 64
+      "resourceId": "631953",
+      "productId": "64"
     },
     {
       "product": "Vtex ID",
@@ -3138,8 +3138,8 @@
       "resource": "Can Punchout",
       "description": "Allow API keys to authenticate users via punchout.",
       "key": "CanPunchout",
-      "resourceId": 2074726,
-      "productId": 64
+      "resourceId": "2074726",
+      "productId": "64"
     },
     {
       "product": "Vtex ID",
@@ -3147,8 +3147,8 @@
       "resource": "Expire User Password",
       "description": "Define the password of a given user as null.",
       "key": "expire_user_password",
-      "resourceId": 1844857,
-      "productId": 64
+      "resourceId": "1844857",
+      "productId": "64"
     },
     {
       "product": "Vtex ID",
@@ -3156,8 +3156,8 @@
       "resource": "Create User",
       "description": "Create a front-end user.",
       "key": "CreateUser",
-      "resourceId": 2117393,
-      "productId": 64
+      "resourceId": "2117393",
+      "productId": "64"
     },
     {
       "product": "WebService",
@@ -3165,8 +3165,8 @@
       "resource": "Webservice access",
       "description": "Create, edit, and delete catalog information using the WebService.",
       "key": "orders",
-      "resourceId": 136106,
-      "productId": 61
+      "resourceId": "136106",
+      "productId": "61"
     }
   ],
   "es": [
@@ -3176,8 +3176,8 @@
       "resource": "Read logs stream",
       "description": "Lea los registros de la aplicación VTEX IO pertenecientes a esta cuenta.",
       "key": "read_logs",
-      "resourceId": 728560,
-      "productId": 81
+      "resourceId": "728560",
+      "productId": "81"
     },
     {
       "product": "Audit",
@@ -3185,8 +3185,8 @@
       "resource": "Save Event",
       "description": "Guardar eventos de auditoría.",
       "key": "SaveEvent",
-      "resourceId": 1353337,
-      "productId": 55
+      "resourceId": "1353337",
+      "productId": "55"
     },
     {
       "product": "B2B",
@@ -3194,8 +3194,8 @@
       "resource": "B2BBulkExport",
       "description": "Permite a las tiendas B2B exportar sus datos de forma masiva a archivos.",
       "key": "B2BBulkExport",
-      "resourceId": 2045795,
-      "productId": 105
+      "resourceId": "2045795",
+      "productId": "105"
     },
     {
       "product": "B2B",
@@ -3203,8 +3203,8 @@
       "resource": "B2BBulkImport",
       "description": "Permite que las tiendas B2B importen varias organizaciones de compras para la solución VTEX B2B.",
       "key": "B2BBulkImport",
-      "resourceId": 1954299,
-      "productId": 105
+      "resourceId": "1954299",
+      "productId": "105"
     },
     {
       "product": "B2B",
@@ -3212,8 +3212,8 @@
       "resource": "BulkImportTest",
       "description": "Permite a las tiendas B2B importar de forma masiva múltiples organizaciones de compradores a la solución B2B de VTEX.",
       "key": "BulkImportTest",
-      "resourceId": 1957237,
-      "productId": 105
+      "resourceId": "1957237",
+      "productId": "105"
     },
     {
       "product": "Billing",
@@ -3221,8 +3221,8 @@
       "resource": "Edit Company Information",
       "description": "Edite la información de registro de un cliente, que incluye: nombre de la empresa, nombre comercial, sucursal, región de ventas, nivel, estado de facturación y dirección.",
       "key": "edit_company",
-      "resourceId": 118281,
-      "productId": 43
+      "resourceId": "118281",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -3230,8 +3230,8 @@
       "resource": "Display Company info",
       "description": "Consulte la información de registro de un cliente, que incluye: nombre de la empresa, nombre comercial, sucursal, región de ventas, nivel, estado de facturación y dirección.",
       "key": "get_company",
-      "resourceId": 118283,
-      "productId": 43
+      "resourceId": "118283",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -3239,8 +3239,8 @@
       "resource": "Edit Company's Document",
       "description": "Editar documentos e información de la empresa.",
       "key": "edit_companys_document",
-      "resourceId": 131970,
-      "productId": 43
+      "resourceId": "131970",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -3248,8 +3248,8 @@
       "resource": "Merge companies",
       "description": "Realizar una fusión de dos cuentas, de modo que toda la información de facturas y contratos de una cuenta se transfiera a la otra.",
       "key": "company_merge",
-      "resourceId": 277452,
-      "productId": 43
+      "resourceId": "277452",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -3257,8 +3257,8 @@
       "resource": "Split companies",
       "description": "Separe dos cuentas: en una registre la información de facturas y contratos, y en la otra deje el texto en blanco.",
       "key": "company_split",
-      "resourceId": 277453,
-      "productId": 43
+      "resourceId": "277453",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -3266,8 +3266,8 @@
       "resource": "Contacts List ",
       "description": "Consulta qué contactos reciben notificaciones por correo electrónico cuando se genera la factura de un cliente específico.",
       "key": "list_contacts",
-      "resourceId": 118284,
-      "productId": 43
+      "resourceId": "118284",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -3275,8 +3275,8 @@
       "resource": "Edit Contacts",
       "description": "Agregar o editar un contacto.",
       "key": "edit_contact",
-      "resourceId": 118285,
-      "productId": 43
+      "resourceId": "118285",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -3284,8 +3284,8 @@
       "resource": "Contracts List ",
       "description": "Consulte los contratos y las condiciones de facturación registradas en el módulo de Facturas de la plataforma VTEX.",
       "key": "list_contracts",
-      "resourceId": 118282,
-      "productId": 43
+      "resourceId": "118282",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -3293,8 +3293,8 @@
       "resource": "Save contracts",
       "description": "Edite los contratos en el módulo de Facturas de la plataforma VTEX, incluyendo el registro de facturas de cualquier valor y el cálculo de comisiones en cualquier porcentaje.",
       "key": "put_contract",
-      "resourceId": 134738,
-      "productId": 43
+      "resourceId": "134738",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -3302,8 +3302,8 @@
       "resource": "Invoices List ",
       "description": "Visualización de la lista de facturas del cliente, así como de los detalles de la factura, que incluyen información como el volumen bruto de mercancías (GMV) y el margen de beneficio.",
       "key": "list_invoices",
-      "resourceId": 105015,
-      "productId": 43
+      "resourceId": "105015",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -3311,8 +3311,8 @@
       "resource": "Generate new Invoice",
       "description": "Crea una factura para un cliente, pero solo cuando ya se haya creado un contrato con un valor definido. Esta función no permite al usuario establecer el importe de la factura.",
       "key": "put_invoices",
-      "resourceId": 120233,
-      "productId": 43
+      "resourceId": "120233",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -3320,8 +3320,8 @@
       "resource": "Cancel Invoice Document",
       "description": "Cancelar el documento fiscal generado por el emisor.",
       "key": "cancel_nfe",
-      "resourceId": 134739,
-      "productId": 43
+      "resourceId": "134739",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -3329,8 +3329,8 @@
       "resource": "Issue Invoice Document",
       "description": "Genere el documento fiscal, pero solo en la plataforma del emisor.",
       "key": "issue_nfe",
-      "resourceId": 134740,
-      "productId": 43
+      "resourceId": "134740",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -3338,8 +3338,8 @@
       "resource": "Invoice reconciliation",
       "description": "Informar al sistema de la fecha y el importe pagado de una factura.",
       "key": "conciliate_invoice",
-      "resourceId": 134741,
-      "productId": 43
+      "resourceId": "134741",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -3347,8 +3347,8 @@
       "resource": "Generate Invoice for overdue payment without added interest fees",
       "description": "Modifique la fecha de vencimiento de una factura sin incurrir en recargos por mora ni intereses.",
       "key": "generate_invoice_overdue_without_interest",
-      "resourceId": 134743,
-      "productId": 43
+      "resourceId": "134743",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -3356,8 +3356,8 @@
       "resource": "Cancel Invoice",
       "description": "Cancelación de una factura en el módulo de Facturas de la plataforma VTEX y en el emisor.",
       "key": "cancel_invoice",
-      "resourceId": 134744,
-      "productId": 43
+      "resourceId": "134744",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -3365,8 +3365,8 @@
       "resource": "Change payment status",
       "description": "Cambie el estado de pago de la empresa a: Alerta, Bloqueado, Temporizador o Aceptar.",
       "key": "set_paymentstatus",
-      "resourceId": 138192,
-      "productId": 43
+      "resourceId": "138192",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -3374,8 +3374,8 @@
       "resource": "Unpaid invoices",
       "description": "Al restablecer una factura al estado de \"abierta\", se cancelará la fecha de pago y el importe pagado.",
       "key": "unpaid_invoices",
-      "resourceId": 525925,
-      "productId": 43
+      "resourceId": "525925",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -3383,8 +3383,8 @@
       "resource": "Simulate Invoices Creation",
       "description": "Simular facturas sin crearlas realmente.",
       "key": "simulate_invoices",
-      "resourceId": 1362361,
-      "productId": 43
+      "resourceId": "1362361",
+      "productId": "43"
     },
     {
       "product": "Buyer Organizations",
@@ -3392,8 +3392,8 @@
       "resource": "Buyer Organization View",
       "description": "Consulte la lista de organizaciones compradoras.",
       "key": "buyer_organization_view",
-      "resourceId": 1522234,
-      "productId": 97
+      "resourceId": "1522234",
+      "productId": "97"
     },
     {
       "product": "Buyer Organizations",
@@ -3401,8 +3401,8 @@
       "resource": "Buyer Organization Edit",
       "description": "Crear o editar organizaciones de compras.",
       "key": "buyer_organization_edit",
-      "resourceId": 1522235,
-      "productId": 97
+      "resourceId": "1522235",
+      "productId": "97"
     },
     {
       "product": "CDN API",
@@ -3410,8 +3410,8 @@
       "resource": "View certificate",
       "description": "Ver detalles del certificado CDN.",
       "key": "ViewCertificate",
-      "resourceId": 2022646,
-      "productId": 108
+      "resourceId": "2022646",
+      "productId": "108"
     },
     {
       "product": "CDN API",
@@ -3419,8 +3419,8 @@
       "resource": "Update certificate",
       "description": "Sustituir los certificados CDN existentes.",
       "key": "UpdateCertificate",
-      "resourceId": 2022647,
-      "productId": 108
+      "resourceId": "2022647",
+      "productId": "108"
     },
     {
       "product": "CDN API",
@@ -3428,8 +3428,8 @@
       "resource": "View WafControl Metrics",
       "description": "Ver métricas WAF.",
       "key": "ViewWafControlMetrics",
-      "resourceId": 2142573,
-      "productId": 108
+      "resourceId": "2142573",
+      "productId": "108"
     },
     {
       "product": "CDN Service",
@@ -3437,8 +3437,8 @@
       "resource": "Query status of domains",
       "description": "Permite al usuario comprobar el estado de los dominios de la tienda en producción.",
       "key": "query-domain",
-      "resourceId": 1271517,
-      "productId": 84
+      "resourceId": "1271517",
+      "productId": "84"
     },
     {
       "product": "CMS",
@@ -3446,8 +3446,8 @@
       "resource": "See CMS menu on the top-bar",
       "description": "Consulta el menú del CMS en la barra superior.",
       "key": "topbar_visualizar",
-      "resourceId": 111439,
-      "productId": 38
+      "resourceId": "111439",
+      "productId": "38"
     },
     {
       "product": "CMS",
@@ -3455,8 +3455,8 @@
       "resource": "Settings",
       "description": "Editar la configuración del CMS.",
       "key": "cms_settings",
-      "resourceId": 1434680,
-      "productId": 38
+      "resourceId": "1434680",
+      "productId": "38"
     },
     {
       "product": "CMS",
@@ -3464,8 +3464,8 @@
       "resource": "CMS GraphQL API",
       "description": "Utilice la API GraphQL de VTEX IO CMS.",
       "key": "access-cms-graphql-api",
-      "resourceId": 1032772,
-      "productId": 38
+      "resourceId": "1032772",
+      "productId": "38"
     },
     {
       "product": "CMS",
@@ -3473,8 +3473,8 @@
       "resource": "Read CMS GraphQL API",
       "description": "Otorga acceso de solo lectura a la API GraphQL del CMS VTEX IO.",
       "key": "read-cms-graphql-api",
-      "resourceId": 2143073,
-      "productId": 38
+      "resourceId": "2143073",
+      "productId": "38"
     },
     {
       "product": "Catalog",
@@ -3482,8 +3482,8 @@
       "resource": "Admin list",
       "description": "Enumere a los administradores del sistema.",
       "key": "Administrador.aspx",
-      "resourceId": 882,
-      "productId": 2
+      "resourceId": "882",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3491,8 +3491,8 @@
       "resource": "Homepage",
       "description": "Página principal",
       "key": "Home.aspx",
-      "resourceId": 1047,
-      "productId": 2
+      "resourceId": "1047",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3500,8 +3500,8 @@
       "resource": "Help page",
       "description": "Página de inicio de ayuda",
       "key": "Help.aspx",
-      "resourceId": 1048,
-      "productId": 2
+      "resourceId": "1048",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3509,8 +3509,8 @@
       "resource": "Read Collections",
       "description": "Te permite ver colecciones.",
       "key": "collections-read",
-      "resourceId": 627875,
-      "productId": 2
+      "resourceId": "627875",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3518,8 +3518,8 @@
       "resource": "Write Collections",
       "description": "Te permite crear una nueva colección de productos.",
       "key": "collections-write",
-      "resourceId": 627876,
-      "productId": 2
+      "resourceId": "627876",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3527,8 +3527,8 @@
       "resource": "Expert Reviews Management",
       "description": "Formulario de registro de opinión de expertos",
       "key": "EspecialistaOpiniaoForm.aspx",
-      "resourceId": 928,
-      "productId": 2
+      "resourceId": "928",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3536,8 +3536,8 @@
       "resource": "Similar product category",
       "description": "Añade una categoría similar al producto.",
       "key": "ProdutoCategoriaSimilar.aspx",
-      "resourceId": 981,
-      "productId": 2
+      "resourceId": "981",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3545,8 +3545,8 @@
       "resource": "Similar category product management",
       "description": "Registro de producto para una categoría similar",
       "key": "ProdutoCategoriaSimilarForm.aspx",
-      "resourceId": 982,
-      "productId": 2
+      "resourceId": "982",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3554,8 +3554,8 @@
       "resource": "SKU management",
       "description": "Formulario de registro de SKU",
       "key": "SkuForm.aspx",
-      "resourceId": 1001,
-      "productId": 2
+      "resourceId": "1001",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3563,8 +3563,8 @@
       "resource": "SKU Services",
       "description": "Servicios de SKU",
       "key": "SkuServicoForm.aspx",
-      "resourceId": 1004,
-      "productId": 2
+      "resourceId": "1004",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3572,8 +3572,8 @@
       "resource": "Prices for SKU Services",
       "description": "Lista de precios de servicio de SKU",
       "key": "SkuServicoValor.aspx",
-      "resourceId": 1005,
-      "productId": 2
+      "resourceId": "1005",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3581,8 +3581,8 @@
       "resource": "SKU service price management",
       "description": "Formulario para registrar un valor para un servicio SKU.",
       "key": "SkuServicoValorForm.aspx",
-      "resourceId": 1006,
-      "productId": 2
+      "resourceId": "1006",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3590,8 +3590,8 @@
       "resource": "Commercial condition",
       "description": "Definición de políticas comerciales",
       "key": "SkuCondicaoComercial.aspx",
-      "resourceId": 1019,
-      "productId": 2
+      "resourceId": "1019",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3599,8 +3599,8 @@
       "resource": "SKU type management",
       "description": "Formulario para registrar tipos de servicio SKU.",
       "key": "SkuServicoTipo.aspx",
-      "resourceId": 1045,
-      "productId": 2
+      "resourceId": "1045",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3608,8 +3608,8 @@
       "resource": "Configuration Management",
       "description": "Formulario de registro de configuración",
       "key": "ConfigForm.aspx",
-      "resourceId": 917,
-      "productId": 2
+      "resourceId": "917",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3617,8 +3617,8 @@
       "resource": "File types list",
       "description": "Lista de tipos de archivo",
       "key": "TipoArquivo.aspx",
-      "resourceId": 1009,
-      "productId": 2
+      "resourceId": "1009",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3626,8 +3626,8 @@
       "resource": "File types management",
       "description": "Formulario para registrar tamaños de imagen estándar y otros tipos de archivo.",
       "key": "TipoArquivoForm.aspx",
-      "resourceId": 1010,
-      "productId": 2
+      "resourceId": "1010",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3635,8 +3635,8 @@
       "resource": "Store Texts",
       "description": "Herramienta para desarrolladores con todos los textos base para la tienda.",
       "key": "TextoSite.aspx",
-      "resourceId": 1034,
-      "productId": 2
+      "resourceId": "1034",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3644,8 +3644,8 @@
       "resource": "CMS Management",
       "description": "Configuración del CMS (Portal)",
       "key": "PortalManagement",
-      "resourceId": 1202,
-      "productId": 2
+      "resourceId": "1202",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3653,8 +3653,8 @@
       "resource": "SEO Configurations",
       "description": "Configuración de contenido SEO (Robots.txt)",
       "key": "ConfigSEOContents.aspx",
-      "resourceId": 1222,
-      "productId": 2
+      "resourceId": "1222",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3662,8 +3662,8 @@
       "resource": "Gift Registry Types List",
       "description": "Lista de tipos de listas",
       "key": "GiftListType.aspx",
-      "resourceId": 1631,
-      "productId": 2
+      "resourceId": "1631",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3671,8 +3671,8 @@
       "resource": "Gift Registry Lists Management",
       "description": "Formulario para crear y editar tipos de listas (Lista de regalos)",
       "key": "GiftListTypeForm.aspx",
-      "resourceId": 1633,
-      "productId": 2
+      "resourceId": "1633",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3680,8 +3680,8 @@
       "resource": "Geographic Region Management",
       "description": "Gestionar la página de listado de regiones geográficas.",
       "key": "GeographicRegion.aspx",
-      "resourceId": 2138652,
-      "productId": 2
+      "resourceId": "2138652",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3689,8 +3689,8 @@
       "resource": "Geographic Region Form",
       "description": "Gestionar el formulario para crear y editar regiones geográficas.",
       "key": "GeographicRegionForm.aspx",
-      "resourceId": 2138653,
-      "productId": 2
+      "resourceId": "2138653",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3698,8 +3698,8 @@
       "resource": "StoreForm.aspx",
       "description": "Consulte la pantalla de detalles de la póliza comercial.",
       "key": "StoreForm.aspx",
-      "resourceId": 2142219,
-      "productId": 2
+      "resourceId": "2142219",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3707,8 +3707,8 @@
       "resource": "InsertOrUpdateStoreForm.aspx",
       "description": "Crear y modificar políticas empresariales (sujeto a cargos recurrentes).",
       "key": "InsertOrUpdateStoreForm.aspx",
-      "resourceId": 2142347,
-      "productId": 2
+      "resourceId": "2142347",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3716,8 +3716,8 @@
       "resource": "Product management",
       "description": "Vea la pantalla de registro y modificación del producto.",
       "key": "ProdutoForm.aspx",
-      "resourceId": 873,
-      "productId": 2
+      "resourceId": "873",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3725,8 +3725,8 @@
       "resource": "Product Form",
       "description": "Acceso a la pantalla del producto",
       "key": "Produto.aspx",
-      "resourceId": 874,
-      "productId": 2
+      "resourceId": "874",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3734,8 +3734,8 @@
       "resource": "Change SKU Pricing",
       "description": "Cambiar precios de SKU",
       "key": "AlterarPrecoSku",
-      "resourceId": 877,
-      "productId": 2
+      "resourceId": "877",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3743,8 +3743,8 @@
       "resource": "SKU images management",
       "description": "Insertar y modificar imágenes SKU",
       "key": "ManterImagemProdutoSku",
-      "resourceId": 880,
-      "productId": 2
+      "resourceId": "880",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3752,8 +3752,8 @@
       "resource": "Product and SKU Management",
       "description": "Modificación y adición de productos y SKU",
       "key": "ManterFormularioProdutoSku",
-      "resourceId": 881,
-      "productId": 2
+      "resourceId": "881",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3761,8 +3761,8 @@
       "resource": "Reviews list",
       "description": "Ver todas las reseñas",
       "key": "Avaliacao.aspx",
-      "resourceId": 885,
-      "productId": 2
+      "resourceId": "885",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3770,8 +3770,8 @@
       "resource": "Reviews management",
       "description": "Formulario de inscripción para la evaluación",
       "key": "AvaliacaoForm.aspx",
-      "resourceId": 886,
-      "productId": 2
+      "resourceId": "886",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3779,8 +3779,8 @@
       "resource": "Fields list",
       "description": "Enumera todos los campos del sistema.",
       "key": "Campo.aspx",
-      "resourceId": 891,
-      "productId": 2
+      "resourceId": "891",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3788,8 +3788,8 @@
       "resource": "Attributes Management",
       "description": "Formulario para registrar campos.",
       "key": "CampoForm.aspx",
-      "resourceId": 896,
-      "productId": 2
+      "resourceId": "896",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3797,8 +3797,8 @@
       "resource": "Value fields list",
       "description": "Lista de valores para un campo",
       "key": "CampoValor.aspx",
-      "resourceId": 897,
-      "productId": 2
+      "resourceId": "897",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3806,8 +3806,8 @@
       "resource": "Attribute values management",
       "description": "Formulario de inscripción de campo",
       "key": "CampoValorForm.aspx",
-      "resourceId": 898,
-      "productId": 2
+      "resourceId": "898",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3815,8 +3815,8 @@
       "resource": "Category ",
       "description": "Enumerar todas las categorías",
       "key": "Categoria.aspx",
-      "resourceId": 899,
-      "productId": 2
+      "resourceId": "899",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3824,8 +3824,8 @@
       "resource": "Categories Management",
       "description": "Formulario de registro de categoría",
       "key": "CategoriaForm.aspx",
-      "resourceId": 900,
-      "productId": 2
+      "resourceId": "900",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3833,8 +3833,8 @@
       "resource": "Similar Category ",
       "description": "Enumera todas las categorías similares",
       "key": "CategoriaSimilar.aspx",
-      "resourceId": 901,
-      "productId": 2
+      "resourceId": "901",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3842,8 +3842,8 @@
       "resource": "Similar Categories Management",
       "description": "Se forman categorías similares",
       "key": "CategoriaSimilarForm.aspx",
-      "resourceId": 902,
-      "productId": 2
+      "resourceId": "902",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3851,8 +3851,8 @@
       "resource": "Price range",
       "description": "Enumerar todos los rangos de precios",
       "key": "FaixaPreco.aspx",
-      "resourceId": 933,
-      "productId": 2
+      "resourceId": "933",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3860,8 +3860,8 @@
       "resource": "Price Range Management",
       "description": "Formulario de registro de precios",
       "key": "FaixaPrecoForm.aspx",
-      "resourceId": 934,
-      "productId": 2
+      "resourceId": "934",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3869,8 +3869,8 @@
       "resource": "Providers",
       "description": "Muestra la lista de proveedores registrados en el sistema.",
       "key": "Fornecedor.aspx",
-      "resourceId": 938,
-      "productId": 2
+      "resourceId": "938",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3878,8 +3878,8 @@
       "resource": "Supplier management",
       "description": "Formulario de registro de proveedores",
       "key": "FornecedorForm.aspx",
-      "resourceId": 939,
-      "productId": 2
+      "resourceId": "939",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3887,8 +3887,8 @@
       "resource": "Groups",
       "description": "Enumerar todos los grupos de categorías",
       "key": "Grupo.aspx",
-      "resourceId": 944,
-      "productId": 2
+      "resourceId": "944",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3896,8 +3896,8 @@
       "resource": "Group Management ",
       "description": "Formulario de registro de grupo de categoría",
       "key": "GrupoForm.aspx",
-      "resourceId": 945,
-      "productId": 2
+      "resourceId": "945",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3905,8 +3905,8 @@
       "resource": "Brands",
       "description": "Lista de todas las marcas registradas",
       "key": "Marca.aspx",
-      "resourceId": 955,
-      "productId": 2
+      "resourceId": "955",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3914,8 +3914,8 @@
       "resource": "Brands Management",
       "description": "Formulario de registro de marca",
       "key": "MarcaForm.aspx",
-      "resourceId": 956,
-      "productId": 2
+      "resourceId": "956",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3923,8 +3923,8 @@
       "resource": "SKUs",
       "description": "Enumera todos los SKU registrados.",
       "key": "Sku.aspx",
-      "resourceId": 996,
-      "productId": 2
+      "resourceId": "996",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3932,8 +3932,8 @@
       "resource": "Enable Product and SKU",
       "description": "Activación de producto y SKU",
       "key": "Ativar Produto Sku",
-      "resourceId": 1013,
-      "productId": 2
+      "resourceId": "1013",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3941,8 +3941,8 @@
       "resource": "Category Management",
       "description": "Verificación de acceso para agregar o cambiar una nueva categoría.",
       "key": "InsertOrUpdateCategoriaFromCategoriaForm.aspx",
-      "resourceId": 1216,
-      "productId": 2
+      "resourceId": "1216",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3950,8 +3950,8 @@
       "resource": "Similar Category Management",
       "description": "Verificación de acceso para agregar o cambiar una nueva categoría similar.",
       "key": "InsertOrUpdateCategoriaFromCategoriaSimilarForm.aspx",
-      "resourceId": 1217,
-      "productId": 2
+      "resourceId": "1217",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3959,8 +3959,8 @@
       "resource": "Brand Management",
       "description": "Validación para agregar o cambiar una marca.",
       "key": "InsertOrUpdateMarcaFromMarcaForm.aspx",
-      "resourceId": 1218,
-      "productId": 2
+      "resourceId": "1218",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3968,8 +3968,8 @@
       "resource": "Insert or Update Group",
       "description": "Insertar o modificar dentro del grupo de categorías.",
       "key": "InsertOrUpdateGrupoFromGrupoForm.aspx",
-      "resourceId": 1219,
-      "productId": 2
+      "resourceId": "1219",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3977,8 +3977,8 @@
       "resource": "Field validation",
       "description": "Validación de campo",
       "key": "InsertOrUpdateCampoFromCampoForm.aspx",
-      "resourceId": 1220,
-      "productId": 2
+      "resourceId": "1220",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3986,8 +3986,8 @@
       "resource": "Value field validation",
       "description": "Validación de valores de campo",
       "key": "InsertOrUpdateCampoValorFromCampoValorForm.aspx",
-      "resourceId": 1221,
-      "productId": 2
+      "resourceId": "1221",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -3995,8 +3995,8 @@
       "resource": "Buy Together Management",
       "description": "Formulario de inscripción para \"Comprar Juntos\"",
       "key": "CompreJuntoForm.aspx",
-      "resourceId": 915,
-      "productId": 2
+      "resourceId": "915",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -4004,8 +4004,8 @@
       "resource": "Reviews",
       "description": "base de datos de revisión de SKU",
       "key": "Resenha.aspx",
-      "resourceId": 988,
-      "productId": 2
+      "resourceId": "988",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -4013,8 +4013,8 @@
       "resource": "Gift/Refund Vouchers",
       "description": "Crear un comprobante de compra",
       "key": "Vale.aspx",
-      "resourceId": 1016,
-      "productId": 2
+      "resourceId": "1016",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -4022,8 +4022,8 @@
       "resource": "Product Collections XML",
       "description": "Colecciones XML",
       "key": "Xml.aspx",
-      "resourceId": 1026,
-      "productId": 2
+      "resourceId": "1026",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -4031,8 +4031,8 @@
       "resource": "Tags management",
       "description": "Control de palabras clave - Etiquetas",
       "key": "Tag.aspx",
-      "resourceId": 1027,
-      "productId": 2
+      "resourceId": "1027",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -4040,8 +4040,8 @@
       "resource": "Sales channels management",
       "description": "Lista de políticas comerciales",
       "key": "Store.aspx",
-      "resourceId": 1226,
-      "productId": 2
+      "resourceId": "1226",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -4049,8 +4049,8 @@
       "resource": "Sellers",
       "description": "Lista de vendedores (tiendas)",
       "key": "Seller.aspx",
-      "resourceId": 1227,
-      "productId": 2
+      "resourceId": "1227",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -4058,8 +4058,8 @@
       "resource": "Seller SKUs",
       "description": "Lista de SKU de vendedores",
       "key": "SkuSeller.aspx",
-      "resourceId": 1229,
-      "productId": 2
+      "resourceId": "1229",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -4067,8 +4067,8 @@
       "resource": "SKU Bundles",
       "description": "Interfaz entre kits y SKU",
       "key": "SkuKit.aspx",
-      "resourceId": 1002,
-      "productId": 2
+      "resourceId": "1002",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -4076,8 +4076,8 @@
       "resource": "Product Bundle Management",
       "description": "Formulario de registro del kit",
       "key": "SkuKitForm.aspx",
-      "resourceId": 1003,
-      "productId": 2
+      "resourceId": "1003",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -4085,8 +4085,8 @@
       "resource": "News Report",
       "description": "Informe del boletín informativo",
       "key": "RelatorioNews.aspx",
-      "resourceId": 1020,
-      "productId": 2
+      "resourceId": "1020",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -4094,8 +4094,8 @@
       "resource": "SKUs Report",
       "description": "Informe de SKU",
       "key": "Relatorio_Skus.aspx",
-      "resourceId": 1022,
-      "productId": 2
+      "resourceId": "1022",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -4103,8 +4103,8 @@
       "resource": "Out of stock notification",
       "description": "Notificarme Solicitar informe",
       "key": "Relatorio_AviseMeSku.aspx",
-      "resourceId": 1025,
-      "productId": 2
+      "resourceId": "1025",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -4112,8 +4112,8 @@
       "resource": "Full-text Search",
       "description": "Informe de búsqueda de texto completo",
       "key": "RelatorioFullText.aspx",
-      "resourceId": 1028,
-      "productId": 2
+      "resourceId": "1028",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -4121,8 +4121,8 @@
       "resource": "Security Monitoring",
       "description": "Vigilancia de seguridad",
       "key": "Relatorio_Seguranca.aspx",
-      "resourceId": 1031,
-      "productId": 2
+      "resourceId": "1031",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -4130,8 +4130,8 @@
       "resource": "Gift Registry List",
       "description": "Ver todas las listas (Lista de regalos)",
       "key": "GiftList.aspx",
-      "resourceId": 1632,
-      "productId": 2
+      "resourceId": "1632",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -4139,8 +4139,8 @@
       "resource": "Assisted Sales Gift Registry List Management",
       "description": "Permite al administrador gestionar las listas de un usuario en el sitio web, como si fuera el propio usuario.",
       "key": "GiftListImpersonation",
-      "resourceId": 1634,
-      "productId": 2
+      "resourceId": "1634",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -4148,8 +4148,8 @@
       "resource": "Assisted Sales",
       "description": "Funcionalidades de televenta. Tras iniciar sesión, el usuario es redirigido al sitio web de televenta www.{nombredetienda}.com.br/a/televendas. De esta forma, el operador puede utilizar las funcionalidades de televenta, como navegar por la tienda en nombre del cliente. Como este recurso provoca la redirección automática a la tienda, el usuario que entre en una cuenta con un rol con este recurso no tendrá acceso a importantes funcionalidades del Admin. Por lo tanto, recomendamos utilizar dos cuentas separadas (con correos electrónicos separados) para los usuarios de televenta: una cuenta para el rol de Call Center Operator (con este recurso y el recurso View Order) y otra cuenta para realizar operaciones en el menú de administración, si es necesario.",
       "key": "Televendas",
-      "resourceId": 1046,
-      "productId": 2
+      "resourceId": "1046",
+      "productId": "2"
     },
     {
       "product": "Catalog API",
@@ -4157,8 +4157,8 @@
       "resource": "View Product",
       "description": "Ver detalles de productos y SKUs.",
       "key": "ViewProduct",
-      "resourceId": 2017533,
-      "productId": 107
+      "resourceId": "2017533",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -4166,8 +4166,8 @@
       "resource": "Edit Product",
       "description": "Editar detalles del producto y SKU.",
       "key": "EditProduct",
-      "resourceId": 2038155,
-      "productId": 107
+      "resourceId": "2038155",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -4175,8 +4175,8 @@
       "resource": "View Category",
       "description": "Ver detalles de la categoría.",
       "key": "ViewCategory",
-      "resourceId": 2038156,
-      "productId": 107
+      "resourceId": "2038156",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -4184,8 +4184,8 @@
       "resource": "Edit Category",
       "description": "Editar detalles de la categoría.",
       "key": "EditCategory",
-      "resourceId": 2038157,
-      "productId": 107
+      "resourceId": "2038157",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -4193,8 +4193,8 @@
       "resource": "View Collection",
       "description": "Ver detalles de la colección.",
       "key": "ViewCollection",
-      "resourceId": 2038158,
-      "productId": 107
+      "resourceId": "2038158",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -4202,8 +4202,8 @@
       "resource": "Edit Collection",
       "description": "Editar detalles de la colección.",
       "key": "EditCollection",
-      "resourceId": 2038159,
-      "productId": 107
+      "resourceId": "2038159",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -4211,8 +4211,8 @@
       "resource": "View Brand",
       "description": "Ver detalles de la marca.",
       "key": "ViewBrand",
-      "resourceId": 2038160,
-      "productId": 107
+      "resourceId": "2038160",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -4220,8 +4220,8 @@
       "resource": "Edit Brand",
       "description": "Editar detalles de la marca.",
       "key": "EditBrand",
-      "resourceId": 2038161,
-      "productId": 107
+      "resourceId": "2038161",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -4229,8 +4229,8 @@
       "resource": "Import Spreadsheet",
       "description": "Importar productos y referencias mediante hoja de cálculo.",
       "key": "ImportSpreadsheet",
-      "resourceId": 2038162,
-      "productId": 107
+      "resourceId": "2038162",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -4238,8 +4238,8 @@
       "resource": "Export Spreadsheet",
       "description": "Exportar la hoja de cálculo con la información del catálogo.",
       "key": "ExportSpreadsheet",
-      "resourceId": 2038163,
-      "productId": 107
+      "resourceId": "2038163",
+      "productId": "107"
     },
     {
       "product": "Channels",
@@ -4247,8 +4247,8 @@
       "resource": "Send Marketplace Suggestions",
       "description": "Permite a los vendedores enviar anuncios al mercado, que serán revisados ​​y aprobados por el mercado a través de la página de SKU recibidos o la API de coincidencia de SKU recibidos.",
       "key": "EnviaSugestao",
-      "resourceId": 1139,
-      "productId": 13
+      "resourceId": "1139",
+      "productId": "13"
     },
     {
       "product": "Channels",
@@ -4256,8 +4256,8 @@
       "resource": "Sellers SKUs List",
       "description": "Permite a los vendedores ver la lista de SKU enviados a los marketplaces donde venden sus productos. En el panel de administración de VTEX, se puede acceder a la lista en MARKETPLACE > Integrations > Products.",
       "key": "Consulta",
-      "resourceId": 1154,
-      "productId": 13
+      "resourceId": "1154",
+      "productId": "13"
     },
     {
       "product": "Channels",
@@ -4265,8 +4265,8 @@
       "resource": "Save Suggestion Rules",
       "description": "Permite a los marketplaces crear y modificar reglas de VTEX Matcher para la aprobación de los SKU recibidos. Esta configuración se realiza a través de la API de configuración de aprobación de SKU.",
       "key": "SalvaRegras",
-      "resourceId": 1155,
-      "productId": 13
+      "resourceId": "1155",
+      "productId": "13"
     },
     {
       "product": "Channels",
@@ -4274,8 +4274,8 @@
       "resource": "Marketplace seller setup",
       "description": "Permite asociar un vendedor a un nuevo mercado o modificar una configuración existente. Los vendedores incluidos en el Portal del Vendedor solo pueden modificar su configuración, pero no pueden asociarse a más de un mercado. Sin embargo, los vendedores de VTEX pueden asociarse a otros mercados y modificar su configuración activando esta función. Esta acción se puede realizar a través de VTEX Admin o mediante la API REST.",
       "key": "ConfiguraSeller",
-      "resourceId": 1156,
-      "productId": 13
+      "resourceId": "1156",
+      "productId": "13"
     },
     {
       "product": "Channels",
@@ -4283,8 +4283,8 @@
       "resource": "Access the Marketplace Network",
       "description": "Crea, edita y publica el perfil de tu tienda en la red Marketplace y envía mensajes a otras tiendas.",
       "key": "MarketplaceNetwork",
-      "resourceId": 1107285,
-      "productId": 13
+      "resourceId": "1107285",
+      "productId": "13"
     },
     {
       "product": "Checkout",
@@ -4292,8 +4292,8 @@
       "resource": "Shopping Cart Full Access",
       "description": "Acceso de lectura y escritura para todos los carritos de compra. Permite visualizar los datos del carrito en su totalidad (sin enmascarar). También permite solicitudes de simulación de carritos privados.",
       "key": "AcessaTodosCarrinhos",
-      "resourceId": 1091,
-      "productId": 5
+      "resourceId": "1091",
+      "productId": "5"
     },
     {
       "product": "Checkout",
@@ -4301,8 +4301,8 @@
       "resource": "Orders Full Access",
       "description": "Acceso de lectura y escritura a todos los pedidos a través de la API de pago. No se permite el acceso a los pedidos mediante el módulo de gestión de pedidos.",
       "key": "AcessaTodosPedidos",
-      "resourceId": 1092,
-      "productId": 5
+      "resourceId": "1092",
+      "productId": "5"
     },
     {
       "product": "Checkout",
@@ -4310,8 +4310,8 @@
       "resource": "Save Order Configuration",
       "description": "Guardar la configuración del pedido.",
       "key": "SaveOrderConfiguration",
-      "resourceId": 600072,
-      "productId": 5
+      "resourceId": "600072",
+      "productId": "5"
     },
     {
       "product": "Checkout",
@@ -4319,8 +4319,8 @@
       "resource": "Save OrderForm Configuration",
       "description": "Guardar la configuración del carrito de compra.",
       "key": "SaveOrderFormConfiguration",
-      "resourceId": 600073,
-      "productId": 5
+      "resourceId": "600073",
+      "productId": "5"
     },
     {
       "product": "Checkout",
@@ -4328,8 +4328,8 @@
       "resource": "Read Shopping Cart",
       "description": "Lee y lista todos los carritos de compra. No permite el acceso a los datos del carrito sin enmascarar.",
       "key": "GetOrderForm",
-      "resourceId": 1949421,
-      "productId": 5
+      "resourceId": "1949421",
+      "productId": "5"
     },
     {
       "product": "Commerce Content",
@@ -4337,8 +4337,8 @@
       "resource": "Save to main branch",
       "description": "Agrega los cambios directamente a la rama principal.",
       "key": "SaveToMainBranch",
-      "resourceId": 2086248,
-      "productId": 115
+      "resourceId": "2086248",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
@@ -4346,8 +4346,8 @@
       "resource": "Remove from main branch",
       "description": "Eliminar los cambios de la rama principal.",
       "key": "RemoveFromMainBranch",
-      "resourceId": 2086250,
-      "productId": 115
+      "resourceId": "2086250",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
@@ -4355,8 +4355,8 @@
       "resource": "Merge branch",
       "description": "Fusiona los cambios de una rama con la rama principal.",
       "key": "MergeBranch",
-      "resourceId": 2086251,
-      "productId": 115
+      "resourceId": "2086251",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
@@ -4364,8 +4364,8 @@
       "resource": "Delete Branch",
       "description": "Permite eliminar una rama y todo el contenido versionado asociado a ella.",
       "key": "DeleteBranch",
-      "resourceId": 2153203,
-      "productId": 115
+      "resourceId": "2153203",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
@@ -4373,8 +4373,8 @@
       "resource": "Create Branch",
       "description": "Te permite crear una nueva rama para desarrollar, probar y guardar nuevas versiones del contenido de forma aislada.",
       "key": "CreateBranch",
-      "resourceId": 2153204,
-      "productId": 115
+      "resourceId": "2153204",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
@@ -4382,8 +4382,8 @@
       "resource": "Delete entry",
       "description": "Elimina permanentemente una entrada de todo el historial y las ramas.",
       "key": "DeleteEntry",
-      "resourceId": 2086249,
-      "productId": 115
+      "resourceId": "2086249",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
@@ -4391,8 +4391,8 @@
       "resource": "Create Store",
       "description": "Crea una nueva tienda de contenido comercial en la cuenta.",
       "key": "CreateStore",
-      "resourceId": 2086252,
-      "productId": 115
+      "resourceId": "2086252",
+      "productId": "115"
     },
     {
       "product": "Credit Control",
@@ -4400,8 +4400,8 @@
       "resource": "Read Checking Accounts",
       "description": "Visualización de la información de la cuenta.",
       "key": "read_checkingaccounts",
-      "resourceId": 170921,
-      "productId": 58
+      "resourceId": "170921",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -4409,8 +4409,8 @@
       "resource": "Create Checking Accounts",
       "description": "Creación de cuenta.",
       "key": "create_checkingaccounts",
-      "resourceId": 170929,
-      "productId": 58
+      "resourceId": "170929",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -4418,8 +4418,8 @@
       "resource": "Edit credits",
       "description": "Cambiar el límite de crédito de una cuenta.",
       "key": "edit_credits",
-      "resourceId": 197575,
-      "productId": 58
+      "resourceId": "197575",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -4427,8 +4427,8 @@
       "resource": "Read Invoices",
       "description": "Visualización de facturas.",
       "key": "read_invoices",
-      "resourceId": 170930,
-      "productId": 58
+      "resourceId": "170930",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -4436,8 +4436,8 @@
       "resource": "Create Invoices",
       "description": "Emisión de facturas.",
       "key": "create_invoices",
-      "resourceId": 170931,
-      "productId": 58
+      "resourceId": "170931",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -4445,8 +4445,8 @@
       "resource": "Pay Invoice",
       "description": "Pago de facturas.",
       "key": "pay_invoice",
-      "resourceId": 200613,
-      "productId": 58
+      "resourceId": "200613",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -4454,8 +4454,8 @@
       "resource": "Main Access",
       "description": "Permite el acceso principal",
       "key": "suggestions",
-      "resourceId": 109448,
-      "productId": 50
+      "resourceId": "109448",
+      "productId": "50"
     },
     {
       "product": "Credit Control",
@@ -4463,8 +4463,8 @@
       "resource": "Read Statements",
       "description": "Lectura de extractos bancarios.",
       "key": "read_statements",
-      "resourceId": 170918,
-      "productId": 58
+      "resourceId": "170918",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -4472,8 +4472,8 @@
       "resource": "Create Statements",
       "description": "Creación de extractos de cuenta.",
       "key": "create_statements",
-      "resourceId": 170920,
-      "productId": 58
+      "resourceId": "170920",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -4481,8 +4481,8 @@
       "resource": "Edit Configuration",
       "description": "Cambia la configuración de la tienda.",
       "key": "edit_config",
-      "resourceId": 198649,
-      "productId": 58
+      "resourceId": "198649",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -4490,8 +4490,8 @@
       "resource": "Read Configuration",
       "description": "Visualización de la configuración de la tienda.",
       "key": "read_config",
-      "resourceId": 198650,
-      "productId": 58
+      "resourceId": "198650",
+      "productId": "58"
     },
     {
       "product": "Delivery Promises",
@@ -4499,8 +4499,8 @@
       "resource": "Notify Product Availability Change",
       "description": "Actualizar la disponibilidad de artículos de vendedores externos en el contexto de la Promesa de Entrega.",
       "key": "NotifyProductAvailabilityChange",
-      "resourceId": 2032871,
-      "productId": 111
+      "resourceId": "2032871",
+      "productId": "111"
     },
     {
       "product": "Dynamic Storage",
@@ -4508,8 +4508,8 @@
       "resource": "List data entity",
       "description": "Enumerar las entidades de datos.",
       "key": "2_dataentity_list",
-      "resourceId": 69077,
-      "productId": 25
+      "resourceId": "69077",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -4517,8 +4517,8 @@
       "resource": "Create data entity",
       "description": "Crear una entidad de datos.",
       "key": "1_dataentity_create",
-      "resourceId": 69078,
-      "productId": 25
+      "resourceId": "69078",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -4526,8 +4526,8 @@
       "resource": "Edit schema",
       "description": "Editar schema.",
       "key": "1_dataentity_edit",
-      "resourceId": 69079,
-      "productId": 25
+      "resourceId": "69079",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -4535,8 +4535,8 @@
       "resource": "Remove data entity",
       "description": "Eliminar entidad de datos.",
       "key": "1_dataentity_delete",
-      "resourceId": 69080,
-      "productId": 25
+      "resourceId": "69080",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -4544,8 +4544,8 @@
       "resource": "View data entity details",
       "description": "Ver detalles de la entidad de datos.",
       "key": "2_dataentity_view",
-      "resourceId": 69081,
-      "productId": 25
+      "resourceId": "69081",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -4553,8 +4553,8 @@
       "resource": "Publish index",
       "description": "Publicar índice.",
       "key": "1_dataentity_publish",
-      "resourceId": 69082,
-      "productId": 25
+      "resourceId": "69082",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -4562,8 +4562,8 @@
       "resource": "Master Data administrator",
       "description": "Administre Master Data.",
       "key": "ADMIN_DS",
-      "resourceId": 69073,
-      "productId": 25
+      "resourceId": "69073",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -4571,8 +4571,8 @@
       "resource": "Full access to all documents",
       "description": "Acceso completo a todos los documentos.",
       "key": "POWER_USER_DS",
-      "resourceId": 69074,
-      "productId": 25
+      "resourceId": "69074",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -4580,8 +4580,8 @@
       "resource": "Insert or update document (not remove)",
       "description": "Crear y actualizar documentos, pero no eliminarlos.",
       "key": "NOREMOVE_USER_DS",
-      "resourceId": 69075,
-      "productId": 25
+      "resourceId": "69075",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -4589,8 +4589,8 @@
       "resource": "Read only documents",
       "description": "Solo lectura del documento.",
       "key": "READONLY_USER_DS",
-      "resourceId": 69076,
-      "productId": 25
+      "resourceId": "69076",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -4598,7 +4598,7 @@
       "resource": "List index",
       "description": "Listar índices.",
       "key": "1_Index_list",
-      "resourceId": 105916,
+      "resourceId": "105916",
       "productId": ""
     },
     {
@@ -4607,7 +4607,7 @@
       "resource": "Create index",
       "description": "Crear índice.",
       "key": "1_Index_create",
-      "resourceId": 105917,
+      "resourceId": "105917",
       "productId": ""
     },
     {
@@ -4616,7 +4616,7 @@
       "resource": "Edit index",
       "description": "Editar índice.",
       "key": "1_Index_edit",
-      "resourceId": 105918,
+      "resourceId": "105918",
       "productId": ""
     },
     {
@@ -4625,7 +4625,7 @@
       "resource": "Remove index",
       "description": "Eliminar índice.",
       "key": "1_Index_delete",
-      "resourceId": 105919,
+      "resourceId": "105919",
       "productId": ""
     },
     {
@@ -4634,7 +4634,7 @@
       "resource": "View index details",
       "description": "Ver detalles del índice.",
       "key": "1_Index_view",
-      "resourceId": 105920,
+      "resourceId": "105920",
       "productId": ""
     },
     {
@@ -4643,7 +4643,7 @@
       "resource": "List internal logs",
       "description": "Listar los registros internos.",
       "key": "1_internallog_list",
-      "resourceId": 105921,
+      "resourceId": "105921",
       "productId": ""
     },
     {
@@ -4652,7 +4652,7 @@
       "resource": "List internal alerts",
       "description": "Enumerar las alertas internas.",
       "key": "1_internalwarning_list",
-      "resourceId": 106143,
+      "resourceId": "106143",
       "productId": ""
     },
     {
@@ -4661,7 +4661,7 @@
       "resource": "View detail schema",
       "description": "Ver detalles del esquema.",
       "key": "1_dataentity_list",
-      "resourceId": 137232,
+      "resourceId": "137232",
       "productId": ""
     },
     {
@@ -4670,8 +4670,8 @@
       "resource": "List trigger",
       "description": "Listar triggers.",
       "key": "2_datarule_list",
-      "resourceId": 69083,
-      "productId": 25
+      "resourceId": "69083",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -4679,8 +4679,8 @@
       "resource": "Create trigger",
       "description": "Crear triggers.",
       "key": "1_datarule_create",
-      "resourceId": 69084,
-      "productId": 25
+      "resourceId": "69084",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -4688,8 +4688,8 @@
       "resource": "Edit trigger",
       "description": "Editar triggers.",
       "key": "1_datarule_edit",
-      "resourceId": 69085,
-      "productId": 25
+      "resourceId": "69085",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -4697,8 +4697,8 @@
       "resource": "Remove trigger",
       "description": "Eliminar triggers.",
       "key": "1_datarule_delete",
-      "resourceId": 69086,
-      "productId": 25
+      "resourceId": "69086",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -4706,8 +4706,8 @@
       "resource": "View trigger details",
       "description": "Ver dettalles de triggers.",
       "key": "2_datarule_view",
-      "resourceId": 69087,
-      "productId": 25
+      "resourceId": "69087",
+      "productId": "25"
     },
     {
       "product": "FastStore",
@@ -4715,8 +4715,8 @@
       "resource": "View Secrets",
       "description": "Permite ver los secretos configurados en WebOps.",
       "key": "ViewSecrets",
-      "resourceId": 2100329,
-      "productId": 129
+      "resourceId": "2100329",
+      "productId": "129"
     },
     {
       "product": "FastStore",
@@ -4724,8 +4724,8 @@
       "resource": "Edit Secrets",
       "description": "Permite crear, eliminar y editar secretos en WebOps.",
       "key": "EditSecrets",
-      "resourceId": 2100330,
-      "productId": 129
+      "resourceId": "2100330",
+      "productId": "129"
     },
     {
       "product": "Fraud Prevention",
@@ -4733,8 +4733,8 @@
       "resource": "View transaction attempts",
       "description": "Consulte los intentos de transacción en la página de Prevención de Fraude.",
       "key": "ViewTransactionAttempts",
-      "resourceId": 2134012,
-      "productId": 127
+      "resourceId": "2134012",
+      "productId": "127"
     },
     {
       "product": "Fraud Prevention",
@@ -4742,8 +4742,8 @@
       "resource": "Edit transaction attempt action settings",
       "description": "Habilite o deshabilite las acciones relacionadas con los intentos de transacción en la página de Prevención de Fraude.",
       "key": "EditTransactionAttemptActionSettings",
-      "resourceId": 2134013,
-      "productId": 127
+      "resourceId": "2134013",
+      "productId": "127"
     },
     {
       "product": "Fraud Prevention",
@@ -4751,8 +4751,8 @@
       "resource": "Edit transaction attempt score settings",
       "description": "Modifique la configuración de puntuación para los intentos de transacción en la página de Prevención de Fraude.",
       "key": "EditTransactionAttemptScoreSettings",
-      "resourceId": 2134014,
-      "productId": 127
+      "resourceId": "2134014",
+      "productId": "127"
     },
     {
       "product": "GiftCard",
@@ -4760,8 +4760,8 @@
       "resource": "Gift card full access",
       "description": "Crea y edita todas las funciones relacionadas con las tarjetas de regalo, sus proveedores y las transacciones.",
       "key": "GiftCardAdmin",
-      "resourceId": 472959,
-      "productId": 70
+      "resourceId": "472959",
+      "productId": "70"
     },
     {
       "product": "GiftCard",
@@ -4769,8 +4769,8 @@
       "resource": "Gift card viewer",
       "description": "Lee todas las funciones de las tarjetas de regalo, sus proveedores y las transacciones.",
       "key": "GiftCardReadOnly",
-      "resourceId": 472961,
-      "productId": 70
+      "resourceId": "472961",
+      "productId": "70"
     },
     {
       "product": "GiftCard",
@@ -4778,8 +4778,8 @@
       "resource": "View Gift Cards",
       "description": "Habilitar las operaciones de lectura de tarjetas para tarjetas de regalo y transacciones.",
       "key": "view_giftcards",
-      "resourceId": 994855,
-      "productId": 70
+      "resourceId": "994855",
+      "productId": "70"
     },
     {
       "product": "GiftCard",
@@ -4787,8 +4787,8 @@
       "resource": "Edit Gift Cards",
       "description": "Permite leer y escribir tarjetas de regalo y transacciones.",
       "key": "edit_giftcards",
-      "resourceId": 994919,
-      "productId": 70
+      "resourceId": "994919",
+      "productId": "70"
     },
     {
       "product": "GiftCard",
@@ -4796,8 +4796,8 @@
       "resource": "View Gift Card providers",
       "description": "Información sobre proveedores de tarjetas de regalo y sus tarjetas de regalo.",
       "key": "view_giftcard_providers",
-      "resourceId": 994983,
-      "productId": 70
+      "resourceId": "994983",
+      "productId": "70"
     },
     {
       "product": "GiftCard",
@@ -4805,8 +4805,8 @@
       "resource": "Edit Gift Card providers",
       "description": "Lectura y edición de proveedores de tarjetas de regalo y sus tarjetas de regalo.",
       "key": "edit_giftcard_providers",
-      "resourceId": 994991,
-      "productId": 70
+      "resourceId": "994991",
+      "productId": "70"
     },
     {
       "product": "Insights",
@@ -4814,8 +4814,8 @@
       "resource": "Insights Metrics",
       "description": "Permite la visualización sin restricciones de todas las métricas y datos presentes en los dashboards de VTEX Admin, incluyendo las siguientes páginas: Rendimiento de ventas, Página de inicio de Admin, Insights y Audit.",
       "key": "view_metrics",
-      "resourceId": 129814,
-      "productId": 57
+      "resourceId": "129814",
+      "productId": "57"
     },
     {
       "product": "License Manager",
@@ -4823,8 +4823,8 @@
       "resource": "Edit Admin Users",
       "description": "Permite crear, editar y eliminar usuarios administradores.",
       "key": "EditAdminUsers",
-      "resourceId": 2099310,
-      "productId": 1
+      "resourceId": "2099310",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -4832,8 +4832,8 @@
       "resource": "View Admin Users",
       "description": "Permite ver la información del usuario y acceder a los perfiles.",
       "key": "ViewAdminUsers",
-      "resourceId": 2099311,
-      "productId": 1
+      "resourceId": "2099311",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -4841,8 +4841,8 @@
       "resource": "View API keys",
       "description": "Visualiza, filtra, busca, ordena y exporta las claves API generadas y de terceros.",
       "key": "ViewApiKeys",
-      "resourceId": 2042457,
-      "productId": 1
+      "resourceId": "2042457",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -4850,8 +4850,8 @@
       "resource": "Edit API keys",
       "description": "Crear, eliminar, cambiar el estado y agregar o eliminar permisos para las claves API.",
       "key": "EditApiKeys",
-      "resourceId": 2042458,
-      "productId": 1
+      "resourceId": "2042458",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -4859,8 +4859,8 @@
       "resource": "Edit API keys settings",
       "description": "Modificar los ajustes relacionados con las claves API, como la duración de los tokens.",
       "key": "EditApiKeysSettings",
-      "resourceId": 2042466,
-      "productId": 1
+      "resourceId": "2042466",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -4868,8 +4868,8 @@
       "resource": "Renew API Token",
       "description": "Ver y renovar el token de una clave API.",
       "key": "RenewApiToken",
-      "resourceId": 2042467,
-      "productId": 1
+      "resourceId": "2042467",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -4877,8 +4877,8 @@
       "resource": "Save account",
       "description": "Guardar una cuenta (cambiar sitios, enlaces, hosts, etc., dirección de contacto).",
       "key": "Save_Account",
-      "resourceId": 1057,
-      "productId": 1
+      "resourceId": "1057",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -4886,8 +4886,8 @@
       "resource": "Get account by identifier",
       "description": "Una consulta que devuelve una cuenta por identificador, que puede ser el ID de la cuenta, el host o el nombre de la aplicación asociada a la cuenta.",
       "key": "Get_Account_By_Identifier",
-      "resourceId": 1064,
-      "productId": 1
+      "resourceId": "1064",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -4895,8 +4895,8 @@
       "resource": "Save user",
       "description": "Cree usuarios, agregue o elimine roles de usuarios, edite datos de usuario, cree y cambie claves de aplicación.",
       "key": "Save_User",
-      "resourceId": 1074,
-      "productId": 1
+      "resourceId": "1074",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -4904,8 +4904,8 @@
       "resource": "Remove user",
       "description": "Revocar el acceso del usuario.",
       "key": "Remove_User",
-      "resourceId": 1075,
-      "productId": 1
+      "resourceId": "1075",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -4913,8 +4913,8 @@
       "resource": "Save access profile",
       "description": "Crear o modificar un perfil de acceso.",
       "key": "Create_Role",
-      "resourceId": 1083,
-      "productId": 1
+      "resourceId": "1083",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -4922,8 +4922,8 @@
       "resource": "Find account resources",
       "description": "Enumera todos los recursos a los que tiene acceso una cuenta.",
       "key": "Get_Resources_By_Account",
-      "resourceId": 1086,
-      "productId": 1
+      "resourceId": "1086",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -4931,8 +4931,8 @@
       "resource": "Get role",
       "description": "Enumere los recursos asociados a un ID de perfil de acceso y los usuarios asociados a dicho perfil de acceso.",
       "key": "Get_Role",
-      "resourceId": 1088,
-      "productId": 1
+      "resourceId": "1088",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -4940,8 +4940,8 @@
       "resource": "Get paged roles",
       "description": "Enumera todos los perfiles de acceso de una cuenta.",
       "key": "Get_Roles_Paged",
-      "resourceId": 1178,
-      "productId": 1
+      "resourceId": "1178",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -4949,8 +4949,8 @@
       "resource": "Get paged users",
       "description": "Enumera todos los usuarios administradores de una cuenta.",
       "key": "Get_Users_Paged",
-      "resourceId": 1179,
-      "productId": 1
+      "resourceId": "1179",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -4958,8 +4958,8 @@
       "resource": "Upload account logo",
       "description": "Acceso para subir la imagen del logotipo de la cuenta.",
       "key": "Upload_Logo",
-      "resourceId": 1183,
-      "productId": 1
+      "resourceId": "1183",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -4967,8 +4967,8 @@
       "resource": "Get account by host",
       "description": "[Interno] Devuelve todos los hosts autorizados para una cuenta y los hosts de la cuenta que autorizó.",
       "key": "Get_Hosts_By_Account",
-      "resourceId": 1210,
-      "productId": 1
+      "resourceId": "1210",
+      "productId": "1"
     },
     {
       "product": "Live Shopping",
@@ -4976,8 +4976,8 @@
       "resource": "view_live_shopping",
       "description": "Está destinada a usuarios invitados de la aplicación Live Shopping, como por ejemplo personas influyentes, que no necesitan acceso a la información de la cuenta.",
       "key": "view_live_shopping",
-      "resourceId": 1532000,
-      "productId": 98
+      "resourceId": "1532000",
+      "productId": "98"
     },
     {
       "product": "Logistics",
@@ -4985,8 +4985,8 @@
       "resource": "Logistics full access",
       "description": "Acceso completo a todas las funciones de logística (visualización, creación, edición y cancelación de ajustes).",
       "key": "LogisticsAdmin",
-      "resourceId": 1158,
-      "productId": 9
+      "resourceId": "1158",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -4994,8 +4994,8 @@
       "resource": "Logistics viewer",
       "description": "Visualización del área inicial del módulo logístico.",
       "key": "LogisticsViewer",
-      "resourceId": 1926,
-      "productId": 9
+      "resourceId": "1926",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -5003,8 +5003,8 @@
       "resource": "Logistics inventory full access",
       "description": "Acceso completo al inventario logístico (visualización, creación, edición y cancelación de ajustes).",
       "key": "InventoryAdmin",
-      "resourceId": 475811,
-      "productId": 9
+      "resourceId": "475811",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -5012,8 +5012,8 @@
       "resource": "Logistics inventory read only",
       "description": "Ver módulo de inventario.",
       "key": "InventoryViewer",
-      "resourceId": 475812,
-      "productId": 9
+      "resourceId": "475812",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -5021,8 +5021,8 @@
       "resource": "Logistics shipping full access",
       "description": "Acceso completo a todas las funciones de envío del módulo de logística (creación, edición y cancelación de configuraciones).",
       "key": "ShippingAdmin",
-      "resourceId": 475813,
-      "productId": 9
+      "resourceId": "475813",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -5030,8 +5030,8 @@
       "resource": "Request Logistics Reports",
       "description": "Solicitar informes logísticos.",
       "key": "RequestLogisticsReports",
-      "resourceId": 881768,
-      "productId": 9
+      "resourceId": "881768",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -5039,8 +5039,8 @@
       "resource": "Transportation full access",
       "description": "Acceso completo al transporte.",
       "key": "TransportationAdmin",
-      "resourceId": 885164,
-      "productId": 9
+      "resourceId": "885164",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -5048,8 +5048,8 @@
       "resource": "Transportation read only",
       "description": "Ver los pedidos, paquetes y etiquetas de envío de VTEX Shipping Network.",
       "key": "TransportationViewer",
-      "resourceId": 1881967,
-      "productId": 9
+      "resourceId": "1881967",
+      "productId": "9"
     },
     {
       "product": "Master Data",
@@ -5057,8 +5057,8 @@
       "resource": "List Applications",
       "description": "Enumerar las solicitudes.",
       "key": "1_application_list",
-      "resourceId": 52286,
-      "productId": 3
+      "resourceId": "52286",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -5066,8 +5066,8 @@
       "resource": "Create Applications",
       "description": "Crear aplicaciones.",
       "key": "1_application_create",
-      "resourceId": 52287,
-      "productId": 3
+      "resourceId": "52287",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -5075,8 +5075,8 @@
       "resource": "Edit Applications",
       "description": "Editar aplicaciones.",
       "key": "1_application_edit",
-      "resourceId": 52288,
-      "productId": 3
+      "resourceId": "52288",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -5084,8 +5084,8 @@
       "resource": "Remove Applications",
       "description": "Eliminar aplicaciones.",
       "key": "1_application_delete",
-      "resourceId": 52289,
-      "productId": 3
+      "resourceId": "52289",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -5093,8 +5093,8 @@
       "resource": "Create custom search",
       "description": "Crea una búsqueda personalizada.",
       "key": "3_application_searchcreate",
-      "resourceId": 52290,
-      "productId": 3
+      "resourceId": "52290",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -5102,8 +5102,8 @@
       "resource": "Allow data export",
       "description": "Exportación de datos.",
       "key": "3_application_export",
-      "resourceId": 52291,
-      "productId": 3
+      "resourceId": "52291",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -5111,8 +5111,8 @@
       "resource": "View logs",
       "description": "Visualización de registros.",
       "key": "4_application_logview",
-      "resourceId": 52292,
-      "productId": 3
+      "resourceId": "52292",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -5120,8 +5120,8 @@
       "resource": "List Comments",
       "description": "Lista de comentarios.",
       "key": "1_commentmanager_list",
-      "resourceId": 52293,
-      "productId": 3
+      "resourceId": "52293",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -5129,8 +5129,8 @@
       "resource": "Remove Comment",
       "description": "Eliminar comentarios.",
       "key": "1_commentmanager_delete",
-      "resourceId": 52294,
-      "productId": 3
+      "resourceId": "52294",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -5138,8 +5138,8 @@
       "resource": "List Custom Search",
       "description": "Lista de búsqueda personalizada.",
       "key": "1_customsearch_list",
-      "resourceId": 52295,
-      "productId": 3
+      "resourceId": "52295",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -5147,8 +5147,8 @@
       "resource": "Exclude Custom Search",
       "description": "Eliminar búsqueda personalizada.",
       "key": "1_customsearch_delete",
-      "resourceId": 52296,
-      "productId": 3
+      "resourceId": "52296",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -5156,8 +5156,8 @@
       "resource": "List Forms",
       "description": "Formularios de lista.",
       "key": "1_form_list",
-      "resourceId": 52297,
-      "productId": 3
+      "resourceId": "52297",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -5165,8 +5165,8 @@
       "resource": "Create Forms",
       "description": "Crear formularios.",
       "key": "1_form_create",
-      "resourceId": 52298,
-      "productId": 3
+      "resourceId": "52298",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -5174,8 +5174,8 @@
       "resource": "Edit Forms",
       "description": "Editar formularios.",
       "key": "1_form_edit",
-      "resourceId": 52299,
-      "productId": 3
+      "resourceId": "52299",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -5183,8 +5183,8 @@
       "resource": "Remove Form",
       "description": "Eliminar formularios.",
       "key": "1_form_delete",
-      "resourceId": 52300,
-      "productId": 3
+      "resourceId": "52300",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -5192,8 +5192,8 @@
       "resource": "CRM administrator",
       "description": "Gestionar la información del CRM.",
       "key": "ADMIN_CRM",
-      "resourceId": 25786,
-      "productId": 3
+      "resourceId": "25786",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -5201,8 +5201,8 @@
       "resource": "Full access to forms",
       "description": "Acceso completo a los formularios.",
       "key": "POWER_USER_CRM",
-      "resourceId": 52283,
-      "productId": 3
+      "resourceId": "52283",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -5210,8 +5210,8 @@
       "resource": "Access to insert and edit but not to delete",
       "description": "Acceso de lectura y edición, pero no de eliminación.",
       "key": "NOREMOVE_USER_CRM",
-      "resourceId": 52284,
-      "productId": 3
+      "resourceId": "52284",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -5219,8 +5219,8 @@
       "resource": "Read-only form access",
       "description": "Solo lectura de formularios.",
       "key": "READONLY_USER_CRM",
-      "resourceId": 52285,
-      "productId": 3
+      "resourceId": "52285",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -5228,8 +5228,8 @@
       "resource": "Run import",
       "description": "Ejecutar el proceso de importación.",
       "key": "3_import_run",
-      "resourceId": 52306,
-      "productId": 3
+      "resourceId": "52306",
+      "productId": "3"
     },
     {
       "product": "Message Center",
@@ -5237,8 +5237,8 @@
       "resource": "Send Message ",
       "description": "Envía un mensaje desde el Centro de mensajes.",
       "key": "send-message",
-      "resourceId": 1026939,
-      "productId": 23
+      "resourceId": "1026939",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -5246,8 +5246,8 @@
       "resource": "View provider list",
       "description": "Visualización de la lista de remitentes en el Centro de mensajes.",
       "key": "provider-listar",
-      "resourceId": 52282,
-      "productId": 23
+      "resourceId": "52282",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -5255,8 +5255,8 @@
       "resource": "Add or edit provider",
       "description": "Cree o edite remitentes (proveedores) creados en el área de remitentes del Centro de mensajes.",
       "key": "provider-salvar",
-      "resourceId": 52325,
-      "productId": 23
+      "resourceId": "52325",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -5264,8 +5264,8 @@
       "resource": "Remove provider",
       "description": "Elimine los remitentes creados en el área de remitentes (proveedores) del Centro de mensajes.",
       "key": "provider-excluir",
-      "resourceId": 52326,
-      "productId": 23
+      "resourceId": "52326",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -5273,8 +5273,8 @@
       "resource": "View template list",
       "description": "Consulta la lista de plantillas disponibles en el Centro de mensajes.",
       "key": "template-listar",
-      "resourceId": 1203,
-      "productId": 23
+      "resourceId": "1203",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -5282,8 +5282,8 @@
       "resource": "Add new template",
       "description": "Agregue nuevas plantillas a la lista de plantillas del Centro de mensajes.",
       "key": "template-criar",
-      "resourceId": 1204,
-      "productId": 23
+      "resourceId": "1204",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -5291,8 +5291,8 @@
       "resource": "Remove template",
       "description": "Eliminar las plantillas nuevas de la lista de plantillas del Centro de mensajes.",
       "key": "template-excluir",
-      "resourceId": 1205,
-      "productId": 23
+      "resourceId": "1205",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -5300,8 +5300,8 @@
       "resource": "Edit template",
       "description": "Edición y personalización de plantillas en el Centro de mensajes.",
       "key": "template-editar",
-      "resourceId": 1207,
-      "productId": 23
+      "resourceId": "1207",
+      "productId": "23"
     },
     {
       "product": "OMS",
@@ -5309,8 +5309,8 @@
       "resource": "Change order workflow status",
       "description": "Acciones dentro del flujo de pedidos para cambiar el estado del pedido, a través del botón Acciones en el flujo.",
       "key": "WorkflowAction",
-      "resourceId": 1150,
-      "productId": 19
+      "resourceId": "1150",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -5318,8 +5318,8 @@
       "resource": "Notify payment",
       "description": "Acceda al botón que notifica manualmente a la pasarela de pago en el área de pago dentro del pedido.",
       "key": "PaymentAction",
-      "resourceId": 1151,
-      "productId": 19
+      "resourceId": "1151",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -5327,8 +5327,8 @@
       "resource": "Notify invoice",
       "description": "Le permite ingresar manualmente facturas (NF) y datos de seguimiento en el OMS.",
       "key": "ShippingAction",
-      "resourceId": 1152,
-      "productId": 19
+      "resourceId": "1152",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -5336,8 +5336,8 @@
       "resource": "View order",
       "description": "Visualizar todos los pedidos de la cuenta.",
       "key": "OMSViewer",
-      "resourceId": 1153,
-      "productId": 19
+      "resourceId": "1153",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -5345,8 +5345,8 @@
       "resource": "Notify refund",
       "description": "Le permite notificarnos la llegada de una factura.",
       "key": "RefundAction",
-      "resourceId": 1407,
-      "productId": 19
+      "resourceId": "1407",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -5354,8 +5354,8 @@
       "resource": "Cancel order",
       "description": "Te permite cancelar un pedido en OMS.",
       "key": "CancelAction",
-      "resourceId": 1408,
-      "productId": 19
+      "resourceId": "1408",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -5363,8 +5363,8 @@
       "resource": "Order feed subscription",
       "description": "Permite al usuario suscribirse para recibir actualizaciones del estado de los pedidos en el Feed de pedidos.",
       "key": "FeedSubscription",
-      "resourceId": 1409,
-      "productId": 19
+      "resourceId": "1409",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -5372,8 +5372,8 @@
       "resource": "Change order",
       "description": "Le permite registrar cambios en el pedido (descuentos y/o cambios).",
       "key": "Changes",
-      "resourceId": 1621,
-      "productId": 19
+      "resourceId": "1621",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -5381,8 +5381,8 @@
       "resource": "View store sales stats",
       "description": "Muestra los totales en la sección \"Todos los pedidos\" de la gestión de pedidos. Muestra las ventas totales además de los detalles del pedido.",
       "key": "ShowTotalizers",
-      "resourceId": 98200,
-      "productId": 19
+      "resourceId": "98200",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -5390,8 +5390,8 @@
       "resource": "Only show orders created by the user (via call center)",
       "description": "Los pedidos se procesarán a través de la dirección de correo electrónico registrada en callcenteroperatoremail.",
       "key": "callCenterOperatorFilter",
-      "resourceId": 428968,
-      "productId": 19
+      "resourceId": "428968",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -5399,8 +5399,8 @@
       "resource": "Feed v3 and Hook Admin",
       "description": "Crea, edita y elimina la configuración de Feed v3/hook.",
       "key": "FeedHookV3Admin",
-      "resourceId": 592028,
-      "productId": 19
+      "resourceId": "592028",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -5408,8 +5408,8 @@
       "resource": "Feed v3 and Hook view only",
       "description": "Ver datos de Feed v3/hook.",
       "key": "FeedHookV3Viewer",
-      "resourceId": 592029,
-      "productId": 19
+      "resourceId": "592029",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -5417,7 +5417,7 @@
       "resource": "Subscription view only",
       "description": "Ver datos de suscripción de la tienda.",
       "key": "SubscriptionViewer",
-      "resourceId": 592030,
+      "resourceId": "592030",
       "productId": ""
     },
     {
@@ -5426,7 +5426,7 @@
       "resource": "Subscription admin",
       "description": "Acción y vista del Admin de subscripciones. Acces al botón de prueba novamente.",
       "key": "SubscriptionAdmin",
-      "resourceId": 592031,
+      "resourceId": "592031",
       "productId": ""
     },
     {
@@ -5435,7 +5435,7 @@
       "resource": "Subscription metrics and reports",
       "description": "Acceso a métricas y visualización de informes en el panel de control de suscripciones.",
       "key": "SubscriptionMetrics",
-      "resourceId": 592032,
+      "resourceId": "592032",
       "productId": ""
     },
     {
@@ -5444,7 +5444,7 @@
       "resource": "Subscription view and edit",
       "description": "Permite visualizar y editar firmas.",
       "key": "SubscriptionManager",
-      "resourceId": 592033,
+      "resourceId": "592033",
       "productId": ""
     },
     {
@@ -5453,8 +5453,8 @@
       "resource": "List Orders",
       "description": "Listar todos los pedidos de la cuenta.",
       "key": "ListOrders",
-      "resourceId": 1860145,
-      "productId": 19
+      "resourceId": "1860145",
+      "productId": "19"
     },
     {
       "product": "Order Authorization",
@@ -5462,8 +5462,8 @@
       "resource": "Save Configuration",
       "description": "En la sección de autorización de pedidos, dentro de la gestión de pedidos, podrá ver y modificar la configuración de aceptación de pedidos con diferencias de valor.",
       "key": "SaveConfiguration",
-      "resourceId": 600081,
-      "productId": 74
+      "resourceId": "600081",
+      "productId": "74"
     },
     {
       "product": "Order Authorization",
@@ -5471,8 +5471,8 @@
       "resource": "View Configuration",
       "description": "Consulte la configuración de aceptación de pedidos para detectar diferencias de valor en la sección de autorización de pedidos dentro de la gestión de pedidos.",
       "key": "ViewConfiguration",
-      "resourceId": 600082,
-      "productId": 74
+      "resourceId": "600082",
+      "productId": "74"
     },
     {
       "product": "PCI Gateway",
@@ -5480,8 +5480,8 @@
       "resource": "BIN Manager Edit Permission",
       "description": "Permite editar a qué banco o institución financiera pertenece un BIN determinado.",
       "key": "binManagerEditPermission",
-      "resourceId": 631530,
-      "productId": 6
+      "resourceId": "631530",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -5489,8 +5489,8 @@
       "resource": "Process payments",
       "description": "Representa las operaciones transaccionales de la pasarela de pago.",
       "key": "MakePayments",
-      "resourceId": 1052,
-      "productId": 6
+      "resourceId": "1052",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -5498,8 +5498,8 @@
       "resource": "Manage Infrastructure",
       "description": "Realizar configuraciones críticas en la infraestructura de Gateway. Disponible solo para administradores.",
       "key": "ManageInfrastructure",
-      "resourceId": 1157,
-      "productId": 6
+      "resourceId": "1157",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -5507,8 +5507,8 @@
       "resource": "Manage Store",
       "description": "Cambia la configuración.",
       "key": "ManageStore",
-      "resourceId": 1097,
-      "productId": 6
+      "resourceId": "1097",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -5516,8 +5516,8 @@
       "resource": "Manage Store Rules",
       "description": "Permiso para gestionar los métodos de pago de la tienda.",
       "key": "ManageStoreRules",
-      "resourceId": 1684986,
-      "productId": 6
+      "resourceId": "1684986",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -5525,8 +5525,8 @@
       "resource": "Manage Store Affiliations",
       "description": "Permiso para gestionar las afiliaciones de Gateway de la tienda.",
       "key": "ManageStoreAffiliations",
-      "resourceId": 1684987,
-      "productId": 6
+      "resourceId": "1684987",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -5534,7 +5534,7 @@
       "resource": "Manage Store AntiFraud",
       "description": "Permiso para gestionar las funciones antifraude de los métodos de pago de la tienda.",
       "key": "ManageStoreAntiFraud ",
-      "resourceId": 1684988,
+      "resourceId": "1684988",
       "productId": ""
     },
     {
@@ -5543,8 +5543,8 @@
       "resource": "Notify Payments",
       "description": "Notificación de aprobación de pago.",
       "key": "NotifyPayments",
-      "resourceId": 1512,
-      "productId": 6
+      "resourceId": "1512",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -5552,8 +5552,8 @@
       "resource": "Payments Notification",
       "description": "Notificación de aprobación de pago mediante la API de la pasarela de pagos.",
       "key": "PaymentsNotification",
-      "resourceId": 2061772,
-      "productId": 6
+      "resourceId": "2061772",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -5561,8 +5561,8 @@
       "resource": "View Payment Data",
       "description": "Recuperar una transacción.",
       "key": "ViewPayments",
-      "resourceId": 1096,
-      "productId": 6
+      "resourceId": "1096",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -5570,8 +5570,8 @@
       "resource": "View Payments Sensitive Data",
       "description": "Visualización de información de identificación personal (PII) para tiendas que utilizan un entorno de cumplimiento de privacidad de datos.",
       "key": "ViewPaymentsSensitiveData",
-      "resourceId": 1515091,
-      "productId": 6
+      "resourceId": "1515091",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -5579,8 +5579,8 @@
       "resource": "BIN Manager View Permission",
       "description": "Le permite buscar y ver a qué banco o institución financiera pertenece un BIN determinado.",
       "key": "binManagerViewPermission",
-      "resourceId": 631529,
-      "productId": 6
+      "resourceId": "631529",
+      "productId": "6"
     },
     {
       "product": "Payments",
@@ -5588,8 +5588,8 @@
       "resource": "View Card Tokens",
       "description": "Permite visualizar los datos de la tarjeta tokenizada.",
       "key": "ViewCardTokens",
-      "resourceId": 2078628,
-      "productId": 114
+      "resourceId": "2078628",
+      "productId": "114"
     },
     {
       "product": "Payments",
@@ -5597,8 +5597,8 @@
       "resource": "Edit Card Tokens",
       "description": "Permite editar datos de tarjetas tokenizadas creadas previamente en la Bóveda de Tokens de Tarjetas.",
       "key": "ManageCardTokens",
-      "resourceId": 2078744,
-      "productId": 114
+      "resourceId": "2078744",
+      "productId": "114"
     },
     {
       "product": "Payments",
@@ -5606,8 +5606,8 @@
       "resource": "Create Card Tokens",
       "description": "Permite almacenar tarjetas tokenizadas.",
       "key": "CreateCardTokens",
-      "resourceId": 2078845,
-      "productId": 114
+      "resourceId": "2078845",
+      "productId": "114"
     },
     {
       "product": "Payments",
@@ -5615,8 +5615,8 @@
       "resource": "Delete Card Token",
       "description": "Permite eliminar una tarjeta tokenizada almacenada previamente.",
       "key": "DeleteCardToken",
-      "resourceId": 2078846,
-      "productId": 114
+      "resourceId": "2078846",
+      "productId": "114"
     },
     {
       "product": "Payments",
@@ -5624,8 +5624,8 @@
       "resource": "Import Card Token",
       "description": "Permite iniciar la importación de tokens de tarjetas de crédito.",
       "key": "ImportCardToken",
-      "resourceId": 2078847,
-      "productId": 114
+      "resourceId": "2078847",
+      "productId": "114"
     },
     {
       "product": "Payments",
@@ -5633,8 +5633,8 @@
       "resource": "Get Import Card Token Status ",
       "description": "Permite ver el estado de importación del token.",
       "key": "GetImportCardTokenStatus",
-      "resourceId": 2078848,
-      "productId": 114
+      "resourceId": "2078848",
+      "productId": "114"
     },
     {
       "product": "Payments",
@@ -5642,8 +5642,8 @@
       "resource": "Get Import Card Tokens Report",
       "description": "Descargue el informe de errores para conocer los errores de importación que se hayan producido.",
       "key": "GetImportCardTokensReport",
-      "resourceId": 2078849,
-      "productId": 114
+      "resourceId": "2078849",
+      "productId": "114"
     },
     {
       "product": "PersonalShopper App",
@@ -5651,8 +5651,8 @@
       "resource": "View Analytics",
       "description": "Consulta las estadísticas de la aplicación Personal Shopper.",
       "key": "view-analytics",
-      "resourceId": 1639728,
-      "productId": 100
+      "resourceId": "1639728",
+      "productId": "100"
     },
     {
       "product": "PersonalShopper App",
@@ -5660,8 +5660,8 @@
       "resource": "View List Call",
       "description": "Consulta la página de la convocatoria.",
       "key": "view-list-call",
-      "resourceId": 1639430,
-      "productId": 100
+      "resourceId": "1639430",
+      "productId": "100"
     },
     {
       "product": "PersonalShopper App",
@@ -5669,8 +5669,8 @@
       "resource": "View Setting",
       "description": "Edita la configuración de la aplicación Personal Shopper.",
       "key": "view-setting",
-      "resourceId": 1643056,
-      "productId": 100
+      "resourceId": "1643056",
+      "productId": "100"
     },
     {
       "product": "Portal",
@@ -5678,8 +5678,8 @@
       "resource": "Manage portal",
       "description": "Cree y edite plantillas, estantes y páginas en el CMS (Portal) y edite la configuración de pago.",
       "key": "AdminPortal",
-      "resourceId": 1299,
-      "productId": 27
+      "resourceId": "1299",
+      "productId": "27"
     },
     {
       "product": "Pricing",
@@ -5687,8 +5687,8 @@
       "resource": "Read prices",
       "description": "Ver todos los precios de un artículo.",
       "key": "read_prices",
-      "resourceId": 152730,
-      "productId": 65
+      "resourceId": "152730",
+      "productId": "65"
     },
     {
       "product": "Pricing",
@@ -5696,8 +5696,8 @@
       "resource": "Modify prices",
       "description": "Cambiar o crear un precio para un SKU.",
       "key": "modify_prices",
-      "resourceId": 152731,
-      "productId": 65
+      "resourceId": "152731",
+      "productId": "65"
     },
     {
       "product": "Pricing",
@@ -5705,8 +5705,8 @@
       "resource": "Read trade policy configurations",
       "description": "Consulte todas las políticas comerciales de la cuenta.",
       "key": "read_tradePolicySettings",
-      "resourceId": 152732,
-      "productId": 65
+      "resourceId": "152732",
+      "productId": "65"
     },
     {
       "product": "Pricing",
@@ -5714,8 +5714,8 @@
       "resource": "Modify trade policy configurations",
       "description": "Elimine todas las políticas comerciales de la cuenta.",
       "key": "modify_tradePolicySettings",
-      "resourceId": 152733,
-      "productId": 65
+      "resourceId": "152733",
+      "productId": "65"
     },
     {
       "product": "Pricing",
@@ -5723,8 +5723,8 @@
       "resource": "Delete all prices from account",
       "description": "Eliminar todos los precios de la cuenta.",
       "key": "modify_prices_delete_all",
-      "resourceId": 152736,
-      "productId": 65
+      "resourceId": "152736",
+      "productId": "65"
     },
     {
       "product": "Promotions Policy Engine",
@@ -5732,8 +5732,8 @@
       "resource": "Evaluate Policy",
       "description": "Obtenga una evaluación de la política.",
       "key": "EvaluatePolicy",
-      "resourceId": 1212434,
-      "productId": 89
+      "resourceId": "1212434",
+      "productId": "89"
     },
     {
       "product": "Promotions Policy Engine",
@@ -5741,8 +5741,8 @@
       "resource": "Create or Update Policy",
       "description": "Crear o actualizar una política.",
       "key": "CreateOrUpdatePolicy",
-      "resourceId": 1212435,
-      "productId": 89
+      "resourceId": "1212435",
+      "productId": "89"
     },
     {
       "product": "Promotions Policy Engine",
@@ -5750,8 +5750,8 @@
       "resource": "Get Policy",
       "description": "Para lograr el objetivo político.",
       "key": "GetPolicy",
-      "resourceId": 1212492,
-      "productId": 89
+      "resourceId": "1212492",
+      "productId": "89"
     },
     {
       "product": "Promotions Policy Engine",
@@ -5759,8 +5759,8 @@
       "resource": "Delete Policy",
       "description": "Eliminar una política.",
       "key": "DeletePolicy",
-      "resourceId": 1212493,
-      "productId": 89
+      "resourceId": "1212493",
+      "productId": "89"
     },
     {
       "product": "Promotions Policy Engine",
@@ -5768,8 +5768,8 @@
       "resource": "List Policies",
       "description": "Enumere las políticas existentes.",
       "key": "ListPolicies",
-      "resourceId": 1212494,
-      "productId": 89
+      "resourceId": "1212494",
+      "productId": "89"
     },
     {
       "product": "Rates and Benefits",
@@ -5777,8 +5777,8 @@
       "resource": "Manage benefits and rates",
       "description": "Crea, edita o archiva promociones, cupones, campañas y tarifas.",
       "key": "GerenciarPromocoesETarifas",
-      "resourceId": 98201,
-      "productId": 16
+      "resourceId": "98201",
+      "productId": "16"
     },
     {
       "product": "Rates and Benefits",
@@ -5786,8 +5786,8 @@
       "resource": "Manage Policies",
       "description": "Permitir la gestión de pólizas comerciales.",
       "key": "GerenciarPolicies",
-      "resourceId": 1118700,
-      "productId": 16
+      "resourceId": "1118700",
+      "productId": "16"
     },
     {
       "product": "Releases",
@@ -5795,8 +5795,8 @@
       "resource": "Edit Release",
       "description": "Crear, programar, reprogramar y eliminar entradas.",
       "key": "edit-release",
-      "resourceId": 1257521,
-      "productId": 91
+      "resourceId": "1257521",
+      "productId": "91"
     },
     {
       "product": "Releases",
@@ -5804,8 +5804,8 @@
       "resource": "Visualize Releases",
       "description": "Consulta la lista de versiones y actualizaciones para cada versión.",
       "key": "get-release",
-      "resourceId": 1257551,
-      "productId": 91
+      "resourceId": "1257551",
+      "productId": "91"
     },
     {
       "product": "Sales App",
@@ -5813,8 +5813,8 @@
       "resource": "View Sales Performance",
       "description": "Permite al vendedor ver la página de rendimiento de ventas en la aplicación VTEX Sales relacionada con una operación de punto de venta (tienda física).",
       "key": "ViewSalesPerformance",
-      "resourceId": 2126563,
-      "productId": 132
+      "resourceId": "2126563",
+      "productId": "132"
     },
     {
       "product": "Search",
@@ -5822,8 +5822,8 @@
       "resource": "General Settings",
       "description": "Editar la configuración general de Intelligent Search.",
       "key": "general-settings",
-      "resourceId": 719379,
-      "productId": 76
+      "resourceId": "719379",
+      "productId": "76"
     },
     {
       "product": "Security Monitor",
@@ -5831,8 +5831,8 @@
       "resource": "View Findings",
       "description": "Obtener, enumerar y ver información sobre hallazgos y tipos de hallazgos en Security Monitor.",
       "key": "ViewFindings",
-      "resourceId": 2000228,
-      "productId": 103
+      "resourceId": "2000228",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -5840,8 +5840,8 @@
       "resource": "Edit Findings",
       "description": "Posponer o reactivar alerta para un hallazgo en Security Monitor.",
       "key": "EditFindings",
-      "resourceId": 2000236,
-      "productId": 103
+      "resourceId": "2000236",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -5849,8 +5849,8 @@
       "resource": "Edit Notification Settings",
       "description": "Editar la configuración de los destinatarios de las notificaciones sobre alertas de seguridad en Security Monitor.",
       "key": "EditNotificationSettings",
-      "resourceId": 2000244,
-      "productId": 103
+      "resourceId": "2000244",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -5858,8 +5858,8 @@
       "resource": "List/Describe reports",
       "description": "Consulte un informe o una lista de informes en Security Monitor.",
       "key": "read-reports",
-      "resourceId": 1858423,
-      "productId": 103
+      "resourceId": "1858423",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -5867,8 +5867,8 @@
       "resource": "List/Describe Sensors",
       "description": "Ver detalles de sensores.",
       "key": "read-sensors",
-      "resourceId": 1880664,
-      "productId": 103
+      "resourceId": "1880664",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -5876,8 +5876,8 @@
       "resource": "Read Notifications Settings",
       "description": "Lea la configuración de notificaciones del Monitor de seguridad.",
       "key": "read-notifications-settings",
-      "resourceId": 1980709,
-      "productId": 103
+      "resourceId": "1980709",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -5885,8 +5885,8 @@
       "resource": "Create Reports",
       "description": "Cree nuevos informes en Security Monitor.",
       "key": "write-reports",
-      "resourceId": 1858424,
-      "productId": 103
+      "resourceId": "1858424",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -5894,8 +5894,8 @@
       "resource": "Update Sensors",
       "description": "Habilitar o deshabilitar sensores en el Monitor de seguridad.",
       "key": "update-sensors",
-      "resourceId": 1880649,
-      "productId": 103
+      "resourceId": "1880649",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -5903,8 +5903,8 @@
       "resource": "Write Notifications Settings",
       "description": "Editar la configuración de notificaciones del Monitor de seguridad.",
       "key": "write-notifications-settings",
-      "resourceId": 1980710,
-      "productId": 103
+      "resourceId": "1980710",
+      "productId": "103"
     },
     {
       "product": "Seller Register",
@@ -5912,8 +5912,8 @@
       "resource": "View Seller",
       "description": "Podrá ver todos los vendedores vinculados a la cuenta de la plataforma descrita en la página de Gestión de vendedores, incluyendo la posibilidad de recuperar datos de los vendedores, ya sea de la lista de vendedores o de un vendedor específico.",
       "key": "view-seller",
-      "resourceId": 575457,
-      "productId": 73
+      "resourceId": "575457",
+      "productId": "73"
     },
     {
       "product": "Seller Register",
@@ -5921,8 +5921,8 @@
       "resource": "Save Seller",
       "description": "Crea nuevos vendedores y edita los datos de todos los vendedores vinculados a la cuenta del marketplace desde la página de Gestión de vendedores.",
       "key": "save-seller",
-      "resourceId": 575458,
-      "productId": 73
+      "resourceId": "575458",
+      "productId": "73"
     },
     {
       "product": "Subscriptions",
@@ -5930,7 +5930,7 @@
       "resource": "Subscription view only",
       "description": "Ver datos de suscripción de la tienda.",
       "key": "SubscriptionViewer",
-      "resourceId": 592030,
+      "resourceId": "592030",
       "productId": ""
     },
     {
@@ -5939,7 +5939,7 @@
       "resource": "Subscription admin",
       "description": "Acción y vista del Admin de subscripciones. Acces al botón de prueba novamente.",
       "key": "SubscriptionAdmin",
-      "resourceId": 592031,
+      "resourceId": "592031",
       "productId": ""
     },
     {
@@ -5948,7 +5948,7 @@
       "resource": "Subscription view and edit",
       "description": "Visualización y edición de firmas.",
       "key": "SubscriptionManager",
-      "resourceId": 592033,
+      "resourceId": "592033",
       "productId": ""
     },
     {
@@ -5957,7 +5957,7 @@
       "resource": "Subscription metrics and reports",
       "description": "Consulta las métricas y los informes en el panel de suscripción.",
       "key": "SubscriptionMetrics",
-      "resourceId": 592032,
+      "resourceId": "592032",
       "productId": ""
     },
     {
@@ -5966,8 +5966,8 @@
       "resource": "Main Access",
       "description": "Acceso sin restricciones a todos los componentes de la página de SKU recibidos, incluyendo la visualización de los datos de la página y las acciones de aprobación de anuncios. Para obtener más información, consulte [Catalogación de SKU recibidos](https://help.vtex.com/pt/tutorial/sugerindo-e-aprovando-skus/).",
       "key": "suggestions",
-      "resourceId": 109448,
-      "productId": 50
+      "resourceId": "109448",
+      "productId": "50"
     },
     {
       "product": "User Rights",
@@ -5975,7 +5975,7 @@
       "resource": "Read Applications",
       "description": "Visualice las operaciones en las aplicaciones de derechos de usuario, ya sea en vista de lista o en vista detallada.",
       "key": "applications_read",
-      "resourceId": 1634515,
+      "resourceId": "1634515",
       "productId": ""
     },
     {
@@ -5984,7 +5984,7 @@
       "resource": "Write Applications",
       "description": "Crear, actualizar o eliminar solicitudes de derechos de usuario.",
       "key": "applications_write",
-      "resourceId": 1634523,
+      "resourceId": "1634523",
       "productId": ""
     },
     {
@@ -5993,8 +5993,8 @@
       "resource": "Read user rights requests",
       "description": "Consulte las solicitudes de derechos de usuario, ya sea en formato de lista o en formato detallado.",
       "key": "user_rights_request_read",
-      "resourceId": 1634546,
-      "productId": 99
+      "resourceId": "1634546",
+      "productId": "99"
     },
     {
       "product": "User Rights",
@@ -6002,8 +6002,8 @@
       "resource": "Write user rights requests",
       "description": "Crear, actualizar o eliminar solicitudes de derechos de usuario.",
       "key": "user_rights_request_write",
-      "resourceId": 1634554,
-      "productId": 99
+      "resourceId": "1634554",
+      "productId": "99"
     },
     {
       "product": "User Rights",
@@ -6011,8 +6011,8 @@
       "resource": "Process User Rights Removal Request",
       "description": "Tramitar las solicitudes de derechos de usuario de tipo eliminación.",
       "key": "removal-request-process",
-      "resourceId": 1705138,
-      "productId": 99
+      "resourceId": "1705138",
+      "productId": "99"
     },
     {
       "product": "VTEX Ad Network",
@@ -6020,8 +6020,8 @@
       "resource": "View Advertiser's details",
       "description": "Ver informaciones de un anunciante relacionada con VTEX Ad Network.",
       "key": "view-advertiser-details",
-      "resourceId": 2012197,
-      "productId": 106
+      "resourceId": "2012197",
+      "productId": "106"
     },
     {
       "product": "VTEX Ad Network",
@@ -6029,8 +6029,8 @@
       "resource": "View Advertiser's campaigns",
       "description": "Ver informaciones de la campaña de un anunciante de VTEX Ad Network.",
       "key": "view-advertiser-campaigns",
-      "resourceId": 2012200,
-      "productId": 106
+      "resourceId": "2012200",
+      "productId": "106"
     },
     {
       "product": "VTEX Ad Network",
@@ -6038,8 +6038,8 @@
       "resource": "Edit Advertiser's campaigns",
       "description": "Editar informaciones de campañas de un anunciante de VTEX Ad Network.",
       "key": "edit-advertiser-campaigns",
-      "resourceId": 2012201,
-      "productId": 106
+      "resourceId": "2012201",
+      "productId": "106"
     },
     {
       "product": "VTEX Ad Network",
@@ -6047,8 +6047,8 @@
       "resource": "View Publisher's details",
       "description": "Ver información del retailer sobre la entrega de anuncios de VTEX Ad Network.",
       "key": "view-publisher-details",
-      "resourceId": 2012196,
-      "productId": 106
+      "resourceId": "2012196",
+      "productId": "106"
     },
     {
       "product": "VTEX Bridge",
@@ -6056,8 +6056,8 @@
       "resource": "List Itens",
       "description": "Visualización de documentos del puente.",
       "key": "listItems",
-      "resourceId": 106704,
-      "productId": 48
+      "resourceId": "106704",
+      "productId": "48"
     },
     {
       "product": "VTEX Bridge",
@@ -6065,8 +6065,8 @@
       "resource": "Execute Actions",
       "description": "Realizar acciones sobre un elemento del registro. Por ejemplo, reprocesar el envío de un elemento en particular.",
       "key": "executeActions",
-      "resourceId": 106965,
-      "productId": 48
+      "resourceId": "106965",
+      "productId": "48"
     },
     {
       "product": "VTEX Bridge",
@@ -6074,8 +6074,8 @@
       "resource": "View Configs",
       "description": "Visualización de la configuración de cada integración.",
       "key": "viewConfig",
-      "resourceId": 106706,
-      "productId": 48
+      "resourceId": "106706",
+      "productId": "48"
     },
     {
       "product": "VTEX Bridge",
@@ -6083,8 +6083,8 @@
       "resource": "Manage Configs",
       "description": "Edita la configuración de una integración.",
       "key": "editConfig",
-      "resourceId": 106707,
-      "productId": 48
+      "resourceId": "106707",
+      "productId": "48"
     },
     {
       "product": "VTEX IO",
@@ -6092,8 +6092,8 @@
       "resource": "Manage A/B Test",
       "description": "Iniciar, finalizar u obtener el estado de una prueba A/B.",
       "key": "manage-abtest",
-      "resourceId": 664798,
-      "productId": 66
+      "resourceId": "664798",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -6101,8 +6101,8 @@
       "resource": "Read Workspace Apps",
       "description": "Lectura de las aplicaciones instaladas en el espacio de trabajo y sus dependencias.",
       "key": "read-workspace-apps",
-      "resourceId": 253175,
-      "productId": 66
+      "resourceId": "253175",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -6110,8 +6110,8 @@
       "resource": "Link App",
       "description": "Vincular y desvincular aplicaciones, así como listar los enlaces existentes dentro de una aplicación determinada.",
       "key": "link-app",
-      "resourceId": 253206,
-      "productId": 66
+      "resourceId": "253206",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -6119,8 +6119,8 @@
       "resource": "Install App",
       "description": "Instalación y desinstalación de aplicaciones sin opciones de facturación.",
       "key": "install-apps",
-      "resourceId": 253207,
-      "productId": 66
+      "resourceId": "253207",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -6128,8 +6128,8 @@
       "resource": "Vbase Read Only",
       "description": "VBase de solo lectura.",
       "key": "vbase-read-only",
-      "resourceId": 253582,
-      "productId": 66
+      "resourceId": "253582",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -6137,8 +6137,8 @@
       "resource": "Vbase Read Write",
       "description": "Lectura y escritura en VBase.",
       "key": "vbase-read-write",
-      "resourceId": 253583,
-      "productId": 66
+      "resourceId": "253583",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -6146,8 +6146,8 @@
       "resource": "Read Workspace Services",
       "description": "Lectura de la infraestructura de las aplicaciones instaladas en el escritorio.",
       "key": "read-workspace-services",
-      "resourceId": 257862,
-      "productId": 66
+      "resourceId": "257862",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -6155,8 +6155,8 @@
       "resource": "Install Service",
       "description": "Instalación y desinstalación de servicios de infraestructura.",
       "key": "install-services",
-      "resourceId": 257864,
-      "productId": 66
+      "resourceId": "257864",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -6164,8 +6164,8 @@
       "resource": "Log Access - Read-only",
       "description": "Leyendo los registros de todas las aplicaciones.",
       "key": "colossus-read-logs",
-      "resourceId": 259184,
-      "productId": 66
+      "resourceId": "259184",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -6173,8 +6173,8 @@
       "resource": "Read Published Service",
       "description": "Lectura de datos procedentes de los servicios de registro de infraestructura.",
       "key": "read-infra-service",
-      "resourceId": 259251,
-      "productId": 66
+      "resourceId": "259251",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -6182,8 +6182,8 @@
       "resource": "Debug App",
       "description": "Conecta un depurador a una aplicación vinculada.",
       "key": "debug-app",
-      "resourceId": 377794,
-      "productId": 66
+      "resourceId": "377794",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -6191,8 +6191,8 @@
       "resource": "Workspace CRUD",
       "description": "Creación, eliminación y modificación de espacios de trabajo.",
       "key": "workspace-read-write",
-      "resourceId": 379639,
-      "productId": 66
+      "resourceId": "379639",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -6200,8 +6200,8 @@
       "resource": "Buy App",
       "description": "Instalación y desinstalación de todo tipo de aplicaciones, incluidas aquellas con opciones de facturación.",
       "key": "buy-app",
-      "resourceId": 382623,
-      "productId": 66
+      "resourceId": "382623",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -6209,8 +6209,8 @@
       "resource": "Import Redirects",
       "description": "Gestione las redirecciones mediante la interfaz de línea de comandos de VTEX IO.",
       "key": "import-redirects",
-      "resourceId": 661667,
-      "productId": 66
+      "resourceId": "661667",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -6218,8 +6218,8 @@
       "resource": "Workspace Manipulation",
       "description": "Crear, modificar y eliminar un espacio de trabajo.",
       "key": "workspace-read-write-v2",
-      "resourceId": 794788,
-      "productId": 66
+      "resourceId": "794788",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -6227,8 +6227,8 @@
       "resource": "Workspace Promotion",
       "description": "Para promover un espacio de trabajo.",
       "key": "workspace-promote",
-      "resourceId": 794789,
-      "productId": 66
+      "resourceId": "794789",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -6236,8 +6236,8 @@
       "resource": "Read Edition",
       "description": "Leer la versión editada de una cuenta o espacio de trabajo.",
       "key": "read-edition",
-      "resourceId": 797718,
-      "productId": 66
+      "resourceId": "797718",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -6245,8 +6245,8 @@
       "resource": "Allow APP configuration",
       "description": "Configurar aplicaciones.",
       "key": "read-write-apps-settings",
-      "resourceId": 808001,
-      "productId": 66
+      "resourceId": "808001",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -6254,8 +6254,8 @@
       "resource": "Change sponsored tenant edition",
       "description": "Defina la edición de un inquilino que está patrocinado por la cuenta donde se otorga este permiso.",
       "key": "change-edition-of-sponsored-tenant",
-      "resourceId": 945388,
-      "productId": 66
+      "resourceId": "945388",
+      "productId": "66"
     },
     {
       "product": "VTEX Support",
@@ -6263,8 +6263,8 @@
       "resource": "Open Support Ticket",
       "description": "Abrir un ticket de soporte para VTEX. Solo válido para cuentas en Brasil.",
       "key": "open-support-ticket",
-      "resourceId": 1945378,
-      "productId": 104
+      "resourceId": "1945378",
+      "productId": "104"
     },
     {
       "product": "VTable",
@@ -6272,8 +6272,8 @@
       "resource": "View apps",
       "description": "Visualización de la aplicación VTable.",
       "key": "view-apps",
-      "resourceId": 257872,
-      "productId": 67
+      "resourceId": "257872",
+      "productId": "67"
     },
     {
       "product": "VTable",
@@ -6281,8 +6281,8 @@
       "resource": "Main access",
       "description": "Punto de acceso principal de la VTable.",
       "key": "main_access_old",
-      "resourceId": 258007,
-      "productId": 67
+      "resourceId": "258007",
+      "productId": "67"
     },
     {
       "product": "Vtex ID",
@@ -6290,8 +6290,8 @@
       "resource": "Write Identity Providers",
       "description": "Cree y actualice los proveedores de identidad (administrador y tienda web) para una cuenta.",
       "key": "write_identity_providers",
-      "resourceId": 631952,
-      "productId": 64
+      "resourceId": "631952",
+      "productId": "64"
     },
     {
       "product": "Vtex ID",
@@ -6299,8 +6299,8 @@
       "resource": "Read Identity Providers",
       "description": "Lee los proveedores de identidad (administrador y tienda web) de una cuenta.",
       "key": "read_identity_providers",
-      "resourceId": 631953,
-      "productId": 64
+      "resourceId": "631953",
+      "productId": "64"
     },
     {
       "product": "Vtex ID",
@@ -6308,8 +6308,8 @@
       "resource": "Can Punchout",
       "description": "Permitir que las claves API autentiquen a los usuarios mediante Punchout.",
       "key": "CanPunchout",
-      "resourceId": 2074726,
-      "productId": 64
+      "resourceId": "2074726",
+      "productId": "64"
     },
     {
       "product": "Vtex ID",
@@ -6317,8 +6317,8 @@
       "resource": "Expire User Password",
       "description": "Defina la contraseña de un usuario como nulo.",
       "key": "expire_user_password",
-      "resourceId": 1844857,
-      "productId": 64
+      "resourceId": "1844857",
+      "productId": "64"
     },
     {
       "product": "Vtex ID",
@@ -6326,8 +6326,8 @@
       "resource": "Create User",
       "description": "Crea un usuario de interfaz.",
       "key": "CreateUser",
-      "resourceId": 2117393,
-      "productId": 64
+      "resourceId": "2117393",
+      "productId": "64"
     },
     {
       "product": "WebService",
@@ -6335,8 +6335,8 @@
       "resource": "Webservice access",
       "description": "Cree, edite y elimine información del catálogo mediante el servicio web.",
       "key": "orders",
-      "resourceId": 136106,
-      "productId": 61
+      "resourceId": "136106",
+      "productId": "61"
     }
   ],
   "pt": [
@@ -6346,8 +6346,8 @@
       "resource": "Read logs stream",
       "description": "Ler registros de aplicativos VTEX IO pertencentes a esta conta.",
       "key": "read_logs",
-      "resourceId": 728560,
-      "productId": 81
+      "resourceId": "728560",
+      "productId": "81"
     },
     {
       "product": "Audit",
@@ -6355,8 +6355,8 @@
       "resource": "Save Event",
       "description": "Salvar eventos de auditoria.",
       "key": "SaveEvent",
-      "resourceId": 1353337,
-      "productId": 55
+      "resourceId": "1353337",
+      "productId": "55"
     },
     {
       "product": "B2B",
@@ -6364,8 +6364,8 @@
       "resource": "B2BBulkExport",
       "description": "Permite que as lojas B2B exportem seus dados em massa para arquivos.",
       "key": "B2BBulkExport",
-      "resourceId": 2045795,
-      "productId": 105
+      "resourceId": "2045795",
+      "productId": "105"
     },
     {
       "product": "B2B",
@@ -6373,8 +6373,8 @@
       "resource": "B2BBulkImport",
       "description": "Permite que as lojas B2B importem em massa várias organizações compradoras para a solução VTEX B2B.",
       "key": "B2BBulkImport",
-      "resourceId": 1954299,
-      "productId": 105
+      "resourceId": "1954299",
+      "productId": "105"
     },
     {
       "product": "B2B",
@@ -6382,8 +6382,8 @@
       "resource": "BulkImportTest",
       "description": "Permite que as lojas B2B importem em massa várias organizações compradoras para a solução VTEX B2B.",
       "key": "BulkImportTest",
-      "resourceId": 1957237,
-      "productId": 105
+      "resourceId": "1957237",
+      "productId": "105"
     },
     {
       "product": "Billing",
@@ -6391,8 +6391,8 @@
       "resource": "Edit Company Information",
       "description": "Editar as informações de registro de um cliente, são elas: razão social, nome fantasia, branch, sales region, tier, status de cobrança e endereço.",
       "key": "edit_company",
-      "resourceId": 118281,
-      "productId": 43
+      "resourceId": "118281",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -6400,8 +6400,8 @@
       "resource": "Display Company info",
       "description": "Visualizar as informações de registro de um cliente, são elas: razão social, nome fantasia, branch, sales region, tier, status de cobrança e endereço.",
       "key": "get_company",
-      "resourceId": 118283,
-      "productId": 43
+      "resourceId": "118283",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -6409,8 +6409,8 @@
       "resource": "Edit Company's Document",
       "description": "Editar documentos e informações da company.",
       "key": "edit_companys_document",
-      "resourceId": 131970,
-      "productId": 43
+      "resourceId": "131970",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -6418,8 +6418,8 @@
       "resource": "Merge companies",
       "description": "Realizar a fusão de dois accounts, de forma que todas as informações de faturas e contratos de um account são transferidas para o outro account.",
       "key": "company_merge",
-      "resourceId": 277452,
-      "productId": 43
+      "resourceId": "277452",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -6427,8 +6427,8 @@
       "resource": "Split companies",
       "description": "Separar dois accounts, sendo que informações de faturas e contratos são registradas em um deles, e outro fica nulo.",
       "key": "company_split",
-      "resourceId": 277453,
-      "productId": 43
+      "resourceId": "277453",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -6436,8 +6436,8 @@
       "resource": "Contacts List ",
       "description": "Visualizar quais são os contatos que recebem notificação por email quando uma fatura de determinado cliente é gerada.",
       "key": "list_contacts",
-      "resourceId": 118284,
-      "productId": 43
+      "resourceId": "118284",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -6445,8 +6445,8 @@
       "resource": "Edit Contacts",
       "description": "Adicionar ou editar um contato.",
       "key": "edit_contact",
-      "resourceId": 118285,
-      "productId": 43
+      "resourceId": "118285",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -6454,8 +6454,8 @@
       "resource": "Contracts List ",
       "description": "Visualizar contratos e condições de cobrança cadastrados no módulo Faturas da plataforma VTEX.",
       "key": "list_contracts",
-      "resourceId": 118282,
-      "productId": 43
+      "resourceId": "118282",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -6463,8 +6463,8 @@
       "resource": "Save contracts",
       "description": "Editar contratos no módulo Faturas da plataforma VTEX, incluindo o cadastro de manifesto de qualquer valor e cobrança de take rate em qualquer percentual.",
       "key": "put_contract",
-      "resourceId": 134738,
-      "productId": 43
+      "resourceId": "134738",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -6472,8 +6472,8 @@
       "resource": "Invoices List ",
       "description": "Visualização da listagem de faturas do cliente, bem como o detalhamento da fatura, que inclui informações como GMV e take rate.",
       "key": "list_invoices",
-      "resourceId": 105015,
-      "productId": 43
+      "resourceId": "105015",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -6481,8 +6481,8 @@
       "resource": "Generate new Invoice",
       "description": "Criar a fatura para um cliente, mas somente quando um contrato já está criado e tem um valor definido. O recurso não autoriza o usuário definir o valor da fatura.",
       "key": "put_invoices",
-      "resourceId": 120233,
-      "productId": 43
+      "resourceId": "120233",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -6490,8 +6490,8 @@
       "resource": "Cancel Invoice Document",
       "description": "Cancelar o documento fiscal gerado pelo emissor.",
       "key": "cancel_nfe",
-      "resourceId": 134739,
-      "productId": 43
+      "resourceId": "134739",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -6499,8 +6499,8 @@
       "resource": "Issue Invoice Document",
       "description": "Gerar o documento fiscal, mas somente no emissor.",
       "key": "issue_nfe",
-      "resourceId": 134740,
-      "productId": 43
+      "resourceId": "134740",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -6508,8 +6508,8 @@
       "resource": "Invoice reconciliation",
       "description": "Informar ao sistema a data e valor pago de uma fatura.",
       "key": "conciliate_invoice",
-      "resourceId": 134741,
-      "productId": 43
+      "resourceId": "134741",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -6517,8 +6517,8 @@
       "resource": "Generate Invoice for overdue payment without added interest fees",
       "description": "Alterar a data de vencimento de uma fatura, sem o acréscimo de multa e juros padrão.",
       "key": "generate_invoice_overdue_without_interest",
-      "resourceId": 134743,
-      "productId": 43
+      "resourceId": "134743",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -6526,8 +6526,8 @@
       "resource": "Cancel Invoice",
       "description": "Cancelamento de uma fatura no módulo Faturas da plataforma VTEX e no emissor.",
       "key": "cancel_invoice",
-      "resourceId": 134744,
-      "productId": 43
+      "resourceId": "134744",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -6535,8 +6535,8 @@
       "resource": "Change payment status",
       "description": "Alterar o status de pagamento da company para: Alert, Blocked, Timer ou Ok.",
       "key": "set_paymentstatus",
-      "resourceId": 138192,
-      "productId": 43
+      "resourceId": "138192",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -6544,8 +6544,8 @@
       "resource": "Unpaid invoices",
       "description": "Resetar uma fatura para o status \"opened\". Anula a data de pagamento e o valor pago.",
       "key": "unpaid_invoices",
-      "resourceId": 525925,
-      "productId": 43
+      "resourceId": "525925",
+      "productId": "43"
     },
     {
       "product": "Billing",
@@ -6553,8 +6553,8 @@
       "resource": "Simulate Invoices Creation",
       "description": "Simular faturas, sem de fato criá-las.",
       "key": "simulate_invoices",
-      "resourceId": 1362361,
-      "productId": 43
+      "resourceId": "1362361",
+      "productId": "43"
     },
     {
       "product": "Buyer Organizations",
@@ -6562,8 +6562,8 @@
       "resource": "Buyer Organization View",
       "description": "Visualizar a lista de organizações de compras.",
       "key": "buyer_organization_view",
-      "resourceId": 1522234,
-      "productId": 97
+      "resourceId": "1522234",
+      "productId": "97"
     },
     {
       "product": "Buyer Organizations",
@@ -6571,8 +6571,8 @@
       "resource": "Buyer Organization Edit",
       "description": "Criar ou editar organizações de compras.",
       "key": "buyer_organization_edit",
-      "resourceId": 1522235,
-      "productId": 97
+      "resourceId": "1522235",
+      "productId": "97"
     },
     {
       "product": "CDN API",
@@ -6580,8 +6580,8 @@
       "resource": "View certificate",
       "description": "Visualizar os detalhes dos certificados CDN.",
       "key": "ViewCertificate",
-      "resourceId": 2022646,
-      "productId": 108
+      "resourceId": "2022646",
+      "productId": "108"
     },
     {
       "product": "CDN API",
@@ -6589,8 +6589,8 @@
       "resource": "Update certificate",
       "description": "Substituir os certificados CDN existentes.",
       "key": "UpdateCertificate",
-      "resourceId": 2022647,
-      "productId": 108
+      "resourceId": "2022647",
+      "productId": "108"
     },
     {
       "product": "CDN API",
@@ -6598,8 +6598,8 @@
       "resource": "View WafControl Metrics",
       "description": "Visualizar métricas do WAF.",
       "key": "ViewWafControlMetrics",
-      "resourceId": 2142573,
-      "productId": 108
+      "resourceId": "2142573",
+      "productId": "108"
     },
     {
       "product": "CDN Service",
@@ -6607,8 +6607,8 @@
       "resource": "Query status of domains",
       "description": "Permite ao usuário consultar o status dos domínios da loja em produção.",
       "key": "query-domain",
-      "resourceId": 1271517,
-      "productId": 84
+      "resourceId": "1271517",
+      "productId": "84"
     },
     {
       "product": "CMS",
@@ -6616,8 +6616,8 @@
       "resource": "See CMS menu on the top-bar",
       "description": "Ver o menu do CMS na barra superior.",
       "key": "topbar_visualizar",
-      "resourceId": 111439,
-      "productId": 38
+      "resourceId": "111439",
+      "productId": "38"
     },
     {
       "product": "CMS",
@@ -6625,8 +6625,8 @@
       "resource": "Settings",
       "description": "Editar configurações do CMS.",
       "key": "cms_settings",
-      "resourceId": 1434680,
-      "productId": 38
+      "resourceId": "1434680",
+      "productId": "38"
     },
     {
       "product": "CMS",
@@ -6634,8 +6634,8 @@
       "resource": "CMS GraphQL API",
       "description": "Usar a API CMS GraphQL da VTEX IO.",
       "key": "access-cms-graphql-api",
-      "resourceId": 1032772,
-      "productId": 38
+      "resourceId": "1032772",
+      "productId": "38"
     },
     {
       "product": "CMS",
@@ -6643,8 +6643,8 @@
       "resource": "Read CMS GraphQL API",
       "description": "Concede acesso somente de leitura à API GraphQL do CMS do VTEX IO.",
       "key": "read-cms-graphql-api",
-      "resourceId": 2143073,
-      "productId": 38
+      "resourceId": "2143073",
+      "productId": "38"
     },
     {
       "product": "Catalog",
@@ -6652,8 +6652,8 @@
       "resource": "Admin list",
       "description": "Lista os administradores do sistema",
       "key": "Administrador.aspx",
-      "resourceId": 882,
-      "productId": 2
+      "resourceId": "882",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6661,8 +6661,8 @@
       "resource": "Homepage",
       "description": "Página Inicial",
       "key": "Home.aspx",
-      "resourceId": 1047,
-      "productId": 2
+      "resourceId": "1047",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6670,8 +6670,8 @@
       "resource": "Help page",
       "description": "Página inicial de ajuda",
       "key": "Help.aspx",
-      "resourceId": 1048,
-      "productId": 2
+      "resourceId": "1048",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6679,8 +6679,8 @@
       "resource": "Read Collections",
       "description": "Permite visualizar coleções",
       "key": "collections-read",
-      "resourceId": 627875,
-      "productId": 2
+      "resourceId": "627875",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6688,8 +6688,8 @@
       "resource": "Write Collections",
       "description": "Permite criar uma nova coleção de produtos",
       "key": "collections-write",
-      "resourceId": 627876,
-      "productId": 2
+      "resourceId": "627876",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6697,8 +6697,8 @@
       "resource": "Expert Reviews Management",
       "description": "Formulário de cadastro de opinião de especialistas",
       "key": "EspecialistaOpiniaoForm.aspx",
-      "resourceId": 928,
-      "productId": 2
+      "resourceId": "928",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6706,8 +6706,8 @@
       "resource": "Similar product category",
       "description": "Adicionar uma categoria similar ao produto",
       "key": "ProdutoCategoriaSimilar.aspx",
-      "resourceId": 981,
-      "productId": 2
+      "resourceId": "981",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6715,8 +6715,8 @@
       "resource": "Similar category product management",
       "description": "Cadastro de produto categoria similar",
       "key": "ProdutoCategoriaSimilarForm.aspx",
-      "resourceId": 982,
-      "productId": 2
+      "resourceId": "982",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6724,8 +6724,8 @@
       "resource": "SKU management",
       "description": "Formulário de cadastro de sku",
       "key": "SkuForm.aspx",
-      "resourceId": 1001,
-      "productId": 2
+      "resourceId": "1001",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6733,8 +6733,8 @@
       "resource": "SKU Services",
       "description": "Serviços de SKU",
       "key": "SkuServicoForm.aspx",
-      "resourceId": 1004,
-      "productId": 2
+      "resourceId": "1004",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6742,8 +6742,8 @@
       "resource": "Prices for SKU Services",
       "description": "Lista de valores de serviços SKU",
       "key": "SkuServicoValor.aspx",
-      "resourceId": 1005,
-      "productId": 2
+      "resourceId": "1005",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6751,8 +6751,8 @@
       "resource": "SKU service price management",
       "description": "Formulário para cadastro de valor para serviço SKU",
       "key": "SkuServicoValorForm.aspx",
-      "resourceId": 1006,
-      "productId": 2
+      "resourceId": "1006",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6760,8 +6760,8 @@
       "resource": "Commercial condition",
       "description": "Definição das políticas comerciais",
       "key": "SkuCondicaoComercial.aspx",
-      "resourceId": 1019,
-      "productId": 2
+      "resourceId": "1019",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6769,8 +6769,8 @@
       "resource": "SKU type management",
       "description": "Formulário para cadastro de tipos de serviços de SKU",
       "key": "SkuServicoTipo.aspx",
-      "resourceId": 1045,
-      "productId": 2
+      "resourceId": "1045",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6778,8 +6778,8 @@
       "resource": "Configuration Management",
       "description": "Formulário de cadastro de configuração",
       "key": "ConfigForm.aspx",
-      "resourceId": 917,
-      "productId": 2
+      "resourceId": "917",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6787,8 +6787,8 @@
       "resource": "File types list",
       "description": "Lista de tipos de arquivos",
       "key": "TipoArquivo.aspx",
-      "resourceId": 1009,
-      "productId": 2
+      "resourceId": "1009",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6796,8 +6796,8 @@
       "resource": "File types management",
       "description": "Formulário para cadastro de tamanhos padrão de imagem e demais arquivos",
       "key": "TipoArquivoForm.aspx",
-      "resourceId": 1010,
-      "productId": 2
+      "resourceId": "1010",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6805,8 +6805,8 @@
       "resource": "Store Texts",
       "description": "Ferramenta do desenvolvedor com todos os textos base da loja",
       "key": "TextoSite.aspx",
-      "resourceId": 1034,
-      "productId": 2
+      "resourceId": "1034",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6814,8 +6814,8 @@
       "resource": "CMS Management",
       "description": "Configurações do CMS (Portal)",
       "key": "PortalManagement",
-      "resourceId": 1202,
-      "productId": 2
+      "resourceId": "1202",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6823,8 +6823,8 @@
       "resource": "SEO Configurations",
       "description": "Configurações de Conteudos SEO (Robots.txt)",
       "key": "ConfigSEOContents.aspx",
-      "resourceId": 1222,
-      "productId": 2
+      "resourceId": "1222",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6832,8 +6832,8 @@
       "resource": "Gift Registry Types List",
       "description": "Listagem de Tipos de Listas",
       "key": "GiftListType.aspx",
-      "resourceId": 1631,
-      "productId": 2
+      "resourceId": "1631",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6841,8 +6841,8 @@
       "resource": "Gift Registry Lists Management",
       "description": "Formulário de criação e edição de tipos de lista (GiftList)",
       "key": "GiftListTypeForm.aspx",
-      "resourceId": 1633,
-      "productId": 2
+      "resourceId": "1633",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6850,8 +6850,8 @@
       "resource": "Geographic Region Management",
       "description": "Gerenciar a página de listagem de regiões geográficas.",
       "key": "GeographicRegion.aspx",
-      "resourceId": 2138652,
-      "productId": 2
+      "resourceId": "2138652",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6859,8 +6859,8 @@
       "resource": "Geographic Region Form",
       "description": "Gerenciar o formulário de criação e edição de regiões geográficas.",
       "key": "GeographicRegionForm.aspx",
-      "resourceId": 2138653,
-      "productId": 2
+      "resourceId": "2138653",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6868,8 +6868,8 @@
       "resource": "StoreForm.aspx",
       "description": "Visualizar a tela de detalhes de políticas comerciais.",
       "key": "StoreForm.aspx",
-      "resourceId": 2142219,
-      "productId": 2
+      "resourceId": "2142219",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6877,8 +6877,8 @@
       "resource": "InsertOrUpdateStoreForm.aspx",
       "description": "Criar e alterar políticas comerciais (sujeito à cobrança recorrente).",
       "key": "InsertOrUpdateStoreForm.aspx",
-      "resourceId": 2142347,
-      "productId": 2
+      "resourceId": "2142347",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6886,8 +6886,8 @@
       "resource": "Product management",
       "description": "Visualizar a tela de cadastro e alteração de produto",
       "key": "ProdutoForm.aspx",
-      "resourceId": 873,
-      "productId": 2
+      "resourceId": "873",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6895,8 +6895,8 @@
       "resource": "Product Form",
       "description": "Acesso à tela do produto",
       "key": "Produto.aspx",
-      "resourceId": 874,
-      "productId": 2
+      "resourceId": "874",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6904,8 +6904,8 @@
       "resource": "Change SKU Pricing",
       "description": "Alterar preços de SKUs",
       "key": "AlterarPrecoSku",
-      "resourceId": 877,
-      "productId": 2
+      "resourceId": "877",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6913,8 +6913,8 @@
       "resource": "SKU images management",
       "description": "Inserir e alterar imagens de SKU",
       "key": "ManterImagemProdutoSku",
-      "resourceId": 880,
-      "productId": 2
+      "resourceId": "880",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6922,8 +6922,8 @@
       "resource": "Product and SKU Management",
       "description": "Alteração e inclusão de produto e SKU",
       "key": "ManterFormularioProdutoSku",
-      "resourceId": 881,
-      "productId": 2
+      "resourceId": "881",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6931,8 +6931,8 @@
       "resource": "Reviews list",
       "description": "Lista todas as avaliações",
       "key": "Avaliacao.aspx",
-      "resourceId": 885,
-      "productId": 2
+      "resourceId": "885",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6940,8 +6940,8 @@
       "resource": "Reviews management",
       "description": "Formulário de cadastro de avaliação",
       "key": "AvaliacaoForm.aspx",
-      "resourceId": 886,
-      "productId": 2
+      "resourceId": "886",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6949,8 +6949,8 @@
       "resource": "Fields list",
       "description": "Lista todos os campos do sistema",
       "key": "Campo.aspx",
-      "resourceId": 891,
-      "productId": 2
+      "resourceId": "891",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6958,8 +6958,8 @@
       "resource": "Attributes Management",
       "description": "Formulário para cadastro de campos",
       "key": "CampoForm.aspx",
-      "resourceId": 896,
-      "productId": 2
+      "resourceId": "896",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6967,8 +6967,8 @@
       "resource": "Value fields list",
       "description": "Lista de valores de um campo",
       "key": "CampoValor.aspx",
-      "resourceId": 897,
-      "productId": 2
+      "resourceId": "897",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6976,8 +6976,8 @@
       "resource": "Attribute values management",
       "description": "Formulário de cadastro de um campo",
       "key": "CampoValorForm.aspx",
-      "resourceId": 898,
-      "productId": 2
+      "resourceId": "898",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6985,8 +6985,8 @@
       "resource": "Category ",
       "description": "Lista todas as categorias",
       "key": "Categoria.aspx",
-      "resourceId": 899,
-      "productId": 2
+      "resourceId": "899",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -6994,8 +6994,8 @@
       "resource": "Categories Management",
       "description": "Formulário de cadastro de categoria",
       "key": "CategoriaForm.aspx",
-      "resourceId": 900,
-      "productId": 2
+      "resourceId": "900",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7003,8 +7003,8 @@
       "resource": "Similar Category ",
       "description": "Lista todas as categorias similares",
       "key": "CategoriaSimilar.aspx",
-      "resourceId": 901,
-      "productId": 2
+      "resourceId": "901",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7012,8 +7012,8 @@
       "resource": "Similar Categories Management",
       "description": "Formulário de categorias similares",
       "key": "CategoriaSimilarForm.aspx",
-      "resourceId": 902,
-      "productId": 2
+      "resourceId": "902",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7021,8 +7021,8 @@
       "resource": "Price range",
       "description": "Lista todas as faixas de preços",
       "key": "FaixaPreco.aspx",
-      "resourceId": 933,
-      "productId": 2
+      "resourceId": "933",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7030,8 +7030,8 @@
       "resource": "Price Range Management",
       "description": "Formulário para cadastro de preços",
       "key": "FaixaPrecoForm.aspx",
-      "resourceId": 934,
-      "productId": 2
+      "resourceId": "934",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7039,8 +7039,8 @@
       "resource": "Providers",
       "description": "Lista os fornecedores cadastrados no sistema",
       "key": "Fornecedor.aspx",
-      "resourceId": 938,
-      "productId": 2
+      "resourceId": "938",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7048,8 +7048,8 @@
       "resource": "Supplier management",
       "description": "Formulário de cadastro de fornecedor",
       "key": "FornecedorForm.aspx",
-      "resourceId": 939,
-      "productId": 2
+      "resourceId": "939",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7057,8 +7057,8 @@
       "resource": "Groups",
       "description": "Lista todos os grupos de categoria",
       "key": "Grupo.aspx",
-      "resourceId": 944,
-      "productId": 2
+      "resourceId": "944",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7066,8 +7066,8 @@
       "resource": "Group Management ",
       "description": "Formulário de cadastro de grupos de categoria",
       "key": "GrupoForm.aspx",
-      "resourceId": 945,
-      "productId": 2
+      "resourceId": "945",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7075,8 +7075,8 @@
       "resource": "Brands",
       "description": "Lista todas as marcas cadastradas",
       "key": "Marca.aspx",
-      "resourceId": 955,
-      "productId": 2
+      "resourceId": "955",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7084,8 +7084,8 @@
       "resource": "Brands Management",
       "description": "Formulário para cadastro de marcas",
       "key": "MarcaForm.aspx",
-      "resourceId": 956,
-      "productId": 2
+      "resourceId": "956",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7093,8 +7093,8 @@
       "resource": "SKUs",
       "description": "Lista todos os SKUs cadastrados",
       "key": "Sku.aspx",
-      "resourceId": 996,
-      "productId": 2
+      "resourceId": "996",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7102,8 +7102,8 @@
       "resource": "Enable Product and SKU",
       "description": "Ativação de produto e de SKU",
       "key": "Ativar Produto Sku",
-      "resourceId": 1013,
-      "productId": 2
+      "resourceId": "1013",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7111,8 +7111,8 @@
       "resource": "Category Management",
       "description": "Verificação de acesso para inclusão ou alteração de nova categoria",
       "key": "InsertOrUpdateCategoriaFromCategoriaForm.aspx",
-      "resourceId": 1216,
-      "productId": 2
+      "resourceId": "1216",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7120,8 +7120,8 @@
       "resource": "Similar Category Management",
       "description": "Verificação de acesso para inclusão ou alteração de nova categoria similar",
       "key": "InsertOrUpdateCategoriaFromCategoriaSimilarForm.aspx",
-      "resourceId": 1217,
-      "productId": 2
+      "resourceId": "1217",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7129,8 +7129,8 @@
       "resource": "Brand Management",
       "description": "Validação para inserção ou alteração de marca",
       "key": "InsertOrUpdateMarcaFromMarcaForm.aspx",
-      "resourceId": 1218,
-      "productId": 2
+      "resourceId": "1218",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7138,8 +7138,8 @@
       "resource": "Insert or Update Group",
       "description": "Inserir ou alterar dentro da grupo de categoria",
       "key": "InsertOrUpdateGrupoFromGrupoForm.aspx",
-      "resourceId": 1219,
-      "productId": 2
+      "resourceId": "1219",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7147,8 +7147,8 @@
       "resource": "Field validation",
       "description": "Validação de campo",
       "key": "InsertOrUpdateCampoFromCampoForm.aspx",
-      "resourceId": 1220,
-      "productId": 2
+      "resourceId": "1220",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7156,8 +7156,8 @@
       "resource": "Value field validation",
       "description": "Validação de campo valor",
       "key": "InsertOrUpdateCampoValorFromCampoValorForm.aspx",
-      "resourceId": 1221,
-      "productId": 2
+      "resourceId": "1221",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7165,8 +7165,8 @@
       "resource": "Buy Together Management",
       "description": "Formulário de cadastro de compre junto",
       "key": "CompreJuntoForm.aspx",
-      "resourceId": 915,
-      "productId": 2
+      "resourceId": "915",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7174,8 +7174,8 @@
       "resource": "Reviews",
       "description": "Banco de avaliações de SKU",
       "key": "Resenha.aspx",
-      "resourceId": 988,
-      "productId": 2
+      "resourceId": "988",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7183,8 +7183,8 @@
       "resource": "Gift/Refund Vouchers",
       "description": "Cria Vale Compra",
       "key": "Vale.aspx",
-      "resourceId": 1016,
-      "productId": 2
+      "resourceId": "1016",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7192,8 +7192,8 @@
       "resource": "Product Collections XML",
       "description": "XML de Coleções",
       "key": "Xml.aspx",
-      "resourceId": 1026,
-      "productId": 2
+      "resourceId": "1026",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7201,8 +7201,8 @@
       "resource": "Tags management",
       "description": "Controle de Palavras - Tags",
       "key": "Tag.aspx",
-      "resourceId": 1027,
-      "productId": 2
+      "resourceId": "1027",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7210,8 +7210,8 @@
       "resource": "Sales channels management",
       "description": "Lista de políticas comerciais",
       "key": "Store.aspx",
-      "resourceId": 1226,
-      "productId": 2
+      "resourceId": "1226",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7219,8 +7219,8 @@
       "resource": "Sellers",
       "description": "Lista de Sellers (Lojas)",
       "key": "Seller.aspx",
-      "resourceId": 1227,
-      "productId": 2
+      "resourceId": "1227",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7228,8 +7228,8 @@
       "resource": "Seller SKUs",
       "description": "Lista SKU Sellers",
       "key": "SkuSeller.aspx",
-      "resourceId": 1229,
-      "productId": 2
+      "resourceId": "1229",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7237,8 +7237,8 @@
       "resource": "SKU Bundles",
       "description": "Interface dos Kits com os SKUs",
       "key": "SkuKit.aspx",
-      "resourceId": 1002,
-      "productId": 2
+      "resourceId": "1002",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7246,8 +7246,8 @@
       "resource": "Product Bundle Management",
       "description": "Formulário para cadastro de kits",
       "key": "SkuKitForm.aspx",
-      "resourceId": 1003,
-      "productId": 2
+      "resourceId": "1003",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7255,8 +7255,8 @@
       "resource": "News Report",
       "description": "Relatório de Newsletter",
       "key": "RelatorioNews.aspx",
-      "resourceId": 1020,
-      "productId": 2
+      "resourceId": "1020",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7264,8 +7264,8 @@
       "resource": "SKUs Report",
       "description": "Relatório SKUs",
       "key": "Relatorio_Skus.aspx",
-      "resourceId": 1022,
-      "productId": 2
+      "resourceId": "1022",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7273,8 +7273,8 @@
       "resource": "Out of stock notification",
       "description": "Relatório Solicitação de Avise-Me",
       "key": "Relatorio_AviseMeSku.aspx",
-      "resourceId": 1025,
-      "productId": 2
+      "resourceId": "1025",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7282,8 +7282,8 @@
       "resource": "Full-text Search",
       "description": "Relatório de buscas Full-text",
       "key": "RelatorioFullText.aspx",
-      "resourceId": 1028,
-      "productId": 2
+      "resourceId": "1028",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7291,8 +7291,8 @@
       "resource": "Security Monitoring",
       "description": "Monitoramento de Segurança",
       "key": "Relatorio_Seguranca.aspx",
-      "resourceId": 1031,
-      "productId": 2
+      "resourceId": "1031",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7300,8 +7300,8 @@
       "resource": "Gift Registry List",
       "description": "Ver todas as listas (GiftList)",
       "key": "GiftList.aspx",
-      "resourceId": 1632,
-      "productId": 2
+      "resourceId": "1632",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7309,8 +7309,8 @@
       "resource": "Assisted Sales Gift Registry List Management",
       "description": "Permite ao administrador gerenciar listas de um usuário no Site, como se fosse o próprio.",
       "key": "GiftListImpersonation",
-      "resourceId": 1634,
-      "productId": 2
+      "resourceId": "1634",
+      "productId": "2"
     },
     {
       "product": "Catalog",
@@ -7318,8 +7318,8 @@
       "resource": "Assisted Sales",
       "description": "Funcionalidades de televendas. Após o login, o usuário é redirecionado para o site de televendas www.{nomedaloja}.com.br/a/televendas. Dessa forma, o operador pode utilizar as funcionalidades de televendas, como navegar na loja em nome do cliente. Como este recurso causa o redirecionamento automático para a loja, o usuário que fizer login em uma conta com esse perfil não terá acesso a recursos importantes do Admin. Portanto, recomendamos a utilização de duas contas separadas (com emails distintos) para usuários de televendas: uma conta para o perfil Call center operator (com este recurso e o recurso View order) e outra conta para realizar operações no menu administrativo, se necessário.",
       "key": "Televendas",
-      "resourceId": 1046,
-      "productId": 2
+      "resourceId": "1046",
+      "productId": "2"
     },
     {
       "product": "Catalog API",
@@ -7327,8 +7327,8 @@
       "resource": "View Product",
       "description": "Visualizar detalhes de produtos e SKUs.",
       "key": "ViewProduct",
-      "resourceId": 2017533,
-      "productId": 107
+      "resourceId": "2017533",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -7336,8 +7336,8 @@
       "resource": "Edit Product",
       "description": "Editar detalhes de produtos e SKUs.",
       "key": "EditProduct",
-      "resourceId": 2038155,
-      "productId": 107
+      "resourceId": "2038155",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -7345,8 +7345,8 @@
       "resource": "View Category",
       "description": "Visualizar detalhes de categorias.",
       "key": "ViewCategory",
-      "resourceId": 2038156,
-      "productId": 107
+      "resourceId": "2038156",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -7354,8 +7354,8 @@
       "resource": "Edit Category",
       "description": "Editar detalhes de categorias.",
       "key": "EditCategory",
-      "resourceId": 2038157,
-      "productId": 107
+      "resourceId": "2038157",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -7363,8 +7363,8 @@
       "resource": "View Collection",
       "description": "Visualizar detalhes de coleções.",
       "key": "ViewCollection",
-      "resourceId": 2038158,
-      "productId": 107
+      "resourceId": "2038158",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -7372,8 +7372,8 @@
       "resource": "Edit Collection",
       "description": "Editar detalhes de coleções.",
       "key": "EditCollection",
-      "resourceId": 2038159,
-      "productId": 107
+      "resourceId": "2038159",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -7381,8 +7381,8 @@
       "resource": "View Brand",
       "description": "Visualizar detalhes de marcas.",
       "key": "ViewBrand",
-      "resourceId": 2038160,
-      "productId": 107
+      "resourceId": "2038160",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -7390,8 +7390,8 @@
       "resource": "Edit Brand",
       "description": "Editar detalhes de marcas.",
       "key": "EditBrand",
-      "resourceId": 2038161,
-      "productId": 107
+      "resourceId": "2038161",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -7399,8 +7399,8 @@
       "resource": "Import Spreadsheet",
       "description": "Importar produtos e SKUs por planilha.",
       "key": "ImportSpreadsheet",
-      "resourceId": 2038162,
-      "productId": 107
+      "resourceId": "2038162",
+      "productId": "107"
     },
     {
       "product": "Catalog API",
@@ -7408,8 +7408,8 @@
       "resource": "Export Spreadsheet",
       "description": "Exportar planilha de informações do catálogo.",
       "key": "ExportSpreadsheet",
-      "resourceId": 2038163,
-      "productId": 107
+      "resourceId": "2038163",
+      "productId": "107"
     },
     {
       "product": "Channels",
@@ -7417,8 +7417,8 @@
       "resource": "Send Marketplace Suggestions",
       "description": "Permite que sellers enviem anúncios ao marketplace, que serão revisados e aprovados pelo marketplace por meio da página SKUs Recebidos ou pela API Match Received SKUs.  ",
       "key": "EnviaSugestao",
-      "resourceId": 1139,
-      "productId": 13
+      "resourceId": "1139",
+      "productId": "13"
     },
     {
       "product": "Channels",
@@ -7426,8 +7426,8 @@
       "resource": "Sellers SKUs List",
       "description": "Permite que sellers visualizem a lista de SKUs enviados para os marketplaces em que vendem seus produtos. No Admin VTEX, a lista pode ser acessada em MARKETPLACE > Integrações > Produtos. ",
       "key": "Consulta",
-      "resourceId": 1154,
-      "productId": 13
+      "resourceId": "1154",
+      "productId": "13"
     },
     {
       "product": "Channels",
@@ -7435,8 +7435,8 @@
       "resource": "Save Suggestion Rules",
       "description": "Permite que marketplaces criem e alterem regras do VTEX Matcher para a aprovação de SKUs Recebidos. Essa configuração é feita por meio da API SKU Approval Settings.",
       "key": "SalvaRegras",
-      "resourceId": 1155,
-      "productId": 13
+      "resourceId": "1155",
+      "productId": "13"
     },
     {
       "product": "Channels",
@@ -7444,8 +7444,8 @@
       "resource": "Marketplace seller setup",
       "description": "Permite associar o seller a um novo marketplace ou alterar uma configuração existente. Sellers incluídos no Seller Portal só poderão ter suas configurações alteradas, mas não associados a mais de um marketplace. Já sellers VTEX podem ser associados a outros marketplaces e terem suas configurações alteradas, ao habilitar esse recurso. Essa ação pode ser feita via Admin VTEX, ou via API Rest.",
       "key": "ConfiguraSeller",
-      "resourceId": 1156,
-      "productId": 13
+      "resourceId": "1156",
+      "productId": "13"
     },
     {
       "product": "Channels",
@@ -7453,8 +7453,8 @@
       "resource": "Access the Marketplace Network",
       "description": "Crie, edite e liste o perfil da sua loja disponível no Marketplace Network e envie mensagens para outras lojas.",
       "key": "MarketplaceNetwork",
-      "resourceId": 1107285,
-      "productId": 13
+      "resourceId": "1107285",
+      "productId": "13"
     },
     {
       "product": "Checkout",
@@ -7462,8 +7462,8 @@
       "resource": "Shopping Cart Full Access",
       "description": "Leitura e escrita para todos os carrinhos de compras. Permite que os dados do carrinho venham abertos (não mascarados). Permite também requisição privada de simulação de carrinho.",
       "key": "AcessaTodosCarrinhos",
-      "resourceId": 1091,
-      "productId": 5
+      "resourceId": "1091",
+      "productId": "5"
     },
     {
       "product": "Checkout",
@@ -7471,8 +7471,8 @@
       "resource": "Orders Full Access",
       "description": "Leitura e escrita para todos os pedidos via API do Checkout. Não permite acesso a pedidos pelo fluxo do módulo de gerenciamento de pedidos.",
       "key": "AcessaTodosPedidos",
-      "resourceId": 1092,
-      "productId": 5
+      "resourceId": "1092",
+      "productId": "5"
     },
     {
       "product": "Checkout",
@@ -7480,8 +7480,8 @@
       "resource": "Save Order Configuration",
       "description": "Salvar configuração de pedidos.",
       "key": "SaveOrderConfiguration",
-      "resourceId": 600072,
-      "productId": 5
+      "resourceId": "600072",
+      "productId": "5"
     },
     {
       "product": "Checkout",
@@ -7489,8 +7489,8 @@
       "resource": "Save OrderForm Configuration",
       "description": "Salvar configuração de carrinhos de compras.",
       "key": "SaveOrderFormConfiguration",
-      "resourceId": 600073,
-      "productId": 5
+      "resourceId": "600073",
+      "productId": "5"
     },
     {
       "product": "Checkout",
@@ -7498,8 +7498,8 @@
       "resource": "Read Shopping Cart",
       "description": "Leitura e listagem de todos os carrinhos de compras. Não permite acesso a dados de carrinho não mascarados.",
       "key": "GetOrderForm",
-      "resourceId": 1949421,
-      "productId": 5
+      "resourceId": "1949421",
+      "productId": "5"
     },
     {
       "product": "Commerce Content",
@@ -7507,8 +7507,8 @@
       "resource": "Save to main branch",
       "description": "Adiciona alterações diretamente na branch main.",
       "key": "SaveToMainBranch",
-      "resourceId": 2086248,
-      "productId": 115
+      "resourceId": "2086248",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
@@ -7516,8 +7516,8 @@
       "resource": "Remove from main branch",
       "description": "Remover alterações da branch main.",
       "key": "RemoveFromMainBranch",
-      "resourceId": 2086250,
-      "productId": 115
+      "resourceId": "2086250",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
@@ -7525,8 +7525,8 @@
       "resource": "Merge branch",
       "description": "Mescla alterações de uma branch para a main.",
       "key": "MergeBranch",
-      "resourceId": 2086251,
-      "productId": 115
+      "resourceId": "2086251",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
@@ -7534,8 +7534,8 @@
       "resource": "Delete Branch",
       "description": "Permite excluir uma branch e todo o conteúdo versionado associado a ela.",
       "key": "DeleteBranch",
-      "resourceId": 2153203,
-      "productId": 115
+      "resourceId": "2153203",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
@@ -7543,8 +7543,8 @@
       "resource": "Create Branch",
       "description": "Permite criar uma nova branch para desenvolver, testar e salvar novas versões de conteúdo de forma isolada.",
       "key": "CreateBranch",
-      "resourceId": 2153204,
-      "productId": 115
+      "resourceId": "2153204",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
@@ -7552,8 +7552,8 @@
       "resource": "Delete entry",
       "description": "Exclui permanentemente uma entrada de todo o histórico e branches.",
       "key": "DeleteEntry",
-      "resourceId": 2086249,
-      "productId": 115
+      "resourceId": "2086249",
+      "productId": "115"
     },
     {
       "product": "Commerce Content",
@@ -7561,8 +7561,8 @@
       "resource": "Create Store",
       "description": "Cria nova loja Commerce Content na conta.",
       "key": "CreateStore",
-      "resourceId": 2086252,
-      "productId": 115
+      "resourceId": "2086252",
+      "productId": "115"
     },
     {
       "product": "Credit Control",
@@ -7570,8 +7570,8 @@
       "resource": "Read Checking Accounts",
       "description": "Visualização de informações de contas.",
       "key": "read_checkingaccounts",
-      "resourceId": 170921,
-      "productId": 58
+      "resourceId": "170921",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -7579,8 +7579,8 @@
       "resource": "Create Checking Accounts",
       "description": "Criação de contas.",
       "key": "create_checkingaccounts",
-      "resourceId": 170929,
-      "productId": 58
+      "resourceId": "170929",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -7588,8 +7588,8 @@
       "resource": "Edit credits",
       "description": "Alterar o limite de crédito de uma conta.",
       "key": "edit_credits",
-      "resourceId": 197575,
-      "productId": 58
+      "resourceId": "197575",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -7597,8 +7597,8 @@
       "resource": "Read Invoices",
       "description": "Visualização de faturas.",
       "key": "read_invoices",
-      "resourceId": 170930,
-      "productId": 58
+      "resourceId": "170930",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -7606,8 +7606,8 @@
       "resource": "Create Invoices",
       "description": "Emissão de notas fiscais.",
       "key": "create_invoices",
-      "resourceId": 170931,
-      "productId": 58
+      "resourceId": "170931",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -7615,8 +7615,8 @@
       "resource": "Pay Invoice",
       "description": "Pagamento de faturas.",
       "key": "pay_invoice",
-      "resourceId": 200613,
-      "productId": 58
+      "resourceId": "200613",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -7624,8 +7624,8 @@
       "resource": "Main Access",
       "description": "Permite acesso principal",
       "key": "suggestions",
-      "resourceId": 109448,
-      "productId": 50
+      "resourceId": "109448",
+      "productId": "50"
     },
     {
       "product": "Credit Control",
@@ -7633,8 +7633,8 @@
       "resource": "Read Statements",
       "description": "Leitura aos extratos de conta.",
       "key": "read_statements",
-      "resourceId": 170918,
-      "productId": 58
+      "resourceId": "170918",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -7642,8 +7642,8 @@
       "resource": "Create Statements",
       "description": "Criação de extratos de conta.",
       "key": "create_statements",
-      "resourceId": 170920,
-      "productId": 58
+      "resourceId": "170920",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -7651,8 +7651,8 @@
       "resource": "Edit Configuration",
       "description": "Alterar as configurações da loja.",
       "key": "edit_config",
-      "resourceId": 198649,
-      "productId": 58
+      "resourceId": "198649",
+      "productId": "58"
     },
     {
       "product": "Credit Control",
@@ -7660,8 +7660,8 @@
       "resource": "Read Configuration",
       "description": "Visualização das configurações da loja.",
       "key": "read_config",
-      "resourceId": 198650,
-      "productId": 58
+      "resourceId": "198650",
+      "productId": "58"
     },
     {
       "product": "Delivery Promises",
@@ -7669,8 +7669,8 @@
       "resource": "Notify Product Availability Change",
       "description": "Atualizar a disponibilidade de itens de sellers externos no contexto da Delivery Promise.",
       "key": "NotifyProductAvailabilityChange",
-      "resourceId": 2032871,
-      "productId": 111
+      "resourceId": "2032871",
+      "productId": "111"
     },
     {
       "product": "Dynamic Storage",
@@ -7678,8 +7678,8 @@
       "resource": "List data entity",
       "description": "Listar entidades de dados.",
       "key": "2_dataentity_list",
-      "resourceId": 69077,
-      "productId": 25
+      "resourceId": "69077",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -7687,8 +7687,8 @@
       "resource": "Create data entity",
       "description": "Criar entidade de dados.",
       "key": "1_dataentity_create",
-      "resourceId": 69078,
-      "productId": 25
+      "resourceId": "69078",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -7696,8 +7696,8 @@
       "resource": "Edit schema",
       "description": "Editar schema.",
       "key": "1_dataentity_edit",
-      "resourceId": 69079,
-      "productId": 25
+      "resourceId": "69079",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -7705,8 +7705,8 @@
       "resource": "Remove data entity",
       "description": "Excluir entidade de dados.",
       "key": "1_dataentity_delete",
-      "resourceId": 69080,
-      "productId": 25
+      "resourceId": "69080",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -7714,8 +7714,8 @@
       "resource": "View data entity details",
       "description": "Ver detalhes de entidade de dados.",
       "key": "2_dataentity_view",
-      "resourceId": 69081,
-      "productId": 25
+      "resourceId": "69081",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -7723,8 +7723,8 @@
       "resource": "Publish index",
       "description": "Publicar índice.",
       "key": "1_dataentity_publish",
-      "resourceId": 69082,
-      "productId": 25
+      "resourceId": "69082",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -7732,8 +7732,8 @@
       "resource": "Master Data administrator",
       "description": "Gerenciar Master Data.",
       "key": "ADMIN_DS",
-      "resourceId": 69073,
-      "productId": 25
+      "resourceId": "69073",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -7741,8 +7741,8 @@
       "resource": "Full access to all documents",
       "description": "Acesso total a todos os documentos.",
       "key": "POWER_USER_DS",
-      "resourceId": 69074,
-      "productId": 25
+      "resourceId": "69074",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -7750,8 +7750,8 @@
       "resource": "Insert or update document (not remove)",
       "description": "Criação e atualização de documentos, mas não remoção.",
       "key": "NOREMOVE_USER_DS",
-      "resourceId": 69075,
-      "productId": 25
+      "resourceId": "69075",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -7759,8 +7759,8 @@
       "resource": "Read only documents",
       "description": "Apenas leitura de documentos.",
       "key": "READONLY_USER_DS",
-      "resourceId": 69076,
-      "productId": 25
+      "resourceId": "69076",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -7768,7 +7768,7 @@
       "resource": "List index",
       "description": "Listar índices.",
       "key": "1_Index_list",
-      "resourceId": 105916,
+      "resourceId": "105916",
       "productId": ""
     },
     {
@@ -7777,7 +7777,7 @@
       "resource": "Create index",
       "description": "Criar índice.",
       "key": "1_Index_create",
-      "resourceId": 105917,
+      "resourceId": "105917",
       "productId": ""
     },
     {
@@ -7786,7 +7786,7 @@
       "resource": "Edit index",
       "description": "Editar índice.",
       "key": "1_Index_edit",
-      "resourceId": 105918,
+      "resourceId": "105918",
       "productId": ""
     },
     {
@@ -7795,7 +7795,7 @@
       "resource": "Remove index",
       "description": "Remover índice.",
       "key": "1_Index_delete",
-      "resourceId": 105919,
+      "resourceId": "105919",
       "productId": ""
     },
     {
@@ -7804,7 +7804,7 @@
       "resource": "View index details",
       "description": "Ver detalhes do índice.",
       "key": "1_Index_view",
-      "resourceId": 105920,
+      "resourceId": "105920",
       "productId": ""
     },
     {
@@ -7813,7 +7813,7 @@
       "resource": "List internal logs",
       "description": "Listar logs internos.",
       "key": "1_internallog_list",
-      "resourceId": 105921,
+      "resourceId": "105921",
       "productId": ""
     },
     {
@@ -7822,7 +7822,7 @@
       "resource": "List internal alerts",
       "description": "Listar alertas internos.",
       "key": "1_internalwarning_list",
-      "resourceId": 106143,
+      "resourceId": "106143",
       "productId": ""
     },
     {
@@ -7831,7 +7831,7 @@
       "resource": "View detail schema",
       "description": "Ver detalhes do schema.",
       "key": "1_dataentity_list",
-      "resourceId": 137232,
+      "resourceId": "137232",
       "productId": ""
     },
     {
@@ -7840,8 +7840,8 @@
       "resource": "List trigger",
       "description": "Listar triggers.",
       "key": "2_datarule_list",
-      "resourceId": 69083,
-      "productId": 25
+      "resourceId": "69083",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -7849,8 +7849,8 @@
       "resource": "Create trigger",
       "description": "Criar triggers.",
       "key": "1_datarule_create",
-      "resourceId": 69084,
-      "productId": 25
+      "resourceId": "69084",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -7858,8 +7858,8 @@
       "resource": "Edit trigger",
       "description": "Editar triggers.",
       "key": "1_datarule_edit",
-      "resourceId": 69085,
-      "productId": 25
+      "resourceId": "69085",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -7867,8 +7867,8 @@
       "resource": "Remove trigger",
       "description": "Excluir triggers.",
       "key": "1_datarule_delete",
-      "resourceId": 69086,
-      "productId": 25
+      "resourceId": "69086",
+      "productId": "25"
     },
     {
       "product": "Dynamic Storage",
@@ -7876,8 +7876,8 @@
       "resource": "View trigger details",
       "description": "Ver detalhes de triggers.",
       "key": "2_datarule_view",
-      "resourceId": 69087,
-      "productId": 25
+      "resourceId": "69087",
+      "productId": "25"
     },
     {
       "product": "FastStore",
@@ -7885,8 +7885,8 @@
       "resource": "View Secrets",
       "description": "Permite visualizar os segredos configurados no WebOps.",
       "key": "ViewSecrets",
-      "resourceId": 2100329,
-      "productId": 129
+      "resourceId": "2100329",
+      "productId": "129"
     },
     {
       "product": "FastStore",
@@ -7894,8 +7894,8 @@
       "resource": "Edit Secrets",
       "description": "Permite criar, deletar e editar segredos no WebOps.",
       "key": "EditSecrets",
-      "resourceId": 2100330,
-      "productId": 129
+      "resourceId": "2100330",
+      "productId": "129"
     },
     {
       "product": "Fraud Prevention",
@@ -7903,8 +7903,8 @@
       "resource": "View transaction attempts",
       "description": "Visualizar tentativas de transações na página Prevenção de Fraudes.",
       "key": "ViewTransactionAttempts",
-      "resourceId": 2134012,
-      "productId": 127
+      "resourceId": "2134012",
+      "productId": "127"
     },
     {
       "product": "Fraud Prevention",
@@ -7912,8 +7912,8 @@
       "resource": "Edit transaction attempt action settings",
       "description": "Ativar ou desativar ações relacionadas a tentativas de transações na página Prevenção de Fraudes.",
       "key": "EditTransactionAttemptActionSettings",
-      "resourceId": 2134013,
-      "productId": 127
+      "resourceId": "2134013",
+      "productId": "127"
     },
     {
       "product": "Fraud Prevention",
@@ -7921,8 +7921,8 @@
       "resource": "Edit transaction attempt score settings",
       "description": "Modificar configurações de pontuação para tentativas de transações na página Prevenção de Fraudes.",
       "key": "EditTransactionAttemptScoreSettings",
-      "resourceId": 2134014,
-      "productId": 127
+      "resourceId": "2134014",
+      "productId": "127"
     },
     {
       "product": "GiftCard",
@@ -7930,8 +7930,8 @@
       "resource": "Gift card full access",
       "description": "Criar e editar todas as funções relacionadas aos cartões-presentes, seus fornecedores e transações.",
       "key": "GiftCardAdmin",
-      "resourceId": 472959,
-      "productId": 70
+      "resourceId": "472959",
+      "productId": "70"
     },
     {
       "product": "GiftCard",
@@ -7939,8 +7939,8 @@
       "resource": "Gift card viewer",
       "description": "Leitura para todas as funções do cartões-presentes, seus fornecedores e transações.",
       "key": "GiftCardReadOnly",
-      "resourceId": 472961,
-      "productId": 70
+      "resourceId": "472961",
+      "productId": "70"
     },
     {
       "product": "GiftCard",
@@ -7948,8 +7948,8 @@
       "resource": "View Gift Cards",
       "description": "Habilite operações de leitura em cartões-presente e transações.",
       "key": "view_giftcards",
-      "resourceId": 994855,
-      "productId": 70
+      "resourceId": "994855",
+      "productId": "70"
     },
     {
       "product": "GiftCard",
@@ -7957,8 +7957,8 @@
       "resource": "Edit Gift Cards",
       "description": "Ative para ler e gravar cartões-presente e transações.",
       "key": "edit_giftcards",
-      "resourceId": 994919,
-      "productId": 70
+      "resourceId": "994919",
+      "productId": "70"
     },
     {
       "product": "GiftCard",
@@ -7966,8 +7966,8 @@
       "resource": "View Gift Card providers",
       "description": "Leitura de fornecedores de cartões-presente e seus cartões-presente.",
       "key": "view_giftcard_providers",
-      "resourceId": 994983,
-      "productId": 70
+      "resourceId": "994983",
+      "productId": "70"
     },
     {
       "product": "GiftCard",
@@ -7975,8 +7975,8 @@
       "resource": "Edit Gift Card providers",
       "description": "Leitura e edição de fornecedores de cartões-presente e seus cartões-presente.",
       "key": "edit_giftcard_providers",
-      "resourceId": 994991,
-      "productId": 70
+      "resourceId": "994991",
+      "productId": "70"
     },
     {
       "product": "Insights",
@@ -7984,8 +7984,8 @@
       "resource": "Insights Metrics",
       "description": "Permite visualizar de forma irrestrita todas as métricas e dados presentes nos dashboards do Admin VTEX, incluindo as páginas: Performance de Vendas, Home page do Admin, Insights e Audit.",
       "key": "view_metrics",
-      "resourceId": 129814,
-      "productId": 57
+      "resourceId": "129814",
+      "productId": "57"
     },
     {
       "product": "License Manager",
@@ -7993,8 +7993,8 @@
       "resource": "Edit Admin Users",
       "description": "Permite criar, editar e remover usuários administrativos.",
       "key": "EditAdminUsers",
-      "resourceId": 2099310,
-      "productId": 1
+      "resourceId": "2099310",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -8002,8 +8002,8 @@
       "resource": "View Admin Users",
       "description": "Permite visualizar informações de usuários e perfis de acesso.",
       "key": "ViewAdminUsers",
-      "resourceId": 2099311,
-      "productId": 1
+      "resourceId": "2099311",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -8011,8 +8011,8 @@
       "resource": "View API keys",
       "description": "Visualizar, filtrar, buscar, ordenar e exportar chaves de API geradas e terceiras.",
       "key": "ViewApiKeys",
-      "resourceId": 2042457,
-      "productId": 1
+      "resourceId": "2042457",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -8020,8 +8020,8 @@
       "resource": "Edit API keys",
       "description": "Criar, excluir, mudar o status e adicionar ou remover permissões de chaves de API.",
       "key": "EditApiKeys",
-      "resourceId": 2042458,
-      "productId": 1
+      "resourceId": "2042458",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -8029,8 +8029,8 @@
       "resource": "Edit API keys settings",
       "description": "Modificar configurações relacionadas a chaves de API, como a duração de tokens de chaves geradas.",
       "key": "EditApiKeysSettings",
-      "resourceId": 2042466,
-      "productId": 1
+      "resourceId": "2042466",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -8038,8 +8038,8 @@
       "resource": "Renew API Token",
       "description": "Visualizar e renovar tokens de chaves geradas.",
       "key": "RenewApiToken",
-      "resourceId": 2042467,
-      "productId": 1
+      "resourceId": "2042467",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -8047,8 +8047,8 @@
       "resource": "Save account",
       "description": "Salva uma conta (muda os sites, bindings, hosts, etc. endereço de contato).",
       "key": "Save_Account",
-      "resourceId": 1057,
-      "productId": 1
+      "resourceId": "1057",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -8056,8 +8056,8 @@
       "resource": "Get account by identifier",
       "description": "Consulta que retorna conta pelo identificador, que pode ser o id da conta ou a host ou nome da aplicação da conta.",
       "key": "Get_Account_By_Identifier",
-      "resourceId": 1064,
-      "productId": 1
+      "resourceId": "1064",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -8065,8 +8065,8 @@
       "resource": "Save user",
       "description": "Criar usuários, atribuir ou remover perfis de acesso para usuários, editar dados de usuários, criar e alterar chaves de aplicação.",
       "key": "Save_User",
-      "resourceId": 1074,
-      "productId": 1
+      "resourceId": "1074",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -8074,8 +8074,8 @@
       "resource": "Remove user",
       "description": "Revogar acesso de usuários.",
       "key": "Remove_User",
-      "resourceId": 1075,
-      "productId": 1
+      "resourceId": "1075",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -8083,8 +8083,8 @@
       "resource": "Save access profile",
       "description": "Criar ou modificar um perfil de acesso.",
       "key": "Create_Role",
-      "resourceId": 1083,
-      "productId": 1
+      "resourceId": "1083",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -8092,8 +8092,8 @@
       "resource": "Find account resources",
       "description": "Listar todos recursos que uma conta tem acesso.",
       "key": "Get_Resources_By_Account",
-      "resourceId": 1086,
-      "productId": 1
+      "resourceId": "1086",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -8101,8 +8101,8 @@
       "resource": "Get role",
       "description": "Listar os recursos associados a um ID de perfil de acesso e os usuários associados a esse perfil de acesso.",
       "key": "Get_Role",
-      "resourceId": 1088,
-      "productId": 1
+      "resourceId": "1088",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -8110,8 +8110,8 @@
       "resource": "Get paged roles",
       "description": "Listar todos os perfis de acesso de uma conta.",
       "key": "Get_Roles_Paged",
-      "resourceId": 1178,
-      "productId": 1
+      "resourceId": "1178",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -8119,8 +8119,8 @@
       "resource": "Get paged users",
       "description": "Listar todos os usuários administrativos de uma conta.",
       "key": "Get_Users_Paged",
-      "resourceId": 1179,
-      "productId": 1
+      "resourceId": "1179",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -8128,8 +8128,8 @@
       "resource": "Upload account logo",
       "description": "Acesso ao upload da imagem do logotipo da conta.",
       "key": "Upload_Logo",
-      "resourceId": 1183,
-      "productId": 1
+      "resourceId": "1183",
+      "productId": "1"
     },
     {
       "product": "License Manager",
@@ -8137,8 +8137,8 @@
       "resource": "Get account by host",
       "description": "[Interno] Retorna todos os hosts autorizados de uma conta e hosts de contas que ele autorizou",
       "key": "Get_Hosts_By_Account",
-      "resourceId": 1210,
-      "productId": 1
+      "resourceId": "1210",
+      "productId": "1"
     },
     {
       "product": "Live Shopping",
@@ -8146,8 +8146,8 @@
       "resource": "view_live_shopping",
       "description": "Destinado a usuários convidados no aplicativo Live Shopping, como influenciadores, que não necessitam de acesso às informações da conta.",
       "key": "view_live_shopping",
-      "resourceId": 1532000,
-      "productId": 98
+      "resourceId": "1532000",
+      "productId": "98"
     },
     {
       "product": "Logistics",
@@ -8155,8 +8155,8 @@
       "resource": "Logistics full access",
       "description": "Acesso pleno a todos os recursos de logística (visualização, criação, edição e cancelamento de configurações).",
       "key": "LogisticsAdmin",
-      "resourceId": 1158,
-      "productId": 9
+      "resourceId": "1158",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -8164,8 +8164,8 @@
       "resource": "Logistics viewer",
       "description": "Visualização da área inicial do módulo de logistica. ",
       "key": "LogisticsViewer",
-      "resourceId": 1926,
-      "productId": 9
+      "resourceId": "1926",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -8173,8 +8173,8 @@
       "resource": "Logistics inventory full access",
       "description": "Acesso pleno ao inventário logístico (visualização, criação, edição e cancelamento de configurações).",
       "key": "InventoryAdmin",
-      "resourceId": 475811,
-      "productId": 9
+      "resourceId": "475811",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -8182,8 +8182,8 @@
       "resource": "Logistics inventory read only",
       "description": "Visualizar módulo de inventário.",
       "key": "InventoryViewer",
-      "resourceId": 475812,
-      "productId": 9
+      "resourceId": "475812",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -8191,8 +8191,8 @@
       "resource": "Logistics shipping full access",
       "description": "Acesso pleno a todas as funções de envio do módulo de logística (criação, edição e cancelamento de configurações). ",
       "key": "ShippingAdmin",
-      "resourceId": 475813,
-      "productId": 9
+      "resourceId": "475813",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -8200,8 +8200,8 @@
       "resource": "Request Logistics Reports",
       "description": "Solicitar relatórios de logística.",
       "key": "RequestLogisticsReports",
-      "resourceId": 881768,
-      "productId": 9
+      "resourceId": "881768",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -8209,8 +8209,8 @@
       "resource": "Transportation full access",
       "description": "Acesso total ao transporte.",
       "key": "TransportationAdmin",
-      "resourceId": 885164,
-      "productId": 9
+      "resourceId": "885164",
+      "productId": "9"
     },
     {
       "product": "Logistics",
@@ -8218,8 +8218,8 @@
       "resource": "Transportation read only",
       "description": "Visualizar pedidos, pacotes e etiquetas de envio do VTEX Shipping Network.",
       "key": "TransportationViewer",
-      "resourceId": 1881967,
-      "productId": 9
+      "resourceId": "1881967",
+      "productId": "9"
     },
     {
       "product": "Master Data",
@@ -8227,8 +8227,8 @@
       "resource": "List Applications",
       "description": "Listar aplicações.",
       "key": "1_application_list",
-      "resourceId": 52286,
-      "productId": 3
+      "resourceId": "52286",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -8236,8 +8236,8 @@
       "resource": "Create Applications",
       "description": "Criar aplicações.",
       "key": "1_application_create",
-      "resourceId": 52287,
-      "productId": 3
+      "resourceId": "52287",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -8245,8 +8245,8 @@
       "resource": "Edit Applications",
       "description": "Editar aplicações.",
       "key": "1_application_edit",
-      "resourceId": 52288,
-      "productId": 3
+      "resourceId": "52288",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -8254,8 +8254,8 @@
       "resource": "Remove Applications",
       "description": "Excluir aplicações.",
       "key": "1_application_delete",
-      "resourceId": 52289,
-      "productId": 3
+      "resourceId": "52289",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -8263,8 +8263,8 @@
       "resource": "Create custom search",
       "description": "Criar busca customizada.",
       "key": "3_application_searchcreate",
-      "resourceId": 52290,
-      "productId": 3
+      "resourceId": "52290",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -8272,8 +8272,8 @@
       "resource": "Allow data export",
       "description": "Exportação de dados.",
       "key": "3_application_export",
-      "resourceId": 52291,
-      "productId": 3
+      "resourceId": "52291",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -8281,8 +8281,8 @@
       "resource": "View logs",
       "description": "Visualização de logs.",
       "key": "4_application_logview",
-      "resourceId": 52292,
-      "productId": 3
+      "resourceId": "52292",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -8290,8 +8290,8 @@
       "resource": "List Comments",
       "description": "Listar comentários.",
       "key": "1_commentmanager_list",
-      "resourceId": 52293,
-      "productId": 3
+      "resourceId": "52293",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -8299,8 +8299,8 @@
       "resource": "Remove Comment",
       "description": "Excluir comentários.",
       "key": "1_commentmanager_delete",
-      "resourceId": 52294,
-      "productId": 3
+      "resourceId": "52294",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -8308,8 +8308,8 @@
       "resource": "List Custom Search",
       "description": "Listar busca customizada.",
       "key": "1_customsearch_list",
-      "resourceId": 52295,
-      "productId": 3
+      "resourceId": "52295",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -8317,8 +8317,8 @@
       "resource": "Exclude Custom Search",
       "description": "Remover busca customizada.",
       "key": "1_customsearch_delete",
-      "resourceId": 52296,
-      "productId": 3
+      "resourceId": "52296",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -8326,8 +8326,8 @@
       "resource": "List Forms",
       "description": "Listar formulários.",
       "key": "1_form_list",
-      "resourceId": 52297,
-      "productId": 3
+      "resourceId": "52297",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -8335,8 +8335,8 @@
       "resource": "Create Forms",
       "description": "Criar formulários.",
       "key": "1_form_create",
-      "resourceId": 52298,
-      "productId": 3
+      "resourceId": "52298",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -8344,8 +8344,8 @@
       "resource": "Edit Forms",
       "description": "Editar formulários.",
       "key": "1_form_edit",
-      "resourceId": 52299,
-      "productId": 3
+      "resourceId": "52299",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -8353,8 +8353,8 @@
       "resource": "Remove Form",
       "description": "Excluir formulários.",
       "key": "1_form_delete",
-      "resourceId": 52300,
-      "productId": 3
+      "resourceId": "52300",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -8362,8 +8362,8 @@
       "resource": "CRM administrator",
       "description": "Gerenciar informações de CRM.",
       "key": "ADMIN_CRM",
-      "resourceId": 25786,
-      "productId": 3
+      "resourceId": "25786",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -8371,8 +8371,8 @@
       "resource": "Full access to forms",
       "description": "Acesso total a formulários.",
       "key": "POWER_USER_CRM",
-      "resourceId": 52283,
-      "productId": 3
+      "resourceId": "52283",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -8380,8 +8380,8 @@
       "resource": "Access to insert and edit but not to delete",
       "description": "Acesso de leitura e edição, mas não remoção.",
       "key": "NOREMOVE_USER_CRM",
-      "resourceId": 52284,
-      "productId": 3
+      "resourceId": "52284",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -8389,8 +8389,8 @@
       "resource": "Read-only form access",
       "description": "Somente leitura de formulários.",
       "key": "READONLY_USER_CRM",
-      "resourceId": 52285,
-      "productId": 3
+      "resourceId": "52285",
+      "productId": "3"
     },
     {
       "product": "Master Data",
@@ -8398,8 +8398,8 @@
       "resource": "Run import",
       "description": "Rodar importação.",
       "key": "3_import_run",
-      "resourceId": 52306,
-      "productId": 3
+      "resourceId": "52306",
+      "productId": "3"
     },
     {
       "product": "Message Center",
@@ -8407,8 +8407,8 @@
       "resource": "Send Message ",
       "description": "Enviar uma mensagem na Central de Mensagens.",
       "key": "send-message",
-      "resourceId": 1026939,
-      "productId": 23
+      "resourceId": "1026939",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -8416,8 +8416,8 @@
       "resource": "View provider list",
       "description": "Visualização da lista de remetentes da Central de Mensagens. ",
       "key": "provider-listar",
-      "resourceId": 52282,
-      "productId": 23
+      "resourceId": "52282",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -8425,8 +8425,8 @@
       "resource": "Add or edit provider",
       "description": "Criar ou editar remetentes (providers) criados na área de remetentes da Central de Mensagens.",
       "key": "provider-salvar",
-      "resourceId": 52325,
-      "productId": 23
+      "resourceId": "52325",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -8434,8 +8434,8 @@
       "resource": "Remove provider",
       "description": "Remover remetentes criados na área de remetentes da Central de Mensagens (providers).",
       "key": "provider-excluir",
-      "resourceId": 52326,
-      "productId": 23
+      "resourceId": "52326",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -8443,8 +8443,8 @@
       "resource": "View template list",
       "description": "Visualização da lista de templates disponíveis da Central de Mensagens.",
       "key": "template-listar",
-      "resourceId": 1203,
-      "productId": 23
+      "resourceId": "1203",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -8452,8 +8452,8 @@
       "resource": "Add new template",
       "description": "Adicionar novos templates à lista de templates da Central de Mensagens.",
       "key": "template-criar",
-      "resourceId": 1204,
-      "productId": 23
+      "resourceId": "1204",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -8461,8 +8461,8 @@
       "resource": "Remove template",
       "description": "Remover novos templates da lista de templates da Central de Mensagens. ",
       "key": "template-excluir",
-      "resourceId": 1205,
-      "productId": 23
+      "resourceId": "1205",
+      "productId": "23"
     },
     {
       "product": "Message Center",
@@ -8470,8 +8470,8 @@
       "resource": "Edit template",
       "description": "Edição e customização de templates na Central de Mensagens. ",
       "key": "template-editar",
-      "resourceId": 1207,
-      "productId": 23
+      "resourceId": "1207",
+      "productId": "23"
     },
     {
       "product": "OMS",
@@ -8479,8 +8479,8 @@
       "resource": "Change order workflow status",
       "description": "Ações dentro do fluxo de pedidos pra mudança de status de pedido, através do botão de Ações no fluxo.",
       "key": "WorkflowAction",
-      "resourceId": 1150,
-      "productId": 19
+      "resourceId": "1150",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -8488,8 +8488,8 @@
       "resource": "Notify payment",
       "description": "Acesso ao botão que notifica pagamento ao gateway manualmente na área de pagamento dentro do pedido.",
       "key": "PaymentAction",
-      "resourceId": 1151,
-      "productId": 19
+      "resourceId": "1151",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -8497,8 +8497,8 @@
       "resource": "Notify invoice",
       "description": "Permite informar faturas (NF) e dados para rastreio manualmente no OMS. ",
       "key": "ShippingAction",
-      "resourceId": 1152,
-      "productId": 19
+      "resourceId": "1152",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -8506,8 +8506,8 @@
       "resource": "View order",
       "description": "Visualizar todos os pedidos da conta.",
       "key": "OMSViewer",
-      "resourceId": 1153,
-      "productId": 19
+      "resourceId": "1153",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -8515,8 +8515,8 @@
       "resource": "Notify refund",
       "description": "Permite notificar uma nota fiscal (invoice) de entrada.",
       "key": "RefundAction",
-      "resourceId": 1407,
-      "productId": 19
+      "resourceId": "1407",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -8524,8 +8524,8 @@
       "resource": "Cancel order",
       "description": "Permite Cancelar pedido no OMS.",
       "key": "CancelAction",
-      "resourceId": 1408,
-      "productId": 19
+      "resourceId": "1408",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -8533,8 +8533,8 @@
       "resource": "Order feed subscription",
       "description": "Permite que o usuário se inscreva para receber atualizações dos status dos pedidos no Feed de pedidos.",
       "key": "FeedSubscription",
-      "resourceId": 1409,
-      "productId": 19
+      "resourceId": "1409",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -8542,8 +8542,8 @@
       "resource": "Change order",
       "description": "Permite registrar mudanças no pedido (descontos e/ou trocas)",
       "key": "Changes",
-      "resourceId": 1621,
-      "productId": 19
+      "resourceId": "1621",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -8551,8 +8551,8 @@
       "resource": "View store sales stats",
       "description": "Exibe totalizadores dentro da seção Todos os pedidos do Gerenciamento de pedidos. Exibe total de vendas além dos detalhes dos pedidos. ",
       "key": "ShowTotalizers",
-      "resourceId": 98200,
-      "productId": 19
+      "resourceId": "98200",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -8560,8 +8560,8 @@
       "resource": "Only show orders created by the user (via call center)",
       "description": "Os pedidos serão ajustados pelo email cadastrado pelo callcenteroperatoremail.",
       "key": "callCenterOperatorFilter",
-      "resourceId": 428968,
-      "productId": 19
+      "resourceId": "428968",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -8569,8 +8569,8 @@
       "resource": "Feed v3 and Hook Admin",
       "description": "Criar, editar e deletar configurações de Feed v3/hook.",
       "key": "FeedHookV3Admin",
-      "resourceId": 592028,
-      "productId": 19
+      "resourceId": "592028",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -8578,8 +8578,8 @@
       "resource": "Feed v3 and Hook view only",
       "description": "Visualizar os dados de Feed v3/hook.",
       "key": "FeedHookV3Viewer",
-      "resourceId": 592029,
-      "productId": 19
+      "resourceId": "592029",
+      "productId": "19"
     },
     {
       "product": "OMS",
@@ -8587,7 +8587,7 @@
       "resource": "Subscription view only",
       "description": "Visualizar os dados das Assinaturas da loja.",
       "key": "SubscriptionViewer",
-      "resourceId": 592030,
+      "resourceId": "592030",
       "productId": ""
     },
     {
@@ -8596,7 +8596,7 @@
       "resource": "Subscription admin",
       "description": "Ação e visualização do Admin de Assinaturas. Acesso ao botão de tentar novamente.",
       "key": "SubscriptionAdmin",
-      "resourceId": 592031,
+      "resourceId": "592031",
       "productId": ""
     },
     {
@@ -8605,7 +8605,7 @@
       "resource": "Subscription metrics and reports",
       "description": "Acesso à visualização de metricas e relatórios no dashboard de Assinaturas. ",
       "key": "SubscriptionMetrics",
-      "resourceId": 592032,
+      "resourceId": "592032",
       "productId": ""
     },
     {
@@ -8614,7 +8614,7 @@
       "resource": "Subscription view and edit",
       "description": "Permite visualização e edição de assinaturas. ",
       "key": "SubscriptionManager",
-      "resourceId": 592033,
+      "resourceId": "592033",
       "productId": ""
     },
     {
@@ -8623,8 +8623,8 @@
       "resource": "List Orders",
       "description": "Listar todos os pedidos da conta.",
       "key": "ListOrders",
-      "resourceId": 1860145,
-      "productId": 19
+      "resourceId": "1860145",
+      "productId": "19"
     },
     {
       "product": "Order Authorization",
@@ -8632,8 +8632,8 @@
       "resource": "Save Configuration",
       "description": "Visualizar e alterar as configurações de aceite de pedidos com diferença de valor, na seção de autorização de pedidos, dentro do gerenciamento de pedidos.",
       "key": "SaveConfiguration",
-      "resourceId": 600081,
-      "productId": 74
+      "resourceId": "600081",
+      "productId": "74"
     },
     {
       "product": "Order Authorization",
@@ -8641,8 +8641,8 @@
       "resource": "View Configuration",
       "description": "Visualizar as configurações de aceite de pedidos com diferença de valor, na seção de autorização de pedidos, dentro do gerenciamento de pedidos.",
       "key": "ViewConfiguration",
-      "resourceId": 600082,
-      "productId": 74
+      "resourceId": "600082",
+      "productId": "74"
     },
     {
       "product": "PCI Gateway",
@@ -8650,8 +8650,8 @@
       "resource": "BIN Manager Edit Permission",
       "description": "Permite editar a qual banco ou instituição financeira pertence determinado BIN",
       "key": "binManagerEditPermission",
-      "resourceId": 631530,
-      "productId": 6
+      "resourceId": "631530",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -8659,8 +8659,8 @@
       "resource": "Process payments",
       "description": "Representa as operações transacionais do gateway de pagamento.",
       "key": "MakePayments",
-      "resourceId": 1052,
-      "productId": 6
+      "resourceId": "1052",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -8668,8 +8668,8 @@
       "resource": "Manage Infrastructure",
       "description": "Realizar configurações críticas na infraestrutura do Gateway. Disponível somente para administradores.",
       "key": "ManageInfrastructure",
-      "resourceId": 1157,
-      "productId": 6
+      "resourceId": "1157",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -8677,8 +8677,8 @@
       "resource": "Manage Store",
       "description": "Modificar as configurações.",
       "key": "ManageStore",
-      "resourceId": 1097,
-      "productId": 6
+      "resourceId": "1097",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -8686,8 +8686,8 @@
       "resource": "Manage Store Rules",
       "description": "Permissão para gerenciar os meios de pagamento da loja.",
       "key": "ManageStoreRules",
-      "resourceId": 1684986,
-      "productId": 6
+      "resourceId": "1684986",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -8695,8 +8695,8 @@
       "resource": "Manage Store Affiliations",
       "description": "Permissão para gerenciar as afiliações de Gateway da loja.",
       "key": "ManageStoreAffiliations",
-      "resourceId": 1684987,
-      "productId": 6
+      "resourceId": "1684987",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -8704,7 +8704,7 @@
       "resource": "Manage Store AntiFraud",
       "description": "Permissão para gerenciar o anti-fraude dos meios de pagamento da loja.",
       "key": "ManageStoreAntiFraud ",
-      "resourceId": 1684988,
+      "resourceId": "1684988",
       "productId": ""
     },
     {
@@ -8713,8 +8713,8 @@
       "resource": "Notify Payments",
       "description": "Notificação de aprovação de pagamento.",
       "key": "NotifyPayments",
-      "resourceId": 1512,
-      "productId": 6
+      "resourceId": "1512",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -8722,8 +8722,8 @@
       "resource": "Payments Notification",
       "description": "Notificação de aprovação de pagamento, utilizando a Payments Gateway API.",
       "key": "PaymentsNotification",
-      "resourceId": 2061772,
-      "productId": 6
+      "resourceId": "2061772",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -8731,8 +8731,8 @@
       "resource": "View Payment Data",
       "description": "Recuperar uma transação.",
       "key": "ViewPayments",
-      "resourceId": 1096,
-      "productId": 6
+      "resourceId": "1096",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -8740,8 +8740,8 @@
       "resource": "View Payments Sensitive Data",
       "description": "Visualização de informações pessoalmente identificáveis (PII), para lojas que utilizam o ambiente de conformidade de privacidade de dados.",
       "key": "ViewPaymentsSensitiveData",
-      "resourceId": 1515091,
-      "productId": 6
+      "resourceId": "1515091",
+      "productId": "6"
     },
     {
       "product": "PCI Gateway",
@@ -8749,8 +8749,8 @@
       "resource": "BIN Manager View Permission",
       "description": "Permite pesquisar e visualizar a qual banco ou instituição financeira pertence determinado BIN",
       "key": "binManagerViewPermission",
-      "resourceId": 631529,
-      "productId": 6
+      "resourceId": "631529",
+      "productId": "6"
     },
     {
       "product": "Payments",
@@ -8758,8 +8758,8 @@
       "resource": "View Card Tokens",
       "description": "Permite a visualização dos dados de cartões tokenizados",
       "key": "ViewCardTokens",
-      "resourceId": 2078628,
-      "productId": 114
+      "resourceId": "2078628",
+      "productId": "114"
     },
     {
       "product": "Payments",
@@ -8767,8 +8767,8 @@
       "resource": "Edit Card Tokens",
       "description": "Permite a edição dos dados de cartões tokenizados previamente criados no Card Token Vault.",
       "key": "ManageCardTokens",
-      "resourceId": 2078744,
-      "productId": 114
+      "resourceId": "2078744",
+      "productId": "114"
     },
     {
       "product": "Payments",
@@ -8776,8 +8776,8 @@
       "resource": "Create Card Tokens",
       "description": "Permite que cartão tokenizado seja armazenado",
       "key": "CreateCardTokens",
-      "resourceId": 2078845,
-      "productId": 114
+      "resourceId": "2078845",
+      "productId": "114"
     },
     {
       "product": "Payments",
@@ -8785,8 +8785,8 @@
       "resource": "Delete Card Token",
       "description": "Permite deletar cartão tokenizado armazenado previamente",
       "key": "DeleteCardToken",
-      "resourceId": 2078846,
-      "productId": 114
+      "resourceId": "2078846",
+      "productId": "114"
     },
     {
       "product": "Payments",
@@ -8794,8 +8794,8 @@
       "resource": "Import Card Token",
       "description": "Permite iniciar importação de tokens de cartões de crédito",
       "key": "ImportCardToken",
-      "resourceId": 2078847,
-      "productId": 114
+      "resourceId": "2078847",
+      "productId": "114"
     },
     {
       "product": "Payments",
@@ -8803,8 +8803,8 @@
       "resource": "Get Import Card Token Status ",
       "description": "Permite visualizar status da importação de tokens",
       "key": "GetImportCardTokenStatus",
-      "resourceId": 2078848,
-      "productId": 114
+      "resourceId": "2078848",
+      "productId": "114"
     },
     {
       "product": "Payments",
@@ -8812,8 +8812,8 @@
       "resource": "Get Import Card Tokens Report",
       "description": "Baixar relatório de erros que ocorreram na importação",
       "key": "GetImportCardTokensReport",
-      "resourceId": 2078849,
-      "productId": 114
+      "resourceId": "2078849",
+      "productId": "114"
     },
     {
       "product": "PersonalShopper App",
@@ -8821,8 +8821,8 @@
       "resource": "View Analytics",
       "description": "Visualizar Analytics do app Personal Shopper.",
       "key": "view-analytics",
-      "resourceId": 1639728,
-      "productId": 100
+      "resourceId": "1639728",
+      "productId": "100"
     },
     {
       "product": "PersonalShopper App",
@@ -8830,8 +8830,8 @@
       "resource": "View List Call",
       "description": "Visualizar a página de chamadas.",
       "key": "view-list-call",
-      "resourceId": 1639430,
-      "productId": 100
+      "resourceId": "1639430",
+      "productId": "100"
     },
     {
       "product": "PersonalShopper App",
@@ -8839,8 +8839,8 @@
       "resource": "View Setting",
       "description": "Editar configurações do app Personal Shopper.",
       "key": "view-setting",
-      "resourceId": 1643056,
-      "productId": 100
+      "resourceId": "1643056",
+      "productId": "100"
     },
     {
       "product": "Portal",
@@ -8848,8 +8848,8 @@
       "resource": "Manage portal",
       "description": "Criar e editar templates, prateleiras e páginas no CMS (Portal) e editar configurações do Checkout.",
       "key": "AdminPortal",
-      "resourceId": 1299,
-      "productId": 27
+      "resourceId": "1299",
+      "productId": "27"
     },
     {
       "product": "Pricing",
@@ -8857,8 +8857,8 @@
       "resource": "Read prices",
       "description": "Visualizar todos os preços de um SKU.",
       "key": "read_prices",
-      "resourceId": 152730,
-      "productId": 65
+      "resourceId": "152730",
+      "productId": "65"
     },
     {
       "product": "Pricing",
@@ -8866,8 +8866,8 @@
       "resource": "Modify prices",
       "description": "Alterar ou criar um preço para um SKU.",
       "key": "modify_prices",
-      "resourceId": 152731,
-      "productId": 65
+      "resourceId": "152731",
+      "productId": "65"
     },
     {
       "product": "Pricing",
@@ -8875,8 +8875,8 @@
       "resource": "Read trade policy configurations",
       "description": "Visualizar todas as políticas comerciais da conta.",
       "key": "read_tradePolicySettings",
-      "resourceId": 152732,
-      "productId": 65
+      "resourceId": "152732",
+      "productId": "65"
     },
     {
       "product": "Pricing",
@@ -8884,8 +8884,8 @@
       "resource": "Modify trade policy configurations",
       "description": "Deletar todas as políticas comerciais da conta.",
       "key": "modify_tradePolicySettings",
-      "resourceId": 152733,
-      "productId": 65
+      "resourceId": "152733",
+      "productId": "65"
     },
     {
       "product": "Pricing",
@@ -8893,8 +8893,8 @@
       "resource": "Delete all prices from account",
       "description": "Deletar todos os preços da conta.",
       "key": "modify_prices_delete_all",
-      "resourceId": 152736,
-      "productId": 65
+      "resourceId": "152736",
+      "productId": "65"
     },
     {
       "product": "Promotions Policy Engine",
@@ -8902,8 +8902,8 @@
       "resource": "Evaluate Policy",
       "description": "Obter a avaliação da política.",
       "key": "EvaluatePolicy",
-      "resourceId": 1212434,
-      "productId": 89
+      "resourceId": "1212434",
+      "productId": "89"
     },
     {
       "product": "Promotions Policy Engine",
@@ -8911,8 +8911,8 @@
       "resource": "Create or Update Policy",
       "description": "Criar ou atualizar uma política.",
       "key": "CreateOrUpdatePolicy",
-      "resourceId": 1212435,
-      "productId": 89
+      "resourceId": "1212435",
+      "productId": "89"
     },
     {
       "product": "Promotions Policy Engine",
@@ -8920,8 +8920,8 @@
       "resource": "Get Policy",
       "description": "Obter o objeto de política.",
       "key": "GetPolicy",
-      "resourceId": 1212492,
-      "productId": 89
+      "resourceId": "1212492",
+      "productId": "89"
     },
     {
       "product": "Promotions Policy Engine",
@@ -8929,8 +8929,8 @@
       "resource": "Delete Policy",
       "description": "Excluir uma política.",
       "key": "DeletePolicy",
-      "resourceId": 1212493,
-      "productId": 89
+      "resourceId": "1212493",
+      "productId": "89"
     },
     {
       "product": "Promotions Policy Engine",
@@ -8938,8 +8938,8 @@
       "resource": "List Policies",
       "description": "Listar as políticas existentes.",
       "key": "ListPolicies",
-      "resourceId": 1212494,
-      "productId": 89
+      "resourceId": "1212494",
+      "productId": "89"
     },
     {
       "product": "Rates and Benefits",
@@ -8947,8 +8947,8 @@
       "resource": "Manage benefits and rates",
       "description": "Criar, editar ou arquivar promoções, cupons, campanhas e taxas.",
       "key": "GerenciarPromocoesETarifas",
-      "resourceId": 98201,
-      "productId": 16
+      "resourceId": "98201",
+      "productId": "16"
     },
     {
       "product": "Rates and Benefits",
@@ -8956,8 +8956,8 @@
       "resource": "Manage Policies",
       "description": "Habilitar o gerenciamento de políticas comerciais.",
       "key": "GerenciarPolicies",
-      "resourceId": 1118700,
-      "productId": 16
+      "resourceId": "1118700",
+      "productId": "16"
     },
     {
       "product": "Releases",
@@ -8965,8 +8965,8 @@
       "resource": "Edit Release",
       "description": "Criação, agendamento, reprogramação e exclusão de lançamentos.",
       "key": "edit-release",
-      "resourceId": 1257521,
-      "productId": 91
+      "resourceId": "1257521",
+      "productId": "91"
     },
     {
       "product": "Releases",
@@ -8974,8 +8974,8 @@
       "resource": "Visualize Releases",
       "description": "Visualizar a lista de lançamentos e atualizações de cada lançamento",
       "key": "get-release",
-      "resourceId": 1257551,
-      "productId": 91
+      "resourceId": "1257551",
+      "productId": "91"
     },
     {
       "product": "Sales App",
@@ -8983,8 +8983,8 @@
       "resource": "View Sales Performance",
       "description": "Permite que o vendedor visualize a página de desempenho de vendas no VTEX Sales App relacionado um ponto de operação de vendas (loja física)",
       "key": "ViewSalesPerformance",
-      "resourceId": 2126563,
-      "productId": 132
+      "resourceId": "2126563",
+      "productId": "132"
     },
     {
       "product": "Search",
@@ -8992,8 +8992,8 @@
       "resource": "General Settings",
       "description": "Editar configurações gerais do VTEX Intelligent Search.",
       "key": "general-settings",
-      "resourceId": 719379,
-      "productId": 76
+      "resourceId": "719379",
+      "productId": "76"
     },
     {
       "product": "Security Monitor",
@@ -9001,8 +9001,8 @@
       "resource": "View Findings",
       "description": "Obter, listar e visualizar as informações sobre descobertas e tipos de descobertas no Security Monitor.",
       "key": "ViewFindings",
-      "resourceId": 2000228,
-      "productId": 103
+      "resourceId": "2000228",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -9010,8 +9010,8 @@
       "resource": "Edit Findings",
       "description": "Silenciar ou voltar a alertar sobre uma descoberta no Security Monitor.",
       "key": "EditFindings",
-      "resourceId": 2000236,
-      "productId": 103
+      "resourceId": "2000236",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -9019,8 +9019,8 @@
       "resource": "Edit Notification Settings",
       "description": "Editar as configurações de destinatários de notificações sobre alertas de segurança no Security Monitor.",
       "key": "EditNotificationSettings",
-      "resourceId": 2000244,
-      "productId": 103
+      "resourceId": "2000244",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -9028,8 +9028,8 @@
       "resource": "List/Describe reports",
       "description": "Visualizar um relatório ou lista de relatórios no Security Monitor.",
       "key": "read-reports",
-      "resourceId": 1858423,
-      "productId": 103
+      "resourceId": "1858423",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -9037,8 +9037,8 @@
       "resource": "List/Describe Sensors",
       "description": "Visualizar detalhes de sensores no Security Monitor.",
       "key": "read-sensors",
-      "resourceId": 1880664,
-      "productId": 103
+      "resourceId": "1880664",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -9046,8 +9046,8 @@
       "resource": "Read Notifications Settings",
       "description": "Ler configurações de notificações do Security Monitor.",
       "key": "read-notifications-settings",
-      "resourceId": 1980709,
-      "productId": 103
+      "resourceId": "1980709",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -9055,8 +9055,8 @@
       "resource": "Create Reports",
       "description": "Criar novos relatórios no Security Monitor.",
       "key": "write-reports",
-      "resourceId": 1858424,
-      "productId": 103
+      "resourceId": "1858424",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -9064,8 +9064,8 @@
       "resource": "Update Sensors",
       "description": "Habilitar ou desabilitar sensores no Security Monitor.",
       "key": "update-sensors",
-      "resourceId": 1880649,
-      "productId": 103
+      "resourceId": "1880649",
+      "productId": "103"
     },
     {
       "product": "Security Monitor",
@@ -9073,8 +9073,8 @@
       "resource": "Write Notifications Settings",
       "description": "Editar configurações de notificações do Security Monitor.",
       "key": "write-notifications-settings",
-      "resourceId": 1980710,
-      "productId": 103
+      "resourceId": "1980710",
+      "productId": "103"
     },
     {
       "product": "Seller Register",
@@ -9082,8 +9082,8 @@
       "resource": "View Seller",
       "description": "Visualizar todos os sellers vinculados à conta do marketplace descritos na página Gerenciamento de Sellers, incluindo recuperar dados de seller, seja da listagem de sellers, ou um seller específico. ",
       "key": "view-seller",
-      "resourceId": 575457,
-      "productId": 73
+      "resourceId": "575457",
+      "productId": "73"
     },
     {
       "product": "Seller Register",
@@ -9091,8 +9091,8 @@
       "resource": "Save Seller",
       "description": "Criar sellers novos e editar dados de todos os sellers vinculados à conta do marketplace, a partir da página Gerenciamento de Sellers.",
       "key": "save-seller",
-      "resourceId": 575458,
-      "productId": 73
+      "resourceId": "575458",
+      "productId": "73"
     },
     {
       "product": "Subscriptions",
@@ -9100,7 +9100,7 @@
       "resource": "Subscription view only",
       "description": "Visualizar os dados das assinaturas da loja.",
       "key": "SubscriptionViewer",
-      "resourceId": 592030,
+      "resourceId": "592030",
       "productId": ""
     },
     {
@@ -9109,7 +9109,7 @@
       "resource": "Subscription admin",
       "description": "Ação e visualização do Admin de Assinaturas. Acesso ao botão de tentar novamente.",
       "key": "SubscriptionAdmin",
-      "resourceId": 592031,
+      "resourceId": "592031",
       "productId": ""
     },
     {
@@ -9118,7 +9118,7 @@
       "resource": "Subscription view and edit",
       "description": "Visualização e edição de assinaturas. ",
       "key": "SubscriptionManager",
-      "resourceId": 592033,
+      "resourceId": "592033",
       "productId": ""
     },
     {
@@ -9127,7 +9127,7 @@
       "resource": "Subscription metrics and reports",
       "description": "Visualização de metricas e relatórios no dashboard de Assinatura. ",
       "key": "SubscriptionMetrics",
-      "resourceId": 592032,
+      "resourceId": "592032",
       "productId": ""
     },
     {
@@ -9136,8 +9136,8 @@
       "resource": "Main Access",
       "description": "Acesso irrestrito a todos os componentes da página SKUs Recebidos, incluindo visualização dos dados da página, além de ações de aprovação de anúncios. Saiba mais em [Catalogação de SKUs recebidos](https://help.vtex.com/pt/tutorial/sugerindo-e-aprovando-skus/).",
       "key": "suggestions",
-      "resourceId": 109448,
-      "productId": 50
+      "resourceId": "109448",
+      "productId": "50"
     },
     {
       "product": "User Rights",
@@ -9145,7 +9145,7 @@
       "resource": "Read Applications",
       "description": "Visualizar operações em aplicações de direitos de usuários, seja em lista ou detalhadas.",
       "key": "applications_read",
-      "resourceId": 1634515,
+      "resourceId": "1634515",
       "productId": ""
     },
     {
@@ -9154,7 +9154,7 @@
       "resource": "Write Applications",
       "description": "Criar, atualizar ou remover aplicações de direitos de usuários.",
       "key": "applications_write",
-      "resourceId": 1634523,
+      "resourceId": "1634523",
       "productId": ""
     },
     {
@@ -9163,8 +9163,8 @@
       "resource": "Read user rights requests",
       "description": "Visualizar solicitações de direitos de usuários, seja em lista ou detalhadas.",
       "key": "user_rights_request_read",
-      "resourceId": 1634546,
-      "productId": 99
+      "resourceId": "1634546",
+      "productId": "99"
     },
     {
       "product": "User Rights",
@@ -9172,8 +9172,8 @@
       "resource": "Write user rights requests",
       "description": "Criar, atualizar ou remover solicitações de direitos de usuários.",
       "key": "user_rights_request_write",
-      "resourceId": 1634554,
-      "productId": 99
+      "resourceId": "1634554",
+      "productId": "99"
     },
     {
       "product": "User Rights",
@@ -9181,8 +9181,8 @@
       "resource": "Process User Rights Removal Request",
       "description": "Processar solicitações de direitos de usuários do tipo remoção.",
       "key": "removal-request-process",
-      "resourceId": 1705138,
-      "productId": 99
+      "resourceId": "1705138",
+      "productId": "99"
     },
     {
       "product": "VTEX Ad Network",
@@ -9190,8 +9190,8 @@
       "resource": "View Advertiser's details",
       "description": "Visualizar informações do anunciante relativas ao VTEX Ad Network.",
       "key": "view-advertiser-details",
-      "resourceId": 2012197,
-      "productId": 106
+      "resourceId": "2012197",
+      "productId": "106"
     },
     {
       "product": "VTEX Ad Network",
@@ -9199,8 +9199,8 @@
       "resource": "View Advertiser's campaigns",
       "description": "Visualizar informações de campanhas de um anunciante do VTEX Ad Network.",
       "key": "view-advertiser-campaigns",
-      "resourceId": 2012200,
-      "productId": 106
+      "resourceId": "2012200",
+      "productId": "106"
     },
     {
       "product": "VTEX Ad Network",
@@ -9208,8 +9208,8 @@
       "resource": "Edit Advertiser's campaigns",
       "description": "Editar informações de campanhas de um anunciante do VTEX Ad Network.",
       "key": "edit-advertiser-campaigns",
-      "resourceId": 2012201,
-      "productId": 106
+      "resourceId": "2012201",
+      "productId": "106"
     },
     {
       "product": "VTEX Ad Network",
@@ -9217,8 +9217,8 @@
       "resource": "View Publisher's details",
       "description": "Visualizar informações de loja relativas a exibição de anúncios do VTEX Ad Network.",
       "key": "view-publisher-details",
-      "resourceId": 2012196,
-      "productId": 106
+      "resourceId": "2012196",
+      "productId": "106"
     },
     {
       "product": "VTEX Bridge",
@@ -9226,8 +9226,8 @@
       "resource": "List Itens",
       "description": "Visualização dos documentos do Brigde.",
       "key": "listItems",
-      "resourceId": 106704,
-      "productId": 48
+      "resourceId": "106704",
+      "productId": "48"
     },
     {
       "product": "VTEX Bridge",
@@ -9235,8 +9235,8 @@
       "resource": "Execute Actions",
       "description": "Tomar ação sobre algum log. Por exemplo, reprocessar o envio de algum item.",
       "key": "executeActions",
-      "resourceId": 106965,
-      "productId": 48
+      "resourceId": "106965",
+      "productId": "48"
     },
     {
       "product": "VTEX Bridge",
@@ -9244,8 +9244,8 @@
       "resource": "View Configs",
       "description": "Visualização das configurações de cada integração.",
       "key": "viewConfig",
-      "resourceId": 106706,
-      "productId": 48
+      "resourceId": "106706",
+      "productId": "48"
     },
     {
       "product": "VTEX Bridge",
@@ -9253,8 +9253,8 @@
       "resource": "Manage Configs",
       "description": "Editar as configurações de uma integração",
       "key": "editConfig",
-      "resourceId": 106707,
-      "productId": 48
+      "resourceId": "106707",
+      "productId": "48"
     },
     {
       "product": "VTEX IO",
@@ -9262,8 +9262,8 @@
       "resource": "Manage A/B Test",
       "description": "Iniciar, terminar ou obter o status de um Teste A / B.",
       "key": "manage-abtest",
-      "resourceId": 664798,
-      "productId": 66
+      "resourceId": "664798",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -9271,8 +9271,8 @@
       "resource": "Read Workspace Apps",
       "description": "Leitura dos aplicativos instalados no espaço de trabalho e suas dependências.",
       "key": "read-workspace-apps",
-      "resourceId": 253175,
-      "productId": 66
+      "resourceId": "253175",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -9280,8 +9280,8 @@
       "resource": "Link App",
       "description": "Vincular e desvincular aplicativos, além de listar links já existentes em um determinado aplicativo.",
       "key": "link-app",
-      "resourceId": 253206,
-      "productId": 66
+      "resourceId": "253206",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -9289,8 +9289,8 @@
       "resource": "Install App",
       "description": "Instalação e desinstalação de aplicativos sem opções de faturamento.",
       "key": "install-apps",
-      "resourceId": 253207,
-      "productId": 66
+      "resourceId": "253207",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -9298,8 +9298,8 @@
       "resource": "Vbase Read Only",
       "description": "Somente leitura do VBase.",
       "key": "vbase-read-only",
-      "resourceId": 253582,
-      "productId": 66
+      "resourceId": "253582",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -9307,8 +9307,8 @@
       "resource": "Vbase Read Write",
       "description": "Leitura e gravação ao VBase.",
       "key": "vbase-read-write",
-      "resourceId": 253583,
-      "productId": 66
+      "resourceId": "253583",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -9316,8 +9316,8 @@
       "resource": "Read Workspace Services",
       "description": "Leitura de infra aplicativos instalados na área de trabalho.",
       "key": "read-workspace-services",
-      "resourceId": 257862,
-      "productId": 66
+      "resourceId": "257862",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -9325,8 +9325,8 @@
       "resource": "Install Service",
       "description": "Instalação e desinstalação de serviços de infraestrutura.",
       "key": "install-services",
-      "resourceId": 257864,
-      "productId": 66
+      "resourceId": "257864",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -9334,8 +9334,8 @@
       "resource": "Log Access - Read-only",
       "description": "Leitura de registros de todos os aplicativos.",
       "key": "colossus-read-logs",
-      "resourceId": 259184,
-      "productId": 66
+      "resourceId": "259184",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -9343,8 +9343,8 @@
       "resource": "Read Published Service",
       "description": "Leitura dos dados dos serviços do cadastro infra.",
       "key": "read-infra-service",
-      "resourceId": 259251,
-      "productId": 66
+      "resourceId": "259251",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -9352,8 +9352,8 @@
       "resource": "Debug App",
       "description": "Conectar um depurador a um aplicativo vinculado.",
       "key": "debug-app",
-      "resourceId": 377794,
-      "productId": 66
+      "resourceId": "377794",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -9361,8 +9361,8 @@
       "resource": "Workspace CRUD",
       "description": "Criação, exclusão e modificação de espaços de trabalho.",
       "key": "workspace-read-write",
-      "resourceId": 379639,
-      "productId": 66
+      "resourceId": "379639",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -9370,8 +9370,8 @@
       "resource": "Buy App",
       "description": "Instalação e desinstalação de todos os tipos de aplicativos, incluindo aqueles com opções de faturamento.",
       "key": "buy-app",
-      "resourceId": 382623,
-      "productId": 66
+      "resourceId": "382623",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -9379,8 +9379,8 @@
       "resource": "Import Redirects",
       "description": "Gerenciar redirecionamentos com a interface de linha de comando do VTEX IO.",
       "key": "import-redirects",
-      "resourceId": 661667,
-      "productId": 66
+      "resourceId": "661667",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -9388,8 +9388,8 @@
       "resource": "Workspace Manipulation",
       "description": "Criar, modificar e deletar um espaço de trabalho.",
       "key": "workspace-read-write-v2",
-      "resourceId": 794788,
-      "productId": 66
+      "resourceId": "794788",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -9397,8 +9397,8 @@
       "resource": "Workspace Promotion",
       "description": "Promover um espaço de trabalho.",
       "key": "workspace-promote",
-      "resourceId": 794789,
-      "productId": 66
+      "resourceId": "794789",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -9406,8 +9406,8 @@
       "resource": "Read Edition",
       "description": "Leitura da edição de uma conta ou de um espaço de trabalho.",
       "key": "read-edition",
-      "resourceId": 797718,
-      "productId": 66
+      "resourceId": "797718",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -9415,8 +9415,8 @@
       "resource": "Allow APP configuration",
       "description": "Configurar aplicativos.",
       "key": "read-write-apps-settings",
-      "resourceId": 808001,
-      "productId": 66
+      "resourceId": "808001",
+      "productId": "66"
     },
     {
       "product": "VTEX IO",
@@ -9424,8 +9424,8 @@
       "resource": "Change sponsored tenant edition",
       "description": "Definir a edição de um inquilino que é patrocinado pela conta onde esta permissão é concedida.",
       "key": "change-edition-of-sponsored-tenant",
-      "resourceId": 945388,
-      "productId": 66
+      "resourceId": "945388",
+      "productId": "66"
     },
     {
       "product": "VTEX Support",
@@ -9433,8 +9433,8 @@
       "resource": "Open Support Ticket",
       "description": "Abrir ticket de suporte para a VTEX. Válido somente para contas no Brasil.",
       "key": "open-support-ticket",
-      "resourceId": 1945378,
-      "productId": 104
+      "resourceId": "1945378",
+      "productId": "104"
     },
     {
       "product": "VTable",
@@ -9442,8 +9442,8 @@
       "resource": "View apps",
       "description": "Visualização de apps do VTable.",
       "key": "view-apps",
-      "resourceId": 257872,
-      "productId": 67
+      "resourceId": "257872",
+      "productId": "67"
     },
     {
       "product": "VTable",
@@ -9451,8 +9451,8 @@
       "resource": "Main access",
       "description": "Acesso principal do VTable.",
       "key": "main_access_old",
-      "resourceId": 258007,
-      "productId": 67
+      "resourceId": "258007",
+      "productId": "67"
     },
     {
       "product": "Vtex ID",
@@ -9460,8 +9460,8 @@
       "resource": "Write Identity Providers",
       "description": "Criar e atualizar os provedores de identidade (admin e webstore) para uma conta.",
       "key": "write_identity_providers",
-      "resourceId": 631952,
-      "productId": 64
+      "resourceId": "631952",
+      "productId": "64"
     },
     {
       "product": "Vtex ID",
@@ -9469,8 +9469,8 @@
       "resource": "Read Identity Providers",
       "description": "Ler os provedores de identidade (admin e webstore) de uma conta.",
       "key": "read_identity_providers",
-      "resourceId": 631953,
-      "productId": 64
+      "resourceId": "631953",
+      "productId": "64"
     },
     {
       "product": "Vtex ID",
@@ -9478,8 +9478,8 @@
       "resource": "Can Punchout",
       "description": "Permitir chaves de API a autenticar usuários via punchout.",
       "key": "CanPunchout",
-      "resourceId": 2074726,
-      "productId": 64
+      "resourceId": "2074726",
+      "productId": "64"
     },
     {
       "product": "Vtex ID",
@@ -9487,8 +9487,8 @@
       "resource": "Expire User Password",
       "description": "Definir como nula a senha de um dado usuário.",
       "key": "expire_user_password",
-      "resourceId": 1844857,
-      "productId": 64
+      "resourceId": "1844857",
+      "productId": "64"
     },
     {
       "product": "Vtex ID",
@@ -9496,8 +9496,8 @@
       "resource": "Create User",
       "description": "Criar usuário de frente de loja.",
       "key": "CreateUser",
-      "resourceId": 2117393,
-      "productId": 64
+      "resourceId": "2117393",
+      "productId": "64"
     },
     {
       "product": "WebService",
@@ -9505,8 +9505,8 @@
       "resource": "Webservice access",
       "description": "Criar, editar e deletar informações do catálogo por meio do WebService.",
       "key": "orders",
-      "resourceId": 136106,
-      "productId": 61
+      "resourceId": "136106",
+      "productId": "61"
     }
   ]
 }

--- a/docs/en/tutorials/account-management/access-control/license-manager-resources.md
+++ b/docs/en/tutorials/account-management/access-control/license-manager-resources.md
@@ -21,7 +21,18 @@ Therefore, the VTEX platform offers you the possibility to create custom access 
 
 > ❗ Unrestricted use of resources increases the risk of store attacks by leaking login credentials with access to critical resources. If you have questions about the description of a specific feature, please feel free to contact us.
 
-<iframe src="https://vtexhelp.myvtex.com/tables/resources/en" title="License Manager resources" frameBorder="0" width="105%" height="850"></iframe>
+<DataTable
+  src="data-tables/license-manager-resources.json"
+  columns={[
+    { key: 'product', label: 'Product', sortable: true, filterable: true },
+    { key: 'category', label: 'Category', sortable: true, filterable: true },
+    { key: 'resource', label: 'Resource', sortable: true, filterable: true },
+    { key: 'description', label: 'Description' },
+    { key: 'key', label: 'Key', type: 'code', sortable: true, filterable: true },
+    { key: 'resourceId', label: 'Resource ID', type: 'number', sortable: true },
+    { key: 'productId', label: 'Product ID', type: 'number', sortable: true },
+  ]}
+/>
 
 > ℹ️ In the [Audit](/en/docs/tutorials/audit) application, License Manager resources are identified by the corresponding keys.
 
@@ -29,5 +40,15 @@ Therefore, the VTEX platform offers you the possibility to create custom access 
 
 In the License Manager interface, you can also find resources that are deprecated or exclusively for internal use by VTEX. These have no impact on your store. They are:
 
-<iframe src="https://vtexhelp.myvtex.com/tables/internalresources/en" title="Internal or deprecated resources" frameBorder="0" width="100%" height="700"></iframe>
+<DataTable
+  src="data-tables/license-manager-internal-resources.json"
+  columns={[
+    { key: 'product', label: 'Product', sortable: true, filterable: true },
+    { key: 'category', label: 'Category', sortable: true, filterable: true },
+    { key: 'resource', label: 'Resource', sortable: true, filterable: true },
+    { key: 'key', label: 'Key', type: 'code', sortable: true, filterable: true },
+    { key: 'resourceId', label: 'Resource ID', type: 'number', sortable: true },
+    { key: 'productId', label: 'Product ID', type: 'number', sortable: true },
+  ]}
+/>
 

--- a/docs/en/tutorials/account-management/access-control/license-manager-resources.md
+++ b/docs/en/tutorials/account-management/access-control/license-manager-resources.md
@@ -29,8 +29,8 @@ Therefore, the VTEX platform offers you the possibility to create custom access 
     { key: 'resource', label: 'Resource', sortable: true, filterable: true },
     { key: 'description', label: 'Description' },
     { key: 'key', label: 'Key', type: 'code', sortable: true, filterable: true },
-    { key: 'resourceId', label: 'Resource ID', type: 'number', sortable: true },
-    { key: 'productId', label: 'Product ID', type: 'number', sortable: true },
+    { key: 'resourceId', label: 'Resource ID', type: 'text', sortable: true },
+    { key: 'productId', label: 'Product ID', type: 'text', sortable: true },
   ]}
 />
 
@@ -47,8 +47,8 @@ In the License Manager interface, you can also find resources that are deprecate
     { key: 'category', label: 'Category', sortable: true, filterable: true },
     { key: 'resource', label: 'Resource', sortable: true, filterable: true },
     { key: 'key', label: 'Key', type: 'code', sortable: true, filterable: true },
-    { key: 'resourceId', label: 'Resource ID', type: 'number', sortable: true },
-    { key: 'productId', label: 'Product ID', type: 'number', sortable: true },
+    { key: 'resourceId', label: 'Resource ID', type: 'text', sortable: true },
+    { key: 'productId', label: 'Product ID', type: 'text', sortable: true },
   ]}
 />
 

--- a/docs/es/tutorials/gestión-de-la-cuenta/control-de-acceso/recursos-del-license-manager.md
+++ b/docs/es/tutorials/gestión-de-la-cuenta/control-de-acceso/recursos-del-license-manager.md
@@ -29,8 +29,8 @@ Por lo tanto, la plataforma VTEX ofrece la posibilidad de crear roles de usuario
     { key: 'resource', label: 'Recurso', sortable: true, filterable: true },
     { key: 'description', label: 'Descripción' },
     { key: 'key', label: 'Llave', type: 'code', sortable: true, filterable: true },
-    { key: 'resourceId', label: 'ID del Recurso', type: 'number', sortable: true },
-    { key: 'productId', label: 'ID del Producto', type: 'number', sortable: true },
+    { key: 'resourceId', label: 'ID del Recurso', type: 'text', sortable: true },
+    { key: 'productId', label: 'ID del Producto', type: 'text', sortable: true },
   ]}
 />
 
@@ -47,8 +47,8 @@ En la interfaz del License Manager, también encontrarás recursos obsoletos o q
     { key: 'category', label: 'Categoría', sortable: true, filterable: true },
     { key: 'resource', label: 'Recurso', sortable: true, filterable: true },
     { key: 'key', label: 'Llave', type: 'code', sortable: true, filterable: true },
-    { key: 'resourceId', label: 'ID del Recurso', type: 'number', sortable: true },
-    { key: 'productId', label: 'ID del Producto', type: 'number', sortable: true },
+    { key: 'resourceId', label: 'ID del Recurso', type: 'text', sortable: true },
+    { key: 'productId', label: 'ID del Producto', type: 'text', sortable: true },
   ]}
 />
 

--- a/docs/es/tutorials/gestión-de-la-cuenta/control-de-acceso/recursos-del-license-manager.md
+++ b/docs/es/tutorials/gestión-de-la-cuenta/control-de-acceso/recursos-del-license-manager.md
@@ -21,7 +21,18 @@ Por lo tanto, la plataforma VTEX ofrece la posibilidad de crear roles de usuario
 
 > ❗ El uso sin restricciones de los recursos aumenta el riesgo de ataques a las tiendas por la filtración de credenciales de acceso a los recursos críticos. Si tienes alguna duda sobre la descripción de un recurso específico, no dudes en ponerse en contacto con nosotros.
 
-<iframe src="https://vtexhelp.myvtex.com/tables/resources/es" title="Recursos del License Manager" frameBorder="0" width="105%" height="850"></iframe>
+<DataTable
+  src="data-tables/license-manager-resources.json"
+  columns={[
+    { key: 'product', label: 'Producto', sortable: true, filterable: true },
+    { key: 'category', label: 'Categoría', sortable: true, filterable: true },
+    { key: 'resource', label: 'Recurso', sortable: true, filterable: true },
+    { key: 'description', label: 'Descripción' },
+    { key: 'key', label: 'Llave', type: 'code', sortable: true, filterable: true },
+    { key: 'resourceId', label: 'ID del Recurso', type: 'number', sortable: true },
+    { key: 'productId', label: 'ID del Producto', type: 'number', sortable: true },
+  ]}
+/>
 
 > ℹ️ En la aplicación [Audit](/es/docs/tutorials/audit), los recursos de License Manager son identificados por las respectivas claves.
 
@@ -29,5 +40,15 @@ Por lo tanto, la plataforma VTEX ofrece la posibilidad de crear roles de usuario
 
 En la interfaz del License Manager, también encontrarás recursos obsoletos o que son de uso exclusivo interno de VTEX. Estos no tienen ningún impacto en tu tienda. Son:
 
-<iframe src="https://vtexhelp.myvtex.com/tables/internalresources/es" title="Recursos internos o obsoletos" frameBorder="0" width="100%" height="700"></iframe>
+<DataTable
+  src="data-tables/license-manager-internal-resources.json"
+  columns={[
+    { key: 'product', label: 'Producto', sortable: true, filterable: true },
+    { key: 'category', label: 'Categoría', sortable: true, filterable: true },
+    { key: 'resource', label: 'Recurso', sortable: true, filterable: true },
+    { key: 'key', label: 'Llave', type: 'code', sortable: true, filterable: true },
+    { key: 'resourceId', label: 'ID del Recurso', type: 'number', sortable: true },
+    { key: 'productId', label: 'ID del Producto', type: 'number', sortable: true },
+  ]}
+/>
 

--- a/docs/pt/tutorials/gerenciamento-da-conta/controle-de-acesso/recursos-do-license-manager.md
+++ b/docs/pt/tutorials/gerenciamento-da-conta/controle-de-acesso/recursos-do-license-manager.md
@@ -29,8 +29,8 @@ Por isso, a plataforma VTEX oferece a possibilidade de criar perfis de acessos c
     { key: 'resource', label: 'Recurso', sortable: true, filterable: true },
     { key: 'description', label: 'Descrição' },
     { key: 'key', label: 'Chave', type: 'code', sortable: true, filterable: true },
-    { key: 'resourceId', label: 'ID do Recurso', type: 'number', sortable: true },
-    { key: 'productId', label: 'ID do Produto', type: 'number', sortable: true },
+    { key: 'resourceId', label: 'ID do Recurso', type: 'text', sortable: true },
+    { key: 'productId', label: 'ID do Produto', type: 'text', sortable: true },
   ]}
 />
 
@@ -47,8 +47,8 @@ Na interface do License Manager, você também encontra recursos deprecados ou d
     { key: 'category', label: 'Categoria', sortable: true, filterable: true },
     { key: 'resource', label: 'Recurso', sortable: true, filterable: true },
     { key: 'key', label: 'Chave', type: 'code', sortable: true, filterable: true },
-    { key: 'resourceId', label: 'ID do Recurso', type: 'number', sortable: true },
-    { key: 'productId', label: 'ID do Produto', type: 'number', sortable: true },
+    { key: 'resourceId', label: 'ID do Recurso', type: 'text', sortable: true },
+    { key: 'productId', label: 'ID do Produto', type: 'text', sortable: true },
   ]}
 />
 

--- a/docs/pt/tutorials/gerenciamento-da-conta/controle-de-acesso/recursos-do-license-manager.md
+++ b/docs/pt/tutorials/gerenciamento-da-conta/controle-de-acesso/recursos-do-license-manager.md
@@ -21,7 +21,18 @@ Por isso, a plataforma VTEX oferece a possibilidade de criar perfis de acessos c
 
 > ❗ O uso irrestrito de recursos aumenta o risco de ataques às lojas por vazamento de credenciais de login com acesso a recursos críticos. Caso haja dúvidas sobre a descrição de um recurso específico, não hesite em nos contatar.
 
-<iframe src="https://vtexhelp.myvtex.com/tables/resources/pt" title="Recursos do License Manager" frameBorder="0" width="105%" height="850"></iframe>
+<DataTable
+  src="data-tables/license-manager-resources.json"
+  columns={[
+    { key: 'product', label: 'Produto', sortable: true, filterable: true },
+    { key: 'category', label: 'Categoria', sortable: true, filterable: true },
+    { key: 'resource', label: 'Recurso', sortable: true, filterable: true },
+    { key: 'description', label: 'Descrição' },
+    { key: 'key', label: 'Chave', type: 'code', sortable: true, filterable: true },
+    { key: 'resourceId', label: 'ID do Recurso', type: 'number', sortable: true },
+    { key: 'productId', label: 'ID do Produto', type: 'number', sortable: true },
+  ]}
+/>
 
 > ℹ️ No aplicativo [Audit](/pt/docs/tutorials/audit), recursos do License Manager são identificados pelas respectivas chaves.
 
@@ -29,5 +40,15 @@ Por isso, a plataforma VTEX oferece a possibilidade de criar perfis de acessos c
 
 Na interface do License Manager, você também encontra recursos deprecados ou de uso exclusivamente interno da VTEX. Estes não têm impacto para a sua loja. São eles:
 
-<iframe src="https://vtexhelp.myvtex.com/tables/internalresources/pt" title="Recursos internos e deprecados" frameBorder="0" width="100%" height="700"></iframe>
+<DataTable
+  src="data-tables/license-manager-internal-resources.json"
+  columns={[
+    { key: 'product', label: 'Produto', sortable: true, filterable: true },
+    { key: 'category', label: 'Categoria', sortable: true, filterable: true },
+    { key: 'resource', label: 'Recurso', sortable: true, filterable: true },
+    { key: 'key', label: 'Chave', type: 'code', sortable: true, filterable: true },
+    { key: 'resourceId', label: 'ID do Recurso', type: 'number', sortable: true },
+    { key: 'productId', label: 'ID do Produto', type: 'number', sortable: true },
+  ]}
+/>
 

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -46068,21 +46068,6 @@
             },
             {
               "name": {
-                "en": "Error in the maximum quantity field of the same SKU in the Cart",
-                "es": "Error en el campo de cantidad máxima del mismo SKU en el carrito.",
-                "pt": "Erro no campo de quantidade máxima do mesmo SKU no carrinho."
-              },
-              "slug": {
-                "en": "error-in-the-maximum-quantity-field-of-the-same-sku-in-the-cart",
-                "es": "error-en-el-campo-de-cantidad-maxima-del-mismo-sku-en-el-carrito",
-                "pt": "erro-no-campo-de-quantidade-maxima-do-mesmo-sku-no-carrinho"
-              },
-              "origin": "",
-              "type": "markdown",
-              "children": []
-            },
-            {
-              "name": {
                 "en": "Error when changing delivery type when seller has recursion",
                 "es": "Error al cambiar el tipo de entrega cuando el vendedor tiene recursividad",
                 "pt": "Erro ao mudar o tipo de entrega quando o vendedor tem recorrência"
@@ -46324,12 +46309,12 @@
             {
               "name": {
                 "en": "Interacting with the payment component while is still in a loading state sends the wrong payment option",
-                "es": "Si se interactúa con el componente de pago mientras aún se está cargando, se envía una opción de pago incorrecta",
+                "es": "Interactuar con el componente de pago mientras aún se encuentra en estado de carga envía la opción de pago incorrecta.",
                 "pt": "Interagir com o componente de pagamento enquanto ele ainda está em estado de carregamento envia a opção de pagamento incorreta."
               },
               "slug": {
                 "en": "interacting-with-the-payment-component-while-is-still-in-a-loading-state-sends-the-wrong-payment-option",
-                "es": "si-se-interactua-con-el-componente-de-pago-mientras-aun-se-esta-cargando-se-envia-una-opcion-de-pago-incorrecta",
+                "es": "interactuar-con-el-componente-de-pago-mientras-aun-se-encuentra-en-estado-de-carga-envia-la-opcion-de-pago-incorrecta",
                 "pt": "interagir-com-o-componente-de-pagamento-enquanto-ele-ainda-esta-em-estado-de-carregamento-envia-a-opcao-de-pagamento-incorreta"
               },
               "origin": "",
@@ -47246,6 +47231,21 @@
                 "en": "pickups-inherited-between-whitelabel-sellers-are-treated-as-differentindependent-pickups-on-the-purchase-flow",
                 "es": "las-recogidas-heredadas-entre-vendedores-de-marca-blanca-se-tratan-como-recogidas-diferentesindependientes-en-el-flujo-de-compra",
                 "pt": "as-pickups-herdadas-entre-os-vendedores-whitelabel-sao-tratadas-como-pickups-diferentesindependentes-no-fluxo-de-compra"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
+                "en": "Place Order APIs don't respect the maximum quantity of the same SKU in the cart configuration",
+                "es": "Las API para realizar pedidos no respetan la cantidad máxima del mismo SKU en la configuración del carrito.",
+                "pt": "As APIs de \"Finalizar Pedido\" não respeitam a quantidade máxima do mesmo SKU na configuração do carrinho."
+              },
+              "slug": {
+                "en": "place-order-apis-dont-respect-the-maximum-quantity-of-the-same-sku-in-the-cart-configuration",
+                "es": "las-api-para-realizar-pedidos-no-respetan-la-cantidad-maxima-del-mismo-sku-en-la-configuracion-del-carrito",
+                "pt": "as-apis-de-finalizar-pedido-nao-respeitam-a-quantidade-maxima-do-mesmo-sku-na-configuracao-do-carrinho"
               },
               "origin": "",
               "type": "markdown",
@@ -54909,6 +54909,21 @@
               "origin": "",
               "type": "markdown",
               "children": []
+            },
+            {
+              "name": {
+                "en": "Wrong warehouse assigned to item added via ChangeOrderV2 (FFM/SOS ShippingEnricher ignores Logistics’ DeliveryIds)",
+                "es": "Se asignó un almacén incorrecto al artículo agregado mediante ChangeOrderV2 (FFM/SOS ShippingEnricher ignora los DeliveryIds de Logística).",
+                "pt": "Armazém incorreto atribuído ao item adicionado via ChangeOrderV2 (FFM/SOS ShippingEnricher ignora os DeliveryIds da Logística)"
+              },
+              "slug": {
+                "en": "wrong-warehouse-assigned-to-item-added-via-changeorderv2-ffmsos-shippingenricher-ignores-logistics-deliveryids",
+                "es": "se-asigno-un-almacen-incorrecto-al-articulo-agregado-mediante-changeorderv2-ffmsos-shippingenricher-ignora-los-deliveryids-de-logistica",
+                "pt": "armazem-incorreto-atribuido-ao-item-adicionado-via-changeorderv2-ffmsos-shippingenricher-ignora-os-deliveryids-da-logistica"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
             }
           ]
         },
@@ -59871,12 +59886,12 @@
             {
               "name": {
                 "en": "Bin sent does not match an associated Card brand",
-                "es": "La papelera enviada no coincide con una marca de tarjeta asociada",
+                "es": "El BIN enviado no coincide con una marca de tarjeta asociada.",
                 "pt": "O endereço enviado não corresponde a nenhuma bandeira de cartão associada."
               },
               "slug": {
                 "en": "bin-sent-does-not-match-an-associated-card-brand",
-                "es": "la-papelera-enviada-no-coincide-con-una-marca-de-tarjeta-asociada",
+                "es": "el-bin-enviado-no-coincide-con-una-marca-de-tarjeta-asociada",
                 "pt": "o-endereco-enviado-nao-corresponde-a-nenhuma-bandeira-de-cartao-associada"
               },
               "origin": "",
@@ -62616,12 +62631,12 @@
             {
               "name": {
                 "en": "The Cielo 3DS2 app is returning an \"approved\" status even in scenarios when the authentication has failed.",
-                "es": "La aplicación Cielo 3DS2 muestra el estado «aprobado» incluso en casos en los que la autenticación ha fallado.",
+                "es": "La aplicación Cielo 3DS2 devuelve un estado de \"aprobado\" incluso en situaciones en las que la autenticación ha fallado.",
                 "pt": "O aplicativo Cielo 3DS2 está retornando o status \"aprovado\" mesmo em cenários nos quais a autenticação falhou."
               },
               "slug": {
                 "en": "the-cielo-3ds2-app-is-returning-an-approved-status-even-in-scenarios-when-the-authentication-has-failed",
-                "es": "la-aplicacion-cielo-3ds2-muestra-el-estado-aprobado-incluso-en-casos-en-los-que-la-autenticacion-ha-fallado",
+                "es": "la-aplicacion-cielo-3ds2-devuelve-un-estado-de-aprobado-incluso-en-situaciones-en-las-que-la-autenticacion-ha-fallado",
                 "pt": "o-aplicativo-cielo-3ds2-esta-retornando-o-status-aprovado-mesmo-em-cenarios-nos-quais-a-autenticacao-falhou"
               },
               "origin": "",


### PR DESCRIPTION
### Summary

Replaces the legacy jQuery DataTables iframes on the License Manager resources docs (en/es/pt) with the new `DataTable` component, backed by JSON data files added under `data-tables/`.

- `data-tables/license-manager-resources.json` — public resources table (per-locale descriptions)
- `data-tables/license-manager-internal-resources.json` — internal/deprecated resources table

relates to https://github.com/vtexdocs/helpcenter/pull/477

---

### Type of change

* [ ] **New content** — Adds new documentation.
* [x] **Content update** — Improves existing documentation (clarity, structure, examples, accuracy).
* [ ] **Bug fix** — Fixes markdown issues.
* [ ] **Editorial fix** — Spelling, grammar, or minor copy edits that don't change meaning.
* [ ] **Content removal** — Deletes deprecated or obsolete content.

---

### Checklist

* [x] The content follows the VTEX Style Guide.
* [ ] Markdown renders correctly (headings, lists, tables, callouts).
* [x] Links, images, code blocks, and examples are valid.
* [x] Terminology, product names, and API references are consistent.
* [x] Frontmatter (title, description, tags, slug) is correct
* [x] Files follow the expected folder structure and naming conventions.

### Test plan

- [ ] Render the `en`, `es`, and `pt` License Manager resources pages in a preview build and confirm both tables load and sort/filter correctly, replacing the old iframes.