### PR TITLE
docs: document English language analyzer stemming fix

### DIFF
--- a/docs/pt/tutorials/intelligent-search/comportamento-do-intelligent-search/comportamento-da-busca.md
+++ b/docs/pt/tutorials/intelligent-search/comportamento-do-intelligent-search/comportamento-da-busca.md
@@ -53,6 +53,12 @@ Exemplo: suponha que um cliente queira pesquisar pelo termo `bola`. Seguindo a c
 
 > ℹ️ Espaços em branco não são considerados no *fuzzy*, então `base ball` não será corrigido para `baseball`, por exemplo. Recomendamos o uso de [sinônimos](https://help.vtex.com/pt/docs/tutorials/sinonimos) para esses casos.
 
+### Stemming (raiz das palavras)
+
+O Intelligent Search usa um analisador de idioma para normalizar os termos pesquisados, unificando variações de singular e plural de uma mesma palavra na mesma raiz. Por exemplo, em lojas em inglês, uma busca por `sneaker` também retorna produtos que contêm `sneakers`.
+
+> ℹ️ A VTEX corrigiu inconsistências de stemming no analisador de idioma inglês para termos como `sticks`, `sharpies`, `its`, `bags`, `boards`, `books`, `bowls`, `cards`, `crackers`, `dividers`, `games`, `glue-sticks`, `k-cups`, `knives`, `nuts`, `rolls`, `shelves` e `supplies`, cujas formas no plural não eram mapeadas corretamente para a raiz no singular. Essa correção não é aplicada automaticamente a todas as contas: para solicitá-la em uma loja em inglês, entre em contato com o [Suporte VTEX](https://supporticket.vtex.com/support).
+
 ### Resultado mínimo
 
 A quantidade mínima de resultados exibidos a partir de qualquer busca realizada é 1. Em qualquer busca, se o número mínimo de resultados não for atingido, a [autocorreção](#autocorrecao) é aplicada.

--- a/docs/pt/tutorials/intelligent-search/relevância/intelligent-search-como-funciona-a-relevancia-dos-resultados-de-busca.md
+++ b/docs/pt/tutorials/intelligent-search/relevância/intelligent-search-como-funciona-a-relevancia-dos-resultados-de-busca.md
@@ -36,6 +36,12 @@ O Intelligent Search tenta localizar produtos que correspondam à busca em grupo
 
 > ℹ️ O Intelligent Search escolhe o operador e o nível de fuzzy automaticamente. O lojista não controla esse comportamento. O sistema começa pelo grupo mais restrito (AND sem fuzzy) e avança para grupos mais permissivos apenas se o anterior não retornar resultados. Para mais detalhes, consulte [Comportamento da busca](https://help.vtex.com/pt/docs/tutorials/comportamento-da-busca#autocorrecao).
 
+### Stemming (raiz das palavras)
+
+O Intelligent Search também normaliza variações de singular e plural de uma mesma palavra, unificando-as na mesma raiz antes da correspondência. Por exemplo, em lojas em inglês, uma busca por `sneaker` também encontra produtos com `sneakers`.
+
+> ℹ️ A VTEX corrigiu inconsistências de stemming no analisador de idioma inglês para termos como `sticks`, `sharpies`, `its`, `bags`, `boards`, `books`, `bowls`, `cards`, `crackers`, `dividers`, `games`, `glue-sticks`, `k-cups`, `knives`, `nuts`, `rolls`, `shelves` e `supplies`, cujas formas no plural não eram mapeadas corretamente para a raiz no singular. Essa correção não é aplicada automaticamente a todas as contas: para solicitá-la em uma loja em inglês, entre em contato com o [Suporte VTEX](https://supporticket.vtex.com/support). Saiba mais em [Comportamento da busca](https://help.vtex.com/pt/docs/tutorials/comportamento-da-busca#stemming-raiz-das-palavras).
+
 ### Fluxo de decisão
 
 - Se o Grupo 1 retorna resultados → exibe e para.

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -69575,6 +69575,21 @@
             },
             {
               "name": {
+                "en": "Mercado Livre Order fails to reprocess when shipment is cancelled (ERR_UNAVAILABLE_SLA)",
+                "es": "Mercado Livre El pedido no se puede reprocesar cuando se cancela el envío (ERR_UNAVAILABLE_SLA)",
+                "pt": "Mercado Livre O pedido não pode ser reprocessado quando o envio é cancelado (ERR_UNAVAILABLE_SLA)"
+              },
+              "slug": {
+                "en": "mercado-livre-order-fails-to-reprocess-when-shipment-is-cancelled-errunavailablesla",
+                "es": "mercado-livre-el-pedido-no-se-puede-reprocesar-cuando-se-cancela-el-envio-errunavailablesla",
+                "pt": "mercado-livre-o-pedido-nao-pode-ser-reprocessado-quando-o-envio-e-cancelado-errunavailablesla"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
                 "en": "Netshoes - Main Image not respected",
                 "es": "Netshoes - Imagen principal no respetada",
                 "pt": "Netshoes - Imagem principal não respeitada"


### PR DESCRIPTION
[EDU-19204](https://vtex-dev.atlassian.net/browse/EDU-19204)

Adds a "Stemming (raiz das palavras)" section to the pt Intelligent Search behavior and relevance docs, documenting the English language analyzer fix for plural-to-singular stemming and noting it's applied on request via VTEX Support.