### PR TITLE
docs: document synonym conflict detection

### DIFF
--- a/docs/en/tutorials/intelligent-search/synonyms/creating-synonyms.md
+++ b/docs/en/tutorials/intelligent-search/synonyms/creating-synonyms.md
@@ -3,7 +3,7 @@ title: 'Creating synonyms'
 id: 5IfjhvjxNAvJGEWNn0AhOA
 status: PUBLISHED
 createdAt: 2024-06-27T16:36:30.904Z
-updatedAt: 2025-10-15T13:46:16.968Z
+updatedAt: 2026-08-05T00:00:00.000Z
 publishedAt: 2025-10-15T13:46:16.968Z
 firstPublishedAt: 2024-06-27T16:37:25.800Z
 contentType: tutorial

--- a/docs/es/tutorials/intelligent-search/sinónimos/crear-sinonimos.md
+++ b/docs/es/tutorials/intelligent-search/sinónimos/crear-sinonimos.md
@@ -3,7 +3,7 @@ title: 'Crear sinónimos'
 id: 5IfjhvjxNAvJGEWNn0AhOA
 status: PUBLISHED
 createdAt: 2024-06-27T16:36:30.904Z
-updatedAt: 2025-10-15T13:46:16.968Z
+updatedAt: 2026-08-05T00:00:00.000Z
 publishedAt: 2025-10-15T13:46:16.968Z
 firstPublishedAt: 2024-06-27T16:37:25.800Z
 contentType: tutorial

--- a/docs/pt/tutorials/intelligent-search/sinônimos/criar-sinonimos.md
+++ b/docs/pt/tutorials/intelligent-search/sinônimos/criar-sinonimos.md
@@ -43,7 +43,7 @@ A alteração pode demorar até duas horas para ser aplicada.
 
 ### Detecção de sinônimos conflitantes
 
-Ao preencher o campo **Termos** na etapa anterior, o VTEX Intelligent Search verifica se os termos informados já são cobertos por outra regra de sinônimo existente na loja. Essa verificação considera toda a base de sinônimos cadastrada, o que ajuda a evitar duplicidade e conflitos de relevância, especialmente em lojas com uma grande quantidade de sinônimos configurados.
+Ao preencher o campo **Termos** na etapa anterior, o Intelligent Search verifica se os termos informados já são cobertos por outra regra de sinônimo existente na loja. Essa verificação ajuda a evitar duplicidade e conflitos de relevância, especialmente em lojas com uma grande quantidade de sinônimos configurados.
 
 Se um termo já estiver coberto por outro sinônimo, um aviso é exibido no formulário informando quantos sinônimos compartilham os mesmos termos. Clique em `Ver regras conflitantes` para abrir, em outra aba, a página de **Sinônimos conflitantes**, que lista as regras sobrepostas com as seguintes informações:
 

--- a/docs/pt/tutorials/intelligent-search/sinônimos/criar-sinonimos.md
+++ b/docs/pt/tutorials/intelligent-search/sinônimos/criar-sinonimos.md
@@ -3,7 +3,7 @@ title: 'Criar sinônimos'
 id: 5IfjhvjxNAvJGEWNn0AhOA
 status: PUBLISHED
 createdAt: 2024-06-27T16:36:30.904Z
-updatedAt: 2025-10-15T13:46:16.968Z
+updatedAt: 2026-08-05T00:00:00.000Z
 publishedAt: 2025-10-15T13:46:16.968Z
 firstPublishedAt: 2024-06-27T16:37:25.800Z
 contentType: tutorial
