### PR TITLE
update: document keyword generation from product specifications

### DIFF
--- a/docs/pt/tutorials/intelligent-search/configuracao-da-busca.md
+++ b/docs/pt/tutorials/intelligent-search/configuracao-da-busca.md
@@ -33,6 +33,8 @@ As configurações gerais apresentam as opções a seguir, relacionadas a [espec
 
     Por exemplo, se uma camisa não tiver a cor no nome do produto, por padrão, o Intelligent Search não identifica esse atributo em uma pesquisa por "camisa azul", trazendo como resultado camisas de diversas cores. Contudo, se a especificação de cor estiver configurada como pesquisável, a busca consegue trazer camisas azuis nas primeiras posições.
 
+> ℹ️ Além do nome do produto e da marca, é possível configurar especificações para também gerar keyword, o que aumenta a relevância de produtos cujo valor de especificação corresponde à busca, mesmo quando o termo não está no nome do produto. Esse recurso está disponível sob demanda: para habilitá-lo, entre em contato com o [Suporte VTEX](https://supporticket.vtex.com/support). Saiba mais em [Como funciona a relevância dos resultados de busca](https://help.vtex.com/pt/docs/tutorials/intelligent-search-como-funciona-a-relevancia-dos-resultados-de-busca#keyword-a-partir-de-especificações).
+
 ## Configurações de filtros
 
 As configurações de filtros apresentam ajustes relacionados aos filtros exibidos para os clientes da sua loja durante a busca:

--- a/docs/pt/tutorials/intelligent-search/relevância/intelligent-search-como-funciona-a-relevancia-dos-resultados-de-busca.md
+++ b/docs/pt/tutorials/intelligent-search/relevância/intelligent-search-como-funciona-a-relevancia-dos-resultados-de-busca.md
@@ -95,6 +95,14 @@ A keyword é a palavra principal que define o produto. O Intelligent Search a id
 
 O match de keyword do nome do produto e o match de marca são cumulativos: um produto que bate com os dois ao mesmo tempo recebe a maior pontuação possível. Ter apenas um dos dois já garante vantagem sobre produtos sem nenhum match de keyword.
 
+#### Keyword a partir de especificações
+
+Além do nome do produto e da marca, é possível configurar especificações de produto para também gerar keyword. Quando uma especificação é definida para gerar keyword, os valores preenchidos nela passam a contar como keyword do produto, com o mesmo peso do keyword extraído do nome ou da marca.
+
+Essa configuração é especialmente útil em catálogos nos quais informações relevantes para a busca estão registradas em especificações, e não no nome do produto. Por exemplo, isso ocorre quando o nome não descreve o tipo, a função ou outro atributo central do item.
+
+> ℹ️ Este recurso está disponível sob demanda. Para habilitá-lo, entre em contato com o [Suporte VTEX](https://supporticket.vtex.com/support).
+
 ### Regras de merchandising
 
 As [regras de merchandising](https://help.vtex.com/pt/docs/tutorials/regras-de-merchandising) são configurações manuais feitas pelo lojista para ajustar os resultados de busca. Elas têm a maior prioridade no algoritmo e permitem três ações:
@@ -161,3 +169,12 @@ O impacto de cada critério é determinado pelo peso configurado pelo lojista. S
 | Pant Minoxidil 50mg/ml 50ml 3 Frascos (Ache) | Baixa | Keyword do nome é "Pant" e a marca é "Ache": nenhum match de keyword ou marca. |
 
 \* Empate na pontuação de relevância. Ambos têm exatamente um match de keyword. A ordem final entre eles é determinada pelos critérios de relevância configurados (ex: mais vendidos, desconto, data de lançamento).
+
+### Busca: "frost free"
+
+| Produto (nome) | Relevância | Justificativa |
+| :---- | :---- | :---- |
+| Refrigerador Duplex 400L (especificação "Tecnologia de degelo": Frost Free) | Alta | A especificação "Tecnologia de degelo" está configurada para gerar keyword. O valor "Frost Free" corresponde à busca e gera o mesmo bônus de um match de keyword, mesmo o termo não aparecendo no nome do produto. |
+| Geladeira 400L (especificação "Tecnologia de degelo": Cíclico) | Baixa | O nome contém "Geladeira", mas nem o nome nem o valor da especificação correspondem a "frost free": não há match de keyword. |
+
+Nesse exemplo, o termo "frost free" não aparece no nome do primeiro produto, mas está preenchido em uma especificação configurada para gerar keyword. Isso garante alta relevância mesmo quando a informação mais relevante para a busca está na especificação, e não no nome. Esse comportamento é especialmente útil para catálogos em que o nome do produto não descreve todos os seus atributos relevantes.

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -69575,6 +69575,21 @@
             },
             {
               "name": {
+                "en": "Mercado Livre Order fails to reprocess when shipment is cancelled (ERR_UNAVAILABLE_SLA)",
+                "es": "Mercado Livre El pedido no se puede reprocesar cuando se cancela el envío (ERR_UNAVAILABLE_SLA)",
+                "pt": "Mercado Livre O pedido não pode ser reprocessado quando o envio é cancelado (ERR_UNAVAILABLE_SLA)"
+              },
+              "slug": {
+                "en": "mercado-livre-order-fails-to-reprocess-when-shipment-is-cancelled-errunavailablesla",
+                "es": "mercado-livre-el-pedido-no-se-puede-reprocesar-cuando-se-cancela-el-envio-errunavailablesla",
+                "pt": "mercado-livre-o-pedido-nao-pode-ser-reprocessado-quando-o-envio-e-cancelado-errunavailablesla"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
                 "en": "Netshoes - Main Image not respected",
                 "es": "Netshoes - Imagen principal no respetada",
                 "pt": "Netshoes - Imagem principal não respeitada"


### PR DESCRIPTION
[EDU-19175](https://vtex-dev.atlassian.net/browse/EDU-19175)

Documents the new Intelligent Search capability of generating product keywords from specifications (not just name/brand), covering how it affects relevance scoring and how to enable it via VTEX Support. PT only; ES/EN translations to follow via localization.