### PR TITLE
EDU-19174: Request Capture to Activity Flow migration announcement

### DIFF
--- a/docs/en/announcements/2026/april/metadata.json
+++ b/docs/en/announcements/2026/april/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-april",
   "name": "April",
   "slug": "2026-april",
-  "order": 4
+  "order": 5
 }

--- a/docs/en/announcements/2026/august/2026-08-05-request-capture-to-activity-flow-migration-navigation-metrics.md
+++ b/docs/en/announcements/2026/august/2026-08-05-request-capture-to-activity-flow-migration-navigation-metrics.md
@@ -1,0 +1,21 @@
+---
+title: 'Request Capture to Activity Flow migration: what changes in navigation metrics'
+slug: '2026-08-05-request-capture-to-activity-flow-migration-navigation-metrics'
+hidden: false
+createdAt: 2026-08-05T12:00:00.000Z
+updatedAt: 2026-08-05T12:00:00.000Z
+contentType: updates
+productTeam: Activity Flow
+slugEN: 2026-08-05-request-capture-to-activity-flow-migration-navigation-metrics
+locale: en
+announcementSynopsisEN: ''
+tags:
+  - Breaking change
+  - Activity Flow
+  - Admin
+  - Master Data
+  - Data Pipelines
+  - Storefront
+---
+
+> ⚠️ Content in translation.

--- a/docs/en/announcements/2026/august/metadata.json
+++ b/docs/en/announcements/2026/august/metadata.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-august",
+  "name": "August",
+  "slug": "2026-august",
+  "order": 1
+}

--- a/docs/en/announcements/2026/february/metadata.json
+++ b/docs/en/announcements/2026/february/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-february",
   "name": "February",
   "slug": "2026-february",
-  "order": 6
+  "order": 7
 }

--- a/docs/en/announcements/2026/january/metadata.json
+++ b/docs/en/announcements/2026/january/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-january",
   "name": "January",
   "slug": "2026-january",
-  "order": 7
+  "order": 8
 }

--- a/docs/en/announcements/2026/july/metadata.json
+++ b/docs/en/announcements/2026/july/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-july",
   "name": "July",
   "slug": "2026-july",
-  "order": 1
+  "order": 2
 }

--- a/docs/en/announcements/2026/june/metadata.json
+++ b/docs/en/announcements/2026/june/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-june",
   "name": "June",
   "slug": "2026-june",
-  "order": 2
+  "order": 3
 }

--- a/docs/en/announcements/2026/march/metadata.json
+++ b/docs/en/announcements/2026/march/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-march",
   "name": "March",
   "slug": "2026-march",
-  "order": 5
+  "order": 6
 }

--- a/docs/en/announcements/2026/may/metadata.json
+++ b/docs/en/announcements/2026/may/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-may",
   "name": "May",
   "slug": "2026-may",
-  "order": 3
+  "order": 4
 }

--- a/docs/es/announcements/2026/abril/metadata.json
+++ b/docs/es/announcements/2026/abril/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-abril",
   "name": "Abril",
   "slug": "2026-abril",
-  "order": 4
+  "order": 5
 }

--- a/docs/es/announcements/2026/agosto/2026-08-05-migracion-de-request-capture-a-activity-flow-que-cambia-en-las-metricas-de-navegacion.md
+++ b/docs/es/announcements/2026/agosto/2026-08-05-migracion-de-request-capture-a-activity-flow-que-cambia-en-las-metricas-de-navegacion.md
@@ -1,0 +1,21 @@
+---
+title: 'Migración de Request Capture a Activity Flow: qué cambia en las métricas de navegación'
+slug: '2026-08-05-migracion-de-request-capture-a-activity-flow-que-cambia-en-las-metricas-de-navegacion'
+hidden: false
+createdAt: 2026-08-05T12:00:00.000Z
+updatedAt: 2026-08-05T12:00:00.000Z
+contentType: updates
+productTeam: Activity Flow
+slugEN: 2026-08-05-request-capture-to-activity-flow-migration-navigation-metrics
+locale: es
+announcementSynopsisES: ''
+tags:
+  - Breaking change
+  - Activity Flow
+  - Admin
+  - Master Data
+  - Data Pipelines
+  - Storefront
+---
+
+> ⚠️ Contenido en traducción.

--- a/docs/es/announcements/2026/agosto/metadata.json
+++ b/docs/es/announcements/2026/agosto/metadata.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-agosto",
+  "name": "Agosto",
+  "slug": "2026-agosto",
+  "order": 1
+}

--- a/docs/es/announcements/2026/enero/metadata.json
+++ b/docs/es/announcements/2026/enero/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-january",
   "name": "Enero",
   "slug": "2026-enero",
-  "order": 7
+  "order": 8
 }

--- a/docs/es/announcements/2026/febrero/metadata.json
+++ b/docs/es/announcements/2026/febrero/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-february",
   "name": "Febrero",
   "slug": "2026-febrero",
-  "order": 6
+  "order": 7
 }