@@ -40,6 +40,24 @@ Siga o passo a passo para configurar sinônimos individualmente no Admin VTEX:
 A alteração pode demorar até duas horas para ser aplicada.
 
 > ℹ️ Essa funcionalidade está disponível no VTEX Intelligent Search Multi-idioma. Leia o nosso artigo [VTEX Intelligent Search: configurações Multi-idioma (Beta)](/pt/docs/tutorials/vtex-intelligent-search-configuracoes-multi-idioma-beta#sinonimos) para saber mais.
+
+### Detecção de sinônimos conflitantes
+
+Ao preencher o campo **Termos** na etapa anterior, o VTEX Intelligent Search verifica se os termos informados já são cobertos por outra regra de sinônimo existente na loja. Essa verificação considera toda a base de sinônimos cadastrada, o que ajuda a evitar duplicidade e conflitos de relevância, especialmente em lojas com uma grande quantidade de sinônimos configurados.
+
+Se um termo já estiver coberto por outro sinônimo, um aviso é exibido no formulário informando quantos sinônimos compartilham os mesmos termos. Clique em `Ver regras conflitantes` para abrir, em outra aba, a página de **Sinônimos conflitantes**, que lista as regras sobrepostas com as seguintes informações:
+
+| Coluna | Descrição |
+|---|---|
+| Termos | Termos definidos no sinônimo conflitante. |
+| Criada em | Data de criação do sinônimo conflitante. |
+| Status | Situação do sinônimo conflitante, que pode ser Ativa ou Inativa. |
+
+A partir dessa página, você pode revisar cada sinônimo conflitante individualmente e [editá-lo](https://help.vtex.com/pt/docs/tutorials/lista-de-sinonimos#editar-sinonimo) ou [excluí-lo](https://help.vtex.com/pt/docs/tutorials/lista-de-sinonimos#deletar-sinonimo), conforme necessário.
+
+Ao clicar em `Salvar`, se houver um conflito, uma janela de confirmação é exibida solicitando que você confirme o cadastro ou a edição mesmo com a sobreposição identificada.
+
+> ℹ️ A detecção de conflitos não impede o cadastro do sinônimo. Ela apenas alerta sobre sobreposições existentes na base, permitindo que você decida se deseja ajustar as regras cadastradas.
 
 ## Importar CSV
 

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -60278,6 +60278,21 @@
             },
             {
               "name": {
+                "en": "Cash (1x) transactions may be recorded under a payment rule that does not offer the 1x installment option",
+                "es": "Las transacciones en efectivo (1x) pueden registrarse bajo una regla de pago que no ofrece la opción de pago a plazos 1x.",
+                "pt": "Transações em dinheiro (1x) podem ser registradas sob uma regra de pagamento que não oferece a opção de parcelamento em 1x."
+              },
+              "slug": {
+                "en": "cash-1x-transactions-may-be-recorded-under-a-payment-rule-that-does-not-offer-the-1x-installment-option",
+                "es": "las-transacciones-en-efectivo-1x-pueden-registrarse-bajo-una-regla-de-pago-que-no-ofrece-la-opcion-de-pago-a-plazos-1x",
+                "pt": "transacoes-em-dinheiro-1x-podem-ser-registradas-sob-uma-regra-de-pagamento-que-nao-oferece-a-opcao-de-parcelamento-em-1x"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
                 "en": "Catalog access profile gives access to the Gift Card module",
                 "es": "El perfil de acceso al catálogo da acceso al módulo de la tarjeta regalo",
                 "pt": "Perfil de acesso ao catálogo dá acesso ao módulo Gift Card"
@@ -61051,21 +61066,6 @@
                 "en": "for-debt-with-cielov3-we-are-not-respecting-the-status-of-the-response",
                 "es": "para-deudas-con-cielov3-no-estamos-respetando-el-estado-de-la-respuesta",
                 "pt": "para-dividas-com-a-cielov3-nao-estamos-respeitando-o-status-da-resposta"
-              },
-              "origin": "",
-              "type": "markdown",
-              "children": []
-            },
-            {
-              "name": {
-                "en": "For in cash payment (1 installment) is being processed by payment conditions that have not 1 installment option",
-                "es": "Para el pago en efectivo (1 plazo) está siendo procesado por las condiciones de pago que no tienen la opción de 1 plazo",
-                "pt": "Pois em pagamento à vista (1 parcela) está sendo processado por condições de pagamento que não têm opção de 1 parcela"
-              },
-              "slug": {
-                "en": "for-in-cash-payment-1-installment-is-being-processed-by-payment-conditions-that-have-not-1-installment-option",
-                "es": "para-el-pago-en-efectivo-1-plazo-esta-siendo-procesado-por-las-condiciones-de-pago-que-no-tienen-la-opcion-de-1-plazo",
-                "pt": "pois-em-pagamento-a-vista-1-parcela-esta-sendo-processado-por-condicoes-de-pagamento-que-nao-tem-opcao-de-1-parcela"
               },
               "origin": "",
               "type": "markdown",
@@ -62191,6 +62191,21 @@
                 "en": "outdated-mastercard-debit-regex-is-causing-us-to-misidentify-some-bins",
                 "es": "una-expresion-regular-obsoleta-para-tarjetas-de-debito-mastercard-nos-esta-llevando-a-identificar-erroneamente-algunos-bin",
                 "pt": "uma-expressao-regular-desatualizada-para-cartoes-de-debito-mastercard-esta-fazendo-com-que-identifiquemos-erroneamente-alguns-bins"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
+                "es": "Para el pago en efectivo (1 plazo) está siendo procesado por las condiciones de pago que no tienen la opción de 1 plazo",
+                "pt": "Pois em pagamento à vista (1 parcela) está sendo processado por condições de pagamento que não têm opção de 1 parcela",
+                "en": "Para el pago en efectivo (1 plazo) está siendo procesado por las condiciones de pago que no tienen la opción de 1 plazo"
+              },
+              "slug": {
+                "es": "para-el-pago-en-efectivo-1-plazo-esta-siendo-procesado-por-las-condiciones-de-pago-que-no-tienen-la-opcion-de-1-plazo",
+                "pt": "pois-em-pagamento-a-vista-1-parcela-esta-sendo-processado-por-condicoes-de-pagamento-que-nao-tem-opcao-de-1-parcela",
+                "en": ""
               },
               "origin": "",
               "type": "markdown",


### PR DESCRIPTION
[EDU-19155](https://vtex-dev.atlassian.net/browse/EDU-19155)

Documents the new synonym conflict detection feature (Search & Recommendation, GA) in the "Criar sinônimos" article: the inline warning shown while filling in the Terms field, the Sinônimos conflitantes page it links to (opens in a new tab), and the save confirmation pop-up.

### Summary

Adds a new section to `docs/pt/tutorials/intelligent-search/sinônimos/criar-sinonimos.md` covering synonym conflict detection. Bumps `updatedAt` on the EN and ES counterparts (`creating-synonyms.md`, `crear-sinonimos.md`) to flag them for localization.

### Type of change

* [x] **Content update** — Improves existing documentation (clarity, structure, examples, accuracy).

### Checklist

* [x] The content follows the VTEX Style Guide.
* [x] Markdown renders correctly (headings, lists, tables, callouts).
* [x] Links, images, code blocks, and examples are valid.
* [x] Terminology, product names, and API references are consistent.
* [x] Frontmatter (title, description, tags, slug) is correct
* [x] Files follow the expected folder structure and naming conventions.