### PR TITLE
update: billing metadata for Spanish and Portuguese tutorials

### DIFF
--- a/docs/es/tutorials/facturacion/facturas/metadata.json
+++ b/docs/es/tutorials/facturacion/facturas/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "invoices",
-  "name": "Títulos",
-  "slug": "titulos-subcategoria",
+  "name": "Facturas",
+  "slug": "facturas-subcategoria",
   "order": 5
 }

--- a/docs/es/tutorials/facturacion/metadata.json
+++ b/docs/es/tutorials/facturacion/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "billing",
-  "name": "Facturas",
-  "slug": "facturas-categoria",
+  "name": "Facturación",
+  "slug": "facturacion-categoria",
   "order": 18
 }

--- a/docs/pt/tutorials/informacoes-de-faturamento/faturas/metadata.json
+++ b/docs/pt/tutorials/informacoes-de-faturamento/faturas/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "invoices",
-  "name": "Títulos",
-  "slug": "títulos-subcategoria",
+  "name": "Faturas",
+  "slug": "faturas-subcategoria",
   "order": 5
 }

--- a/docs/pt/tutorials/informacoes-de-faturamento/metadata.json
+++ b/docs/pt/tutorials/informacoes-de-faturamento/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "billing",
-  "name": "Faturas",
-  "slug": "faturas-categoria",
+  "name": "Informações de faturamento",
+  "slug": "informacoes-de-faturamento-categoria",
   "order": 18
 }

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -18712,13 +18712,13 @@
         {
           "name": {
             "en": "Billing",
-            "es": "Facturas",
-            "pt": "Faturas"
+            "es": "Facturación",
+            "pt": "Informações de faturamento"
           },
           "slug": {
             "en": "billing-category",
-            "es": "facturas-categoria",
-            "pt": "faturas-categoria"
+            "es": "facturacion-categoria",
+            "pt": "informacoes-de-faturamento-categoria"
           },
           "origin": "",
           "type": "category",
@@ -18757,13 +18757,13 @@
             {
               "name": {
                 "en": "Invoices",
-                "es": "Títulos",
-                "pt": "Títulos"
+                "es": "Facturas",
+                "pt": "Faturas"
               },
               "slug": {
                 "en": "invoices-subcategory",
-                "es": "titulos-subcategoria",
-                "pt": "títulos-subcategoria"
+                "es": "facturas-subcategoria",
+                "pt": "faturas-subcategoria"
               },
               "origin": "",
               "type": "category",
@@ -54887,13 +54887,13 @@
             {
               "name": {
                 "en": "Timeout in Analytics Query Can Prevent Inventory Log from Loading",
-                "es": "El tiempo de espera en la consulta de Analytics puede impedir que se cargue el registro de inventario",
-                "pt": "O tempo limite na consulta do Analytics pode impedir o carregamento do registro de inventário"
+                "es": "Un tiempo de espera agotado en una consulta de análisis puede impedir que se cargue el registro de inventario.",
+                "pt": "Um tempo limite excedido na consulta de análise pode impedir o carregamento do log de inventário."
               },
               "slug": {
                 "en": "timeout-in-analytics-query-can-prevent-inventory-log-from-loading",
-                "es": "el-tiempo-de-espera-en-la-consulta-de-analytics-puede-impedir-que-se-cargue-el-registro-de-inventario",
-                "pt": "o-tempo-limite-na-consulta-do-analytics-pode-impedir-o-carregamento-do-registro-de-inventario"
+                "es": "un-tiempo-de-espera-agotado-en-una-consulta-de-analisis-puede-impedir-que-se-cargue-el-registro-de-inventario",
+                "pt": "um-tempo-limite-excedido-na-consulta-de-analise-pode-impedir-o-carregamento-do-log-de-inventario"
               },
               "origin": "",
               "type": "markdown",

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -40099,6 +40099,21 @@
             },
             {
               "name": {
+                "en": "My Quotes Organization and Cost Center Filter doesn't work for users with Access All Quotes and Carts Permission",
+                "es": "Mi filtro de organización y centro de costos de cotizaciones no funciona para los usuarios con permiso de acceso a todas las cotizaciones y carritos.",
+                "pt": "A organização \"Minhas Cotações\" e o filtro de centro de custos não funcionam para usuários com permissão de acesso a todas as cotações e carrinhos."
+              },
+              "slug": {
+                "en": "my-quotes-organization-and-cost-center-filter-doesnt-work-for-users-with-access-all-quotes-and-carts-permission",
+                "es": "mi-filtro-de-organizacion-y-centro-de-costos-de-cotizaciones-no-funciona-para-los-usuarios-con-permiso-de-acceso-a-todas-las-cotizaciones-y-carritos",
+                "pt": "a-organizacao-minhas-cotacoes-e-o-filtro-de-centro-de-custos-nao-funcionam-para-usuarios-com-permissao-de-acesso-a-todas-as-cotacoes-e-carrinhos"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
                 "en": "Non-responsive B2B components cause layout and usability issues on mobile",
                 "es": "Los componentes B2B que no responden causan problemas de diseño y usabilidad en dispositivos móviles.",
                 "pt": "Componentes B2B não responsivos causam problemas de layout e usabilidade em dispositivos móveis"
@@ -69344,6 +69359,21 @@
                 "en": "amazon-order-cancellation-flow",
                 "es": "amazon-proceso-de-cancelacion-de-pedidos",
                 "pt": "amazon-fluxo-de-cancelamento-de-pedidos"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
+                "en": "Category mapping via XLS not reprocessed for accounts with large volume of suggestions",
+                "es": "La asignación de categorías mediante XLS no se reprocesa para cuentas con un gran volumen de sugerencias.",
+                "pt": "O mapeamento de categorias via XLS não é reprocessado para contas com grande volume de sugestões."
+              },
+              "slug": {
+                "en": "category-mapping-via-xls-not-reprocessed-for-accounts-with-large-volume-of-suggestions",
+                "es": "la-asignacion-de-categorias-mediante-xls-no-se-reprocesa-para-cuentas-con-un-gran-volumen-de-sugerencias",
+                "pt": "o-mapeamento-de-categorias-via-xls-nao-e-reprocessado-para-contas-com-grande-volume-de-sugestoes"
               },
               "origin": "",
               "type": "markdown",


### PR DESCRIPTION
### Summary

Updates the billing tutorial metadata.json names and slugs for ES and PT to align with the folder structure and the correct category/subcategory labels (Facturación / Facturas, Informações de faturamento / Faturas) as defined in [PR 920](https://github.com/vtexdocs/help-center-content/pull/920).

---

### Type of change

* [ ] **New content** — Adds new documentation.
* [X] **Content update** — Improves existing documentation (clarity, structure, examples, accuracy).
* [ ] **Bug fix** — Fixes markdown issues.
* [ ] **Editorial fix** — Spelling, grammar, or minor copy edits that don’t change meaning.
* [ ] **Content removal** — Deletes deprecated or obsolete content.

---

### Checklist

* [ ] The content follows the VTEX Style Guide.
* [ ] Markdown renders correctly (headings, lists, tables, callouts).
* [ ] Links, images, code blocks, and examples are valid.
* [ ] Terminology, product names, and API references are consistent.
* [ ] Frontmatter (title, description, tags, slug) is correct
* [ ] Files follow the expected folder structure and naming conventions.

---

### AI review instructions

This repository supports automated AI reviews for Markdown files in the `docs/pt` folder.

To run reviews on this PR, add at least one of the following labels:

* `AI style review`: evaluates tone and adherence to VTEX style guidelines.
* `AI grammar review`: identifies grammar and spelling issues.

Once at least one label is added, the review(s) will run automatically.

After the review is completed, the corresponding label will be removed and the label `AI reviewed` will be added to the PR.

> [!NOTE]
> To rerun a review, remove and add the desired label again.