--- a/docs/es/announcements/2026/julio/metadata.json
+++ b/docs/es/announcements/2026/julio/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-julio",
   "name": "Julio",
   "slug": "2026-julio",
-  "order": 1
+  "order": 2
 }

--- a/docs/es/announcements/2026/junio/metadata.json
+++ b/docs/es/announcements/2026/junio/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-junio",
   "name": "Junio",
   "slug": "2026-junio",
-  "order": 2
+  "order": 3
 }

--- a/docs/es/announcements/2026/marzo/metadata.json
+++ b/docs/es/announcements/2026/marzo/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-march",
   "name": "Marzo",
   "slug": "2026-marzo",
-  "order": 5
+  "order": 6
 }

--- a/docs/es/announcements/2026/mayo/metadata.json
+++ b/docs/es/announcements/2026/mayo/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-mayo",
   "name": "Mayo",
   "slug": "2026-mayo",
-  "order": 3
+  "order": 4
 }

--- a/docs/pt/announcements/2026/abril/metadata.json
+++ b/docs/pt/announcements/2026/abril/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-abril",
   "name": "Abril",
   "slug": "2026-abril",
-  "order": 4
+  "order": 5
 }

--- a/docs/pt/announcements/2026/agosto/2026-08-05-migracao-de-request-capture-para-activity-flow-o-que-muda-nas-metricas-de-navegacao.md
+++ b/docs/pt/announcements/2026/agosto/2026-08-05-migracao-de-request-capture-para-activity-flow-o-que-muda-nas-metricas-de-navegacao.md
@@ -1,0 +1,68 @@
+---
+title: 'Migração de Request Capture para Activity Flow: o que muda nas métricas de navegação'
+slug: '2026-08-05-migracao-de-request-capture-para-activity-flow-o-que-muda-nas-metricas-de-navegacao'
+hidden: false
+createdAt: 2026-08-05T12:00:00.000Z
+updatedAt: 2026-08-05T12:00:00.000Z
+contentType: updates
+productTeam: Activity Flow
+slugEN: 2026-08-05-request-capture-to-activity-flow-migration-navigation-metrics
+locale: pt
+announcementSynopsisPT: 'A VTEX substitui o pixel Request Capture pelo Activity Flow para medir navegação com mais precisão, cobertura e estabilidade, sem alterar o tráfego real da loja.'
+tags:
+  - Breaking change
+  - Activity Flow
+  - Admin
+  - Master Data
+  - Data Pipelines
+  - Storefront
+---
+
+A VTEX está substituindo o pixel legado **Request Capture** pelo **Activity Flow** como fonte de medição de eventos de navegação na plataforma. Com essa mudança, você passa a contar com medição de navegação mais precisa, cobertura mais ampla de eventos, maior estabilidade e melhor desempenho de carregamento da loja, já que o pixel Request Capture deixa de ser carregado no storefront.
+
+## Por que mudamos?
+
+O Activity Flow fecha gaps conhecidos de coleta do Request Capture, usando uma instalação mais enxuta e reduzindo perdas quando a configuração da loja está incompleta.
+
+A confiabilidade dos dados do Activity Flow é monitorada de forma contínua, com checks constantes de consistência e qualidade.
+
+## O que mudou?
+
+### Dados de navegação
+
+Todos os eventos de navegação antes medidos pelo Request Capture passarão a ser medidos pelo Activity Flow. O Activity Flow pode expor tipos de evento adicionais, mas não remove eventos existentes, substituindo 100% dos dados do Request Capture.
+
+### Impacto nas métricas
+
+O Activity Flow mede cerca de **20% mais sessões e page views** do que o Request Capture, com base em comparações dos últimos dois anos. Esse aumento reflete uma medição mais completa, **não** um crescimento real de tráfego na sua loja.
+
+Indicadores derivados de sessão, como sessões por hora ou por dia e taxa de conversão, tendem a acompanhar essa diferença.
+
+### Produtos afetados
+
+**Carrinho abandonado (Master Data)**: a heurística que identifica carrinhos abandonados usa sinais de navegação, visualização de produto e carrinho coletados pelo Request Capture. As regras de negócio para decidir quando enviar notificações permanecem as mesmas. Saiba mais em [Configurar carrinho abandonado](/pt/docs/tutorials/checkout/configurações-do-checkout/configurar-carrinho-abandonado).
+
+**Teste A/B**: a comparação entre workspaces passará a usar sessões e pedidos medidos pelo Activity Flow à medida que a migração avança. Comparações de conversão podem variar em relação ao período anterior. Veja [Teste A/B: como, onde, quando e por quê](/pt/docs/tutorials/storefront/cms-portal-legado/layout/teste-ab-como-onde-quando-e-porque).
+
+**VTEX Data Pipelines**: as tabelas de navegação replicadas para o data warehouse do cliente estão em transição do esquema do Request Capture para o esquema do Activity Flow. Clientes que consomem dados de navegação passarão a receber dados novos gerados pelo Activity Flow. Saiba mais em [Navegação (Data Pipeline Beta)](/pt/docs/tutorials/beta/vtex-data-pipeline-beta/navegacao-data-pipeline-beta).
+
+### Campos renomeados
+
+Alguns campos usados em integrações downstream podem ser renomeados, como `RC_last_cart`, usado em retargeting no Checkout. <!-- TODO: mapa de/para de campos renomeados, incluindo RC_last_cart? -->.
+
+### Retenção de dados históricos
+
+<!-- TODO: qual a política de retenção dos dados históricos do Request Capture após o sunset? -->.
+
+## O que precisa ser feito?
+
+Para integrações que consomem campos de navegação do Request Capture ou tabelas de Data Pipelines, não é esperado que campos desapareçam nem que integrações quebrem. Confira o mapa de/para para saber se ajustes de nomenclatura serão necessários.
+
+Em caso de dúvidas, entre em contato com o [Suporte VTEX](https://help.vtex.com/pt/support).
+
+## Saiba mais
+
+* [Configurar carrinho abandonado](/pt/docs/tutorials/checkout/configurações-do-checkout/configurar-carrinho-abandonado)
+* [Navegação (Data Pipeline Beta)](/pt/docs/tutorials/beta/vtex-data-pipeline-beta/navegacao-data-pipeline-beta)
+* [Teste A/B: como, onde, quando e por quê](/pt/docs/tutorials/storefront/cms-portal-legado/layout/teste-ab-como-onde-quando-e-porque)
+* [Visão geral da loja](/pt/docs/tutorials/dashboards/visao-geral-da-loja)

--- a/docs/pt/announcements/2026/agosto/metadata.json
+++ b/docs/pt/announcements/2026/agosto/metadata.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-agosto",
+  "name": "Agosto",
+  "slug": "2026-agosto",
+  "order": 1
+}

