### PR TITLE
new: add Intelligent Search improvements announcement

### DIFF
--- a/docs/en/announcements/2026/august/2026-08-15-intelligent-search-filters-keywords-and-special-characters-improvements.md
+++ b/docs/en/announcements/2026/august/2026-08-15-intelligent-search-filters-keywords-and-special-characters-improvements.md
@@ -1,0 +1,17 @@
+---
+title: 'Intelligent Search: filters, keywords, and special character improvements'
+slug: '2026-08-15-intelligent-search-filters-keywords-and-special-characters-improvements'
+hidden: false
+createdAt: 2026-08-15T00:00:00.000Z
+updatedAt: 2026-08-15T00:00:00.000Z
+contentType: updates
+productTeam: Intelligent Search
+slugEN: 2026-08-15-intelligent-search-filters-keywords-and-special-characters-improvements
+locale: en
+announcementSynopsisEN: 'Content pending translation.'
+tags:
+  - Improvement
+  - Intelligent Search
+---
+
+_Content pending translation._

--- a/docs/en/announcements/2026/august/metadata.json
+++ b/docs/en/announcements/2026/august/metadata.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-august",
+  "name": "August",
+  "slug": "2026-august",
+  "order": 1
+}

--- a/docs/es/announcements/2026/agosto/2026-08-15-intelligent-search-mejoras-en-filtros-keywords-y-caracteres-especiales.md
+++ b/docs/es/announcements/2026/agosto/2026-08-15-intelligent-search-mejoras-en-filtros-keywords-y-caracteres-especiales.md
@@ -1,0 +1,17 @@
+---
+title: 'Intelligent Search: mejoras en filtros, keywords y caracteres especiales'
+slug: '2026-08-15-intelligent-search-mejoras-en-filtros-keywords-y-caracteres-especiales'
+hidden: false
+createdAt: 2026-08-15T00:00:00.000Z
+updatedAt: 2026-08-15T00:00:00.000Z
+contentType: updates
+productTeam: Intelligent Search
+slugEN: 2026-08-15-intelligent-search-filters-keywords-and-special-characters-improvements
+locale: es
+announcementSynopsisES: 'Contenido pendiente de traducción.'
+tags:
+  - Improvement
+  - Intelligent Search
+---
+
+_Contenido pendiente de traducción._

--- a/docs/es/announcements/2026/agosto/metadata.json
+++ b/docs/es/announcements/2026/agosto/metadata.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-agosto",
+  "name": "Agosto",
+  "slug": "2026-agosto",
+  "order": 1
+}

--- a/docs/pt/announcements/2026/abril/metadata.json
+++ b/docs/pt/announcements/2026/abril/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-abril",
   "name": "Abril",
   "slug": "2026-abril",
-  "order": 4
+  "order": 5
 }

