### PR TITLE
docs: document categoryCover frontmatter field rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Welcome to the [VTEX Help Center](https://help.vtex.com/) content repository!
       - [Announcements fields](#announcements-fields)
       - [Track fields](#track-fields)
       - [Troubleshooting fields](#troubleshooting-fields)
+      - [Category cover field (tracks and tutorials only)](#category-cover-field-tracks-and-tutorials-only)
     - [Applying filters to an announcement](#applying-filters-to-an-announcement)
       - [Announcements Type filters](#announcements-type-filters)
       - [Announcements Area filters](#announcements-area-filters)
@@ -103,6 +104,25 @@ In addition to the standard fields for all articles, check the specific fields f
 
 - **domainFilters**: Troubleshooting Area filters. These values identify the product or area in which the user is most likely to associate the issue (for example, `Checkout`, `Logistics`, `Master Data`).
 - **symptomFilters**: Troubleshooting Type filters. These values identify the problem type the user is experiencing (for example, `Loading issue`, `Misconfiguration`, `Flow interruption`).
+
+#### Category cover field (tracks and tutorials only)
+
+- **categoryCover**: Marks a folder's own overview article as that category's landing page (`true` or omitted).
+
+This field only has an effect for folders that have subfolders. When one of the direct `.md` files in such a folder is marked `categoryCover: true`, that article becomes the entry point for the whole category: clicking the category in the navigation opens that article directly, instead of just expanding the list of subcategories.
+
+Rules for using `categoryCover`:
+
+- **It only applies to the `tracks` and `tutorials` sections.** It has no effect in `announcements`, `faq`, or `troubleshooting`.
+- **Only one file per folder can be marked as cover.** If more than one file in the same folder has `categoryCover: true`, the navigation generator ignores the flag for that folder and falls back to a regular category, logging a warning.
+- **Set it on the PT file only.** Marking `categoryCover: true` on an EN or ES file still works, but the navigation generator logs a warning asking for it to be moved to the PT version.
+- **The folder needs subfolders for the cover to apply.** If the folder has no subfolders, `categoryCover` has no effect and the article is listed normally.
+
+Example frontmatter for a cover article:
+
+```yaml
+categoryCover: true
+```
 
 ### Applying filters to an announcement
 

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -69575,6 +69575,21 @@
             },
             {
               "name": {
+                "en": "Mercado Livre Order fails to reprocess when shipment is cancelled (ERR_UNAVAILABLE_SLA)",
+                "es": "Mercado Livre El pedido no se puede reprocesar cuando se cancela el envío (ERR_UNAVAILABLE_SLA)",
+                "pt": "Mercado Livre O pedido não pode ser reprocessado quando o envio é cancelado (ERR_UNAVAILABLE_SLA)"
+              },
+              "slug": {
+                "en": "mercado-livre-order-fails-to-reprocess-when-shipment-is-cancelled-errunavailablesla",
+                "es": "mercado-livre-el-pedido-no-se-puede-reprocesar-cuando-se-cancela-el-envio-errunavailablesla",
+                "pt": "mercado-livre-o-pedido-nao-pode-ser-reprocessado-quando-o-envio-e-cancelado-errunavailablesla"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
                 "en": "Netshoes - Main Image not respected",
                 "es": "Netshoes - Imagen principal no respetada",
                 "pt": "Netshoes - Imagem principal não respeitada"


### PR DESCRIPTION
## Summary

Adds a README section documenting the `categoryCover` frontmatter field, following up on [vtexhelp-nav-cli#9](https://github.com/vtexdocs/vtexhelp-nav-cli/pull/9), which fixed a bug where this field was silently failing to apply.

Documents:

- What `categoryCover` does (marks a folder's article as that category's landing page).
- It only applies to the `tracks` and `tutorials` sections.
- Only one file per folder can be marked as cover; more than one falls back to a regular category with a warning.
- It should be set on the PT file only (a warning is logged otherwise).
- It has no effect on folders without subfolders.

## Test plan

- [x] Rendered the README locally to confirm formatting and the new table of contents link