--- a/docs/pt/announcements/2026/fevereiro/metadata.json
+++ b/docs/pt/announcements/2026/fevereiro/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-february",
   "name": "Fevereiro",
   "slug": "2026-fevereiro",
-  "order": 6
+  "order": 7
 }

--- a/docs/pt/announcements/2026/janeiro/metadata.json
+++ b/docs/pt/announcements/2026/janeiro/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-january",
   "name": "Janeiro",
   "slug": "2026-janeiro",
-  "order": 7
+  "order": 8
 }

--- a/docs/pt/announcements/2026/julho/metadata.json
+++ b/docs/pt/announcements/2026/julho/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-julho",
   "name": "Julho",
   "slug": "2026-julho",
-  "order": 1
+  "order": 2
 }

--- a/docs/pt/announcements/2026/junho/metadata.json
+++ b/docs/pt/announcements/2026/junho/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-junho",
   "name": "Junho",
   "slug": "2026-junho",
-  "order": 2
+  "order": 3
 }

--- a/docs/pt/announcements/2026/maio/metadata.json
+++ b/docs/pt/announcements/2026/maio/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-maio",
   "name": "Maio",
   "slug": "2026-maio",
-  "order": 3
+  "order": 4
 }

--- a/docs/pt/announcements/2026/março/metadata.json
+++ b/docs/pt/announcements/2026/março/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-march",
   "name": "Março",
   "slug": "2026-março",
-  "order": 5
+  "order": 6
 }

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -25,6 +25,37 @@
           "children": [
             {
               "name": {
+                "en": "August",
+                "es": "Agosto",
+                "pt": "Agosto"
+              },
+              "slug": {
+                "en": "2026-august",
+                "es": "2026-agosto",
+                "pt": "2026-agosto"
+              },
+              "origin": "",
+              "type": "category",
+              "children": [
+                {
+                  "name": {
+                    "en": "Request Capture to Activity Flow migration: what changes in navigation metrics",
+                    "es": "Migración de Request Capture a Activity Flow: qué cambia en las métricas de navegación",
+                    "pt": "Migração de Request Capture para Activity Flow: o que muda nas métricas de navegação"
+                  },
+                  "slug": {
+                    "en": "2026-08-05-request-capture-to-activity-flow-migration-navigation-metrics",
+                    "es": "2026-08-05-migracion-de-request-capture-a-activity-flow-que-cambia-en-las-metricas-de-navegacion",
+                    "pt": "2026-08-05-migracao-de-request-capture-para-activity-flow-o-que-muda-nas-metricas-de-navegacao"
+                  },
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                }
+              ]
+            },
+            {
+              "name": {
                 "en": "July",
                 "es": "Julio",
                 "pt": "Julho"


### PR DESCRIPTION

Adds the August 2026 Help Center announcement about the Request Capture to Activity Flow migration and its impact on navigation metrics, abandoned cart, A/B testing, and Data Pipelines.

### Metadata (order updates for August 2026)
- Updated `metadata.json` order values for January–July 2026 in EN, ES, and PT.

## Related Task

[EDU-19174](https://vtex-dev.atlassian.net/browse/EDU-19174)