--- a/docs/pt/announcements/2026/agosto/2026-08-15-intelligent-search-melhorias-em-filtros-keywords-e-caracteres-especiais.md
+++ b/docs/pt/announcements/2026/agosto/2026-08-15-intelligent-search-melhorias-em-filtros-keywords-e-caracteres-especiais.md
@@ -1,0 +1,64 @@
+---
+title: 'Intelligent Search: melhorias em filtros, keywords e caracteres especiais'
+createdAt: 2026-08-15T00:00:00.000Z
+updatedAt: 2026-08-15T00:00:00.000Z
+contentType: updates
+productTeam: Intelligent Search
+slugEN: 2026-08-15-intelligent-search-filters-keywords-and-special-characters-improvements
+locale: pt
+announcementSynopsisPT: 'O Intelligent Search recebeu melhorias na visibilidade de filtros, na geração de keywords e no tratamento de caracteres especiais, além da correção de um bug no analisador de idioma inglês.'
+tags:
+  - Melhoria
+  - Intelligent Search
+---
+
+O [Intelligent Search](/pt/docs/tracks/visao-geral-intelligent-search) recebeu um conjunto de melhorias que aumentam a relevância e a precisão dos resultados de busca, além da correção de um bug no analisador de idioma inglês. Essas melhorias não são aplicadas automaticamente. Para habilitar qualquer uma delas na sua conta, entre em contato com o [Suporte VTEX](https://supporticket.vtex.com/support).
+
+## O que mudou?
+
+### Cobertura mínima de resultados para filtros
+
+Agora é possível ocultar filtros que afetam apenas uma pequena parte dos resultados de busca. Catálogos grandes frequentemente contêm filtros criados a partir de especificações compartilhadas por poucos produtos, o que polui o painel de filtros com opções de baixa cobertura.
+
+Com a cobertura mínima ativada, filtros em que nenhuma opção atinge o percentual mínimo definido sobre o total de resultados da busca são ocultados automaticamente. É possível excluir filtros específicos dessa regra para que sejam sempre exibidos, independentemente da configuração.
+
+Considere uma busca por "camisa" que retorna 1.000 produtos, com cobertura mínima definida em 5%:
+
+* O filtro **Cor** cobre 1.000 produtos (100%) e é exibido.
+* O filtro **Tamanho** cobre 600 produtos (60%) e é exibido.
+* O filtro **Tecido** cobre apenas 30 produtos (3%) e é ocultado automaticamente, pois nenhuma de suas opções atinge o percentual mínimo.
+
+Saiba mais em [Configuração da busca](https://help.vtex.com/pt/docs/tutorials/configuracao-da-busca).
+
+### Geração de keyword a partir de qualquer especificação de produto
+
+Além do nome do produto e da marca, agora é possível configurar especificações de produto para também gerar keyword. Quando uma especificação é definida para esse fim, os valores preenchidos nela passam a contar como keyword do produto, com o mesmo peso do keyword extraído do nome ou da marca.
+
+Essa melhoria é especialmente útil em catálogos nos quais informações relevantes para a busca estão registradas em especificações, e não no nome do produto, por exemplo, quando o nome não descreve o tipo, a função ou outro atributo central do item.
+
+Considere uma busca por "frost free":
+
+* **Refrigerador Duplex 400L** (especificação "Tecnologia de degelo": Frost Free, configurada para gerar keyword) tem alta relevância, pois o valor da especificação corresponde à busca e gera o mesmo bônus de um match de keyword, mesmo o termo não aparecendo no nome do produto.
+* **Geladeira 400L** (especificação "Tecnologia de degelo": Cíclico) tem baixa relevância, pois nem o nome nem o valor da especificação correspondem a "frost free".
+
+Saiba mais em [Como funciona a relevância dos resultados de busca](https://help.vtex.com/pt/docs/tutorials/intelligent-search-como-funciona-a-relevancia-dos-resultados-de-busca#keyword-a-partir-de-especificações).
+
+### Tratamento de caracteres especiais
+
+O processamento de símbolos como `®`, `@` e `&` na busca foi aprimorado. Ao habilitar esse recurso, esses caracteres passam a ser neutralizados na indexação, permitindo que produtos com símbolos no nome sejam encontrados mesmo quando o cliente os omite na busca.
+
+Por exemplo, o produto `Brand® Papel Sulfite Multifuncional & Copiadora` passa a ser encontrado pela busca `brand papel sulfite`.
+
+Saiba mais em [Comportamento da busca](https://help.vtex.com/pt/docs/tutorials/comportamento-da-busca).
+
+### Correção de bug: stemming do analisador de idioma inglês
+
+O Intelligent Search usa um analisador de idioma para normalizar os termos pesquisados, unificando variações de singular e plural de uma mesma palavra na mesma raiz. Por exemplo, em lojas em inglês, uma busca por `sneaker` também retorna produtos que contêm `sneakers`.
+
+Corrigimos inconsistências de stemming (raiz das palavras) no analisador de idioma inglês para termos como `sticks`, `sharpies`, `its`, `bags`, `boards`, `books`, `bowls`, `cards`, `crackers`, `dividers`, `games`, `glue-sticks`, `k-cups`, `knives`, `nuts`, `rolls`, `shelves` e `supplies`, cujas formas no plural não eram mapeadas corretamente para a raiz no singular. Essa correção está disponível apenas para contas que operam em inglês.
+
+Saiba mais em [Comportamento da busca](https://help.vtex.com/pt/docs/tutorials/comportamento-da-busca#stemming-raiz-das-palavras) e em [Como funciona a relevância dos resultados de busca](https://help.vtex.com/pt/docs/tutorials/intelligent-search-como-funciona-a-relevancia-dos-resultados-de-busca).
+
+## O que precisa ser feito?
+
+Nenhuma das melhorias listadas é aplicada automaticamente. Para habilitar qualquer uma delas na sua conta, entre em contato com o [Suporte VTEX](https://supporticket.vtex.com/support) informando qual melhoria deseja ativar. A correção de stemming está disponível apenas para contas que operam em inglês.

--- a/docs/pt/announcements/2026/agosto/metadata.json
+++ b/docs/pt/announcements/2026/agosto/metadata.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-agosto",
+  "name": "Agosto",
+  "slug": "2026-agosto",
+  "order": 1
+}

--- a/docs/pt/announcements/2026/fevereiro/metadata.json
+++ b/docs/pt/announcements/2026/fevereiro/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-february",
   "name": "Fevereiro",
   "slug": "2026-fevereiro",
-  "order": 6
+  "order": 7
 }

--- a/docs/pt/announcements/2026/janeiro/metadata.json
+++ b/docs/pt/announcements/2026/janeiro/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-january",
   "name": "Janeiro",
   "slug": "2026-janeiro",
-  "order": 7
+  "order": 8
 }

--- a/docs/pt/announcements/2026/julho/metadata.json
+++ b/docs/pt/announcements/2026/julho/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-julho",
   "name": "Julho",
   "slug": "2026-julho",
-  "order": 1
+  "order": 2
 }

--- a/docs/pt/announcements/2026/junho/metadata.json
+++ b/docs/pt/announcements/2026/junho/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-junho",
   "name": "Junho",
   "slug": "2026-junho",
-  "order": 2
+  "order": 3
 }

--- a/docs/pt/announcements/2026/maio/metadata.json
+++ b/docs/pt/announcements/2026/maio/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-maio",
   "name": "Maio",
   "slug": "2026-maio",
-  "order": 3
+  "order": 4
 }

--- a/docs/pt/announcements/2026/março/metadata.json
+++ b/docs/pt/announcements/2026/março/metadata.json
@@ -2,5 +2,5 @@
   "id": "2026-march",
   "name": "Março",
   "slug": "2026-março",
-  "order": 5
+  "order": 6
 }

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -25,6 +25,37 @@
           "children": [
             {
               "name": {
+                "en": "August",
+                "es": "Agosto",
+                "pt": "Agosto"
+              },
+              "slug": {
+                "en": "2026-august",
+                "es": "2026-agosto",
+                "pt": "2026-agosto"
+              },
+              "origin": "",
+              "type": "category",
+              "children": [
+                {
+                  "name": {
+                    "en": "Intelligent Search: filters, keywords, and special character improvements",
+                    "es": "Intelligent Search: mejoras en filtros, keywords y caracteres especiales",
+                    "pt": "Intelligent Search: melhorias em filtros, keywords e caracteres especiais"
+                  },
+                  "slug": {
+                    "en": "2026-08-15-intelligent-search-filters-keywords-and-special-characters-improvements",
+                    "es": "2026-08-15-intelligent-search-mejoras-en-filtros-keywords-y-caracteres-especiales",
+                    "pt": "2026-08-15-intelligent-search-melhorias-em-filtros-keywords-e-caracteres-especiais"
+                  },
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                }
+              ]
+            },
+            {
+              "name": {
                 "en": "July",
                 "es": "Julio",
                 "pt": "Julho"
@@ -137,37 +168,6 @@
                     "en": "2026-07-01-new-roas-calculation-methodology-for-sponsored-products",
                     "es": "2026-07-01-nueva-metodologia-calculo-roas-productos-patrocinados",
                     "pt": "2026-07-01-nova-metodologia-calculo-roas-produtos-patrocinados"
-                  },
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "name": {
-                "en": "Agosto",
-                "es": "Agosto",
-                "pt": "Agosto"
-              },
-              "slug": {
-                "en": "agosto",
-                "es": "agosto",
-                "pt": "2026-agosto"
-              },
-              "origin": "",
-              "type": "category",
-              "children": [
-                {
-                  "name": {
-                    "pt": "Intelligent Search: melhorias em filtros, keywords e caracteres especiais",
-                    "en": "Intelligent Search: melhorias em filtros, keywords e caracteres especiais",
-                    "es": "Intelligent Search: melhorias em filtros, keywords e caracteres especiais"
-                  },
-                  "slug": {
-                    "pt": "2026-08-15-intelligent-search-melhorias-em-filtros-keywords-e-caracteres-especiais",
-                    "en": "",
-                    "es": ""
                   },
                   "origin": "",
                   "type": "markdown",

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -146,6 +146,37 @@
             },
             {
               "name": {
+                "en": "Agosto",
+                "es": "Agosto",
+                "pt": "Agosto"
+              },
+              "slug": {
+                "en": "agosto",
+                "es": "agosto",
+                "pt": "2026-agosto"
+              },
+              "origin": "",
+              "type": "category",
+              "children": [
+                {
+                  "name": {
+                    "pt": "Intelligent Search: melhorias em filtros, keywords e caracteres especiais",
+                    "en": "Intelligent Search: melhorias em filtros, keywords e caracteres especiais",
+                    "es": "Intelligent Search: melhorias em filtros, keywords e caracteres especiais"
+                  },
+                  "slug": {
+                    "pt": "2026-08-15-intelligent-search-melhorias-em-filtros-keywords-e-caracteres-especiais",
+                    "en": "",
+                    "es": ""
+                  },
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                }
+              ]
+            },
+            {
+              "name": {
                 "en": "June",
                 "es": "Junio",
                 "pt": "Junho"
@@ -60278,6 +60309,21 @@
             },
             {
               "name": {
+                "en": "Cash (1x) transactions may be recorded under a payment rule that does not offer the 1x installment option",
+                "es": "Las transacciones en efectivo (1x) pueden registrarse bajo una regla de pago que no ofrece la opción de pago a plazos 1x.",
+                "pt": "Transações em dinheiro (1x) podem ser registradas sob uma regra de pagamento que não oferece a opção de parcelamento em 1x."
+              },
+              "slug": {
+                "en": "cash-1x-transactions-may-be-recorded-under-a-payment-rule-that-does-not-offer-the-1x-installment-option",
+                "es": "las-transacciones-en-efectivo-1x-pueden-registrarse-bajo-una-regla-de-pago-que-no-ofrece-la-opcion-de-pago-a-plazos-1x",
+                "pt": "transacoes-em-dinheiro-1x-podem-ser-registradas-sob-uma-regra-de-pagamento-que-nao-oferece-a-opcao-de-parcelamento-em-1x"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
                 "en": "Catalog access profile gives access to the Gift Card module",
                 "es": "El perfil de acceso al catálogo da acceso al módulo de la tarjeta regalo",
                 "pt": "Perfil de acesso ao catálogo dá acesso ao módulo Gift Card"
@@ -61051,21 +61097,6 @@
                 "en": "for-debt-with-cielov3-we-are-not-respecting-the-status-of-the-response",
                 "es": "para-deudas-con-cielov3-no-estamos-respetando-el-estado-de-la-respuesta",
                 "pt": "para-dividas-com-a-cielov3-nao-estamos-respeitando-o-status-da-resposta"
-              },
-              "origin": "",
-              "type": "markdown",
-              "children": []
-            },
-            {
-              "name": {
-                "en": "For in cash payment (1 installment) is being processed by payment conditions that have not 1 installment option",
-                "es": "Para el pago en efectivo (1 plazo) está siendo procesado por las condiciones de pago que no tienen la opción de 1 plazo",
-                "pt": "Pois em pagamento à vista (1 parcela) está sendo processado por condições de pagamento que não têm opção de 1 parcela"
-              },
-              "slug": {
-                "en": "for-in-cash-payment-1-installment-is-being-processed-by-payment-conditions-that-have-not-1-installment-option",
-                "es": "para-el-pago-en-efectivo-1-plazo-esta-siendo-procesado-por-las-condiciones-de-pago-que-no-tienen-la-opcion-de-1-plazo",
-                "pt": "pois-em-pagamento-a-vista-1-parcela-esta-sendo-processado-por-condicoes-de-pagamento-que-nao-tem-opcao-de-1-parcela"
               },
               "origin": "",
               "type": "markdown",
@@ -62191,6 +62222,21 @@
                 "en": "outdated-mastercard-debit-regex-is-causing-us-to-misidentify-some-bins",
                 "es": "una-expresion-regular-obsoleta-para-tarjetas-de-debito-mastercard-nos-esta-llevando-a-identificar-erroneamente-algunos-bin",
                 "pt": "uma-expressao-regular-desatualizada-para-cartoes-de-debito-mastercard-esta-fazendo-com-que-identifiquemos-erroneamente-alguns-bins"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
+                "es": "Para el pago en efectivo (1 plazo) está siendo procesado por las condiciones de pago que no tienen la opción de 1 plazo",
+                "pt": "Pois em pagamento à vista (1 parcela) está sendo processado por condições de pagamento que não têm opção de 1 parcela",
+                "en": "Para el pago en efectivo (1 plazo) está siendo procesado por las condiciones de pago que no tienen la opción de 1 plazo"
+              },
+              "slug": {
+                "es": "para-el-pago-en-efectivo-1-plazo-esta-siendo-procesado-por-las-condiciones-de-pago-que-no-tienen-la-opcion-de-1-plazo",
+                "pt": "pois-em-pagamento-a-vista-1-parcela-esta-sendo-processado-por-condicoes-de-pagamento-que-nao-tem-opcao-de-1-parcela",
+                "en": ""
               },
               "origin": "",
               "type": "markdown",


### PR DESCRIPTION
[EDU-19205](https://vtex-dev.atlassian.net/browse/EDU-19205)

Adds the PT announcement for four Intelligent Search improvements (filter visibility by result coverage, keyword generation from product specifications, special character handling, and the English stemming bug fix), and bumps the `order` field on the other 2026 month folders since `agosto` is now the most recent.