### PR TITLE
EDU-19085: Add Master Data billing callout and troubleshooting article

### DIFF
--- a/docs/en/troubleshooting/data-access-and-security/master-data-billing-did-not-decrease-after-deleting-a-data-entity.md
+++ b/docs/en/troubleshooting/data-access-and-security/master-data-billing-did-not-decrease-after-deleting-a-data-entity.md
@@ -1,0 +1,17 @@
+---
+title: 'Master Data billing did not decrease after deleting a data entity'
+createdAt: '2026-08-07T00:00:00.000Z'
+updatedAt: '2026-08-07T00:00:00.000Z'
+contentType: tutorial
+productTeam: Master Data
+slugEN: master-data-billing-did-not-decrease-after-deleting-a-data-entity
+locale: en
+subcategoryId: 2Q0IQjRcOqSgJTh6wRHVMB
+domainFilters:
+  - Master Data
+  - Admin
+symptomFilters:
+  - Stuck status or flow
+---
+
+> ⚠️ Content in translation.

--- a/docs/en/tutorials/master-data/master-data-basics/data-entity.md
+++ b/docs/en/tutorials/master-data/master-data-basics/data-entity.md
@@ -27,7 +27,7 @@ With these concepts in mind, you can set up several data control scenarios in Ma
 
 > ⚠️ This article outlines the Master Data v1 operation. You should evaluate which Master Data version meets your needs or is in use in your operation. Learn more: <ul> <li>[Master Data version features](/en/docs/tutorials/master-data#available-versions)</li> <li>[Master Data v2](https://developers.vtex.com/docs/guides/master-data-v2-basics)</li> </ul>
 
-> ⚠️ Deleting a data entity through the Master Data v1 interface does not remove the documents (records) already stored. The billed volume remains unchanged until the records are removed via the API. To delete documents and reduce billing, see the [Deleting documents in Master Data v1](https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1) guide on the Developers Portal.
+> ⚠️ Deleting a data entity through the Master Data v1 interface does not remove the documents (records) already stored. The billed volume remains unchanged until the records are removed via the API. To delete documents and reduce billing, see the [Deleting documents in Master Data v1](https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1) guide on the Developers Portal. See the [step-by-step guide to fix](/docs/tutorials/master-data-billing-did-not-decrease-after-deleting-a-data-entity) this issue.
 
 ## Data types
 

--- a/docs/en/tutorials/master-data/master-data-basics/master-data.md
+++ b/docs/en/tutorials/master-data/master-data-basics/master-data.md
@@ -295,6 +295,8 @@ Measurement and billing follow a monthly cycle:
 - At the end of each month, a snapshot of the number of documents stored in custom entities is generated.
 - By the 30th of each month, VTEX calculates the amounts related to Master Data usage and the applicable credits for the next invoice.
 
+> ⚠️ Deleting a data entity through the Master Data v1 interface does not remove the documents (records) already stored. The billed volume remains unchanged until the records are removed via the API. To delete documents and reduce billing, see the [Deleting documents in Master Data v1](https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1) guide on the Developers Portal.
+
 > ℹ️ To track the number of documents in custom entities throughout the month, check the **Master Data usage** dashboard in the VTEX Admin. This dashboard is updated weekly and is intended only for usage tracking. To learn how to access it, see [Checking Master Data usage in the VTEX Admin](/docs/tutorials/checking-master-data-usage-in-the-vtex-admin).
 
 > ℹ️ To view billing details, learn how to [download VTEX invoices](/docs/tutorials/how-to-download-the-vtex-invoices).

--- a/docs/es/troubleshooting/acceso-a-datos-y-seguridad/la-facturacion-de-master-data-no-disminuyo-despues-de-eliminar-una-entidad-de-datos.md
+++ b/docs/es/troubleshooting/acceso-a-datos-y-seguridad/la-facturacion-de-master-data-no-disminuyo-despues-de-eliminar-una-entidad-de-datos.md
@@ -1,0 +1,17 @@
+---
+title: 'La facturación de Master Data no disminuyó después de eliminar una entidad de datos'
+createdAt: '2026-08-07T00:00:00.000Z'
+updatedAt: '2026-08-07T00:00:00.000Z'
+contentType: tutorial
+productTeam: Master Data
+slugEN: master-data-billing-did-not-decrease-after-deleting-a-data-entity
+locale: es
+subcategoryId: 2Q0IQjRcOqSgJTh6wRHVMB
+domainFilters:
+  - Master Data
+  - Admin
+symptomFilters:
+  - Interrupción del flujo
+---
+
+> ⚠️ Contenido en traducción.

--- a/docs/es/tutorials/master-data/conceptos-básicos-de-master-data/entidade-de-datos.md
+++ b/docs/es/tutorials/master-data/conceptos-básicos-de-master-data/entidade-de-datos.md
@@ -27,7 +27,7 @@ Estos conceptos permiten configurar los más diversos escenarios de control de d
 
 > ⚠️ Este artículo describe el funcionamiento de Master Data v1. Es importante evaluar la versión de Master Data que satisface las necesidades de tu operación o que ya está en uso. Más información: <ul> <li>[Características de las versiones de Master Data](/es/docs/tutorials/master-data#versiones-disponibles)</li> <li>[Master Data v2](https://developers.vtex.com/docs/guides/master-data-v2-basics)</li> </ul>
 
-> ⚠️ Eliminar una entidad de datos a través de la interfaz de Master Data v1 no elimina los documentos (registros) ya almacenados. El volumen facturado permanece sin cambios hasta que los registros se eliminen mediante la API. Para eliminar documentos y reducir la facturación, consulta la guía [Deleting documents in Master Data v1](https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1) en el portal de desarrolladores.
+> ⚠️ Eliminar una entidad de datos a través de la interfaz de Master Data v1 no elimina los documentos (registros) ya almacenados. El volumen facturado permanece sin cambios hasta que los registros se eliminen mediante la API. Para eliminar documentos y reducir la facturación, consulta la guía [Deleting documents in Master Data v1](https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1) en el portal de desarrolladores. Consulta la [guía paso a paso para resolver](/es/docs/tutorials/la-facturacion-de-master-data-no-disminuyo-despues-de-eliminar-una-entidad-de-datos) este problema.
 
 ## Tipos de datos
 

--- a/docs/es/tutorials/master-data/conceptos-básicos-de-master-data/master-data-es.md
+++ b/docs/es/tutorials/master-data/conceptos-básicos-de-master-data/master-data-es.md
@@ -295,6 +295,8 @@ Tanto la medición como la facturación siguen un ciclo mensual:
 - Al final de cada mes, se genera un snapshot del volumen de documentos almacenados en entidades no nativas.
 - Hasta el día 30 de cada mes, VTEX calcula los valores correspondientes al uso de Master Data y los créditos aplicables para la próxima factura.
 
+> ⚠️ Eliminar una entidad de datos a través de la interfaz de Master Data v1 no elimina los documentos (registros) ya almacenados. El volumen facturado permanece sin cambios hasta que los registros se eliminen mediante la API. Para eliminar documentos y reducir la facturación, consulta la guía [Deleting documents in Master Data v1](https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1) en el portal de desarrolladores.
+
 > ℹ️ Para hacer seguimiento del volumen de documentos en entidades personalizadas a lo largo del mes, consulta el dashboard **Uso de Master Data** en el Admin VTEX. Este dashboard se actualiza semanalmente y está destinado únicamente al seguimiento del uso. Las instrucciones de acceso están disponibles en Consultar el uso de Master Data en el Admin VTEX.
 
 > ℹ️ Para saber más sobre detalles de las facturas, consulta cómo [Descargar las facturas de VTEX](https://help.vtex.com/es/docs/tutorials/como-descargar-las-facturas-de-vtex).

--- a/docs/pt/troubleshooting/acesso-a-dados-e-segurança/a-cobranca-do-master-data-nao-diminuiu-depois-que-exclui-uma-entidade-de-dados.md
+++ b/docs/pt/troubleshooting/acesso-a-dados-e-segurança/a-cobranca-do-master-data-nao-diminuiu-depois-que-exclui-uma-entidade-de-dados.md
@@ -1,0 +1,36 @@
+---
+title: 'A cobrança do Master Data não diminuiu depois que excluí uma entidade de dados'
+createdAt: '2026-08-07T00:00:00.000Z'
+updatedAt: '2026-08-07T00:00:00.000Z'
+contentType: tutorial
+productTeam: Master Data
+slugEN: master-data-billing-did-not-decrease-after-deleting-a-data-entity
+locale: pt
+subcategoryId: 2Q0IQjRcOqSgJTh6wRHVMB
+domainFilters:
+  - Master Data
+  - Admin
+symptomFilters:
+  - Interrupção no fluxo
+---
+
+Depois de excluir uma [entidade de dados](/pt/docs/tutorials/entidade-de-dados) pela interface do Master Data v1, você espera que o volume cobrado mensalmente diminua, mas isso não acontece.
+
+Esse problema ocorre porque a exclusão de uma entidade de dados pela interface não remove os documentos (registros) já armazenados nela. Esses documentos continuam sendo contabilizados na cobrança mensal até que sejam excluídos pela API.
+
+## Solução
+
+Para resolver esse problema, siga os passos abaixo:
+
+1. [Exclua os documentos da entidade pela API](#exclua-os-documentos-da-entidade-pela-api): remova os registros armazenados para que eles deixem de ser contabilizados na cobrança.
+2. [Confirme a redução no dashboard de uso do Master Data](#confirme-a-reducao-no-dashboard-de-uso-do-master-data): verifique se a quantidade de documentos diminuiu após a exclusão.
+
+### Exclua os documentos da entidade pela API
+
+Siga as instruções do guia [Deleting documents in Master Data v1](https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1) para excluir os documentos armazenados na entidade de dados. Apenas essa exclusão via API reduz o volume contabilizado na cobrança mensal.
+
+### Confirme a redução no dashboard de uso do Master Data
+
+Depois de excluir os documentos, acesse o dashboard [Master Data usage](/pt/docs/tutorials/consultar-o-uso-do-master-data-no-admin-vtex) no Admin VTEX para confirmar que a quantidade de documentos da entidade diminuiu.
+
+Se a cobrança continuar sem alterações após a exclusão dos documentos, entre em contato com o [Suporte](/pt/docs/tutorials/como-funciona-o-suporte-da-vtex).

--- a/docs/pt/tutorials/master-data/conceitos-básicos-do-master-data/entidade-de-dados.md
+++ b/docs/pt/tutorials/master-data/conceitos-básicos-do-master-data/entidade-de-dados.md
@@ -27,7 +27,7 @@ Com esses conceitos, é possível configurar os mais diversos cenários de contr
 
 > ⚠️ Este artigo diz respeito ao funcionamento do Master Data v1. É importante avaliar qual versão do Master Data atende as necessidades ou está em uso na sua operação. Saiba mais: <ul> <li>[Características das versões do Master Data](/pt/docs/tutorials/master-data#versoes-disponiveis)</li> <li>[Master Data v2](https://developers.vtex.com/docs/guides/master-data-v2-basics)</li> </ul>
 
-> ⚠️ Excluir uma entidade de dados pela interface do Master Data v1 **não** remove os documentos (registros) já armazenados. O volume faturado permanece inalterado até que os registros sejam removidos pela API. Para excluir documentos e reduzir a cobrança, consulte o guia [Deleting documents in Master Data v1](https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1) no portal de desenvolvedores.
+> ⚠️ Excluir uma entidade de dados pela interface do Master Data v1 **não** remove os documentos (registros) já armazenados. O volume faturado permanece inalterado até que os registros sejam removidos pela API. Para excluir documentos e reduzir a cobrança, consulte o guia [Deleting documents in Master Data v1](https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1) no portal de desenvolvedores. Veja o [passo a passo para resolver](/pt/docs/tutorials/a-cobranca-do-master-data-nao-diminuiu-depois-que-exclui-uma-entidade-de-dados) esse problema.
 
 ## Tipos de dados
 

--- a/docs/pt/tutorials/master-data/conceitos-básicos-do-master-data/master-data-pt.md
+++ b/docs/pt/tutorials/master-data/conceitos-básicos-do-master-data/master-data-pt.md
@@ -294,6 +294,8 @@ A medição e a cobrança seguem um ciclo mensal:
 - Ao final de cada mês, é gerado um snapshot do volume de documentos armazenados em entidades não nativas.
 - Até o dia 30 de cada mês, a VTEX calcula os valores referentes ao uso do Master Data e os créditos aplicáveis para a próxima fatura.
 
+> ⚠️ Excluir uma entidade de dados pela interface do Master Data v1 **não** remove os documentos (registros) já armazenados. O volume faturado permanece inalterado até que os registros sejam removidos pela API. Para excluir documentos e reduzir a cobrança, consulte o guia [Deleting documents in Master Data v1](https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1) no portal de desenvolvedores.
+
 > ℹ️ Para monitorar o volume de documentos em entidades personalizadas ao longo do mês, consulte o dashboard **Master Data usage** no Admin VTEX. Este dashboard é atualizado semanalmente e destinado apenas ao acompanhamento do uso. Para saber como acessá-lo, veja [Consultar o uso do Master Data no Admin VTEX](/pt/docs/tutorials/consultar-o-uso-do-master-data-no-admin-vtex).
 
 > ℹ️ Para consultar o detalhamento de cobranças, veja como [fazer o download das faturas da VTEX](/pt/docs/tutorials/como-fazer-download-faturas-da-vtex).

--- a/docs/pt/tutorials/master-data/consultar-o-uso-do-master-data-no-admin-vtex.md
+++ b/docs/pt/tutorials/master-data/consultar-o-uso-do-master-data-no-admin-vtex.md
@@ -13,7 +13,7 @@ O dashboard **Master Data usage** no Admin VTEX ajuda você a acompanhar o volum
 
 Com esse dashboard, você pode consultar o total de documentos, verificar quando os dados foram atualizados pela última vez e analisar o volume por entidade antes de tomar decisões sobre armazenamento ou limpeza de dados.
 
-> ℹ️ O uso de entidades personalizadas segue regras de cobrança mensal. Para entender como a VTEX mede o volume de documentos para faturamento, consulte a seção [Cobrança](/pt/docs/tutorials/master-data#cobranca) do artigo Master Data.
+> ℹ️ O uso de entidades personalizadas segue regras de cobrança mensal. Para entender como a VTEX mede o volume de documentos para faturamento, consulte a seção [Cobrança](/pt/docs/tutorials/master-data#cobranca) do artigo Master Data. Se a cobrança não diminuiu como esperado após excluir uma entidade, veja [este passo a passo](/pt/docs/tutorials/a-cobranca-do-master-data-nao-diminuiu-depois-que-exclui-uma-entidade-de-dados).
 
 ## Acessar o dashboard
 

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -15826,6 +15826,21 @@
             },
             {
               "name": {
+                "en": "Master Data billing did not decrease after deleting a data entity",
+                "es": "La facturación de Master Data no disminuyó después de eliminar una entidad de datos",
+                "pt": "A cobrança do Master Data não diminuiu depois que excluí uma entidade de dados"
+              },
+              "slug": {
+                "en": "master-data-billing-did-not-decrease-after-deleting-a-data-entity",
+                "es": "la-facturacion-de-master-data-no-disminuyo-despues-de-eliminar-una-entidad-de-datos",
+                "pt": "a-cobranca-do-master-data-nao-diminuiu-depois-que-exclui-uma-entidade-de-dados"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
                 "en": "My store’s Site Editor is not working",
                 "es": "Problemas con Site Editor en mi tienda",
                 "pt": "O Site Editor da minha loja não está funcionando"
@@ -45906,6 +45921,21 @@
             },
             {
               "name": {
+                "en": "CheckoutOrderFormOwnership is lost/doesn't exist in some purchase flows",
+                "es": "La propiedad del formulario de pedido de pago se pierde o no existe en algunos flujos de compra.",
+                "pt": "A propriedade do formulário de pedido no checkout é perdida/não existe em alguns fluxos de compra."
+              },
+              "slug": {
+                "en": "checkoutorderformownership-is-lostdoesnt-exist-in-some-purchase-flows",
+                "es": "la-propiedad-del-formulario-de-pedido-de-pago-se-pierde-o-no-existe-en-algunos-flujos-de-compra",
+                "pt": "a-propriedade-do-formulario-de-pedido-no-checkout-e-perdidanao-existe-em-alguns-fluxos-de-compra"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
                 "en": "City and state are not sent to PayPalPlus when there is only pickup address available",
                 "es": "La ciudad y el estado no se envían a PayPalPlus cuando solo hay una dirección de recogida disponible",
                 "pt": "A cidade e o estado não são enviados ao PayPalPlus quando há apenas um endereço de retirada disponível"
@@ -58522,12 +58552,12 @@
               "name": {
                 "en": "My Account - Receiver Name field doesn't recognize input.",
                 "es": "Mi cuenta - El campo Nombre del receptor no reconoce la entrada.",
-                "pt": "Minha Conta - O campo Nome do Receptor não reconhece a entrada."
+                "pt": "O campo \"Nome do destinatário\" em \"Minha conta\" não reconhece a entrada de dados."
               },
               "slug": {
                 "en": "my-account-receiver-name-field-doesnt-recognize-input",
                 "es": "mi-cuenta-el-campo-nombre-del-receptor-no-reconoce-la-entrada",
-                "pt": "minha-conta-o-campo-nome-do-receptor-nao-reconhece-a-entrada"
+                "pt": "o-campo-nome-do-destinatario-em-minha-conta-nao-reconhece-a-entrada-de-dados"
               },
               "origin": "",
               "type": "markdown",
@@ -60278,6 +60308,21 @@
             },
             {
               "name": {
+                "en": "Cash (1x) transactions may be recorded under a payment rule that does not offer the 1x installment option",
+                "es": "Las transacciones en efectivo (1x) pueden registrarse bajo una regla de pago que no ofrece la opción de pago a plazos 1x.",
+                "pt": "Transações em dinheiro (1x) podem ser registradas sob uma regra de pagamento que não oferece a opção de parcelamento em 1x."
+              },
+              "slug": {
+                "en": "cash-1x-transactions-may-be-recorded-under-a-payment-rule-that-does-not-offer-the-1x-installment-option",
+                "es": "las-transacciones-en-efectivo-1x-pueden-registrarse-bajo-una-regla-de-pago-que-no-ofrece-la-opcion-de-pago-a-plazos-1x",
+                "pt": "transacoes-em-dinheiro-1x-podem-ser-registradas-sob-uma-regra-de-pagamento-que-nao-oferece-a-opcao-de-parcelamento-em-1x"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
                 "en": "Catalog access profile gives access to the Gift Card module",
                 "es": "El perfil de acceso al catálogo da acceso al módulo de la tarjeta regalo",
                 "pt": "Perfil de acesso ao catálogo dá acesso ao módulo Gift Card"
@@ -61051,21 +61096,6 @@
                 "en": "for-debt-with-cielov3-we-are-not-respecting-the-status-of-the-response",
                 "es": "para-deudas-con-cielov3-no-estamos-respetando-el-estado-de-la-respuesta",
                 "pt": "para-dividas-com-a-cielov3-nao-estamos-respeitando-o-status-da-resposta"
-              },
-              "origin": "",
-              "type": "markdown",
-              "children": []
-            },
-            {
-              "name": {
-                "en": "For in cash payment (1 installment) is being processed by payment conditions that have not 1 installment option",
-                "es": "Para el pago en efectivo (1 plazo) está siendo procesado por las condiciones de pago que no tienen la opción de 1 plazo",
-                "pt": "Pois em pagamento à vista (1 parcela) está sendo processado por condições de pagamento que não têm opção de 1 parcela"
-              },
-              "slug": {
-                "en": "for-in-cash-payment-1-installment-is-being-processed-by-payment-conditions-that-have-not-1-installment-option",
-                "es": "para-el-pago-en-efectivo-1-plazo-esta-siendo-procesado-por-las-condiciones-de-pago-que-no-tienen-la-opcion-de-1-plazo",
-                "pt": "pois-em-pagamento-a-vista-1-parcela-esta-sendo-processado-por-condicoes-de-pagamento-que-nao-tem-opcao-de-1-parcela"
               },
               "origin": "",
               "type": "markdown",
@@ -62191,6 +62221,21 @@
                 "en": "outdated-mastercard-debit-regex-is-causing-us-to-misidentify-some-bins",
                 "es": "una-expresion-regular-obsoleta-para-tarjetas-de-debito-mastercard-nos-esta-llevando-a-identificar-erroneamente-algunos-bin",
                 "pt": "uma-expressao-regular-desatualizada-para-cartoes-de-debito-mastercard-esta-fazendo-com-que-identifiquemos-erroneamente-alguns-bins"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
+                "es": "Para el pago en efectivo (1 plazo) está siendo procesado por las condiciones de pago que no tienen la opción de 1 plazo",
+                "pt": "Pois em pagamento à vista (1 parcela) está sendo processado por condições de pagamento que não têm opção de 1 parcela",
+                "en": "Para el pago en efectivo (1 plazo) está siendo procesado por las condiciones de pago que no tienen la opción de 1 plazo"
+              },
+              "slug": {
+                "es": "para-el-pago-en-efectivo-1-plazo-esta-siendo-procesado-por-las-condiciones-de-pago-que-no-tienen-la-opcion-de-1-plazo",
+                "pt": "pois-em-pagamento-a-vista-1-parcela-esta-sendo-processado-por-condicoes-de-pagamento-que-nao-tem-opcao-de-1-parcela",
+                "en": ""
               },
               "origin": "",
               "type": "markdown",
@@ -69018,13 +69063,13 @@
             {
               "name": {
                 "en": "Some custom pages are not returning in Custom Routes API causing missing entries in the sitemap",
-                "es": "Algunas páginas personalizadas no aparecen en la API de rutas personalizadas, por lo que faltan entradas en el mapa del sitio.",
-                "pt": "Algumas páginas personalizadas não estão retornando na API de rotas personalizadas, causando a falta de entradas no mapa do site."
+                "es": "Algunas páginas personalizadas no se devuelven en la API de Rutas Personalizadas, lo que provoca que falten entradas en el mapa del sitio.",
+                "pt": "Algumas páginas personalizadas não estão sendo retornadas na API de Rotas Personalizadas, o que causa a ausência de entradas no mapa do site."
               },
               "slug": {
                 "en": "some-custom-pages-are-not-returning-in-custom-routes-api-causing-missing-entries-in-the-sitemap",
-                "es": "algunas-paginas-personalizadas-no-aparecen-en-la-api-de-rutas-personalizadas-por-lo-que-faltan-entradas-en-el-mapa-del-sitio",
-                "pt": "algumas-paginas-personalizadas-nao-estao-retornando-na-api-de-rotas-personalizadas-causando-a-falta-de-entradas-no-mapa-do-site"
+                "es": "algunas-paginas-personalizadas-no-se-devuelven-en-la-api-de-rutas-personalizadas-lo-que-provoca-que-falten-entradas-en-el-mapa-del-sitio",
+                "pt": "algumas-paginas-personalizadas-nao-estao-sendo-retornadas-na-api-de-rotas-personalizadas-o-que-causa-a-ausencia-de-entradas-no-mapa-do-site"
               },
               "origin": "",
               "type": "markdown",


### PR DESCRIPTION

Closes two documentation gaps identified in a billing-dispute audit: merchants deleting a Master Data entity via the UI believe this deletes the stored documents, but the monthly billing snapshot keeps counting them until the documents are deleted via the API.

## Changes

- Added a warning callout to the Billing/Cobranca/Facturacion section of the main Master Data tutorial (EN/PT/ES), stating that entity deletion does not delete documents and linking to the [Deleting documents in Master Data v1](https://developers.vtex.com/docs/guides/deleting-documents-in-master-data-v1) guide.
- Added a new troubleshooting article, "Master Data billing did not decrease after deleting a data entity" (PT canonical, EN/ES placeholders pending localization), explaining the cause and the fix via the same guide.
- Added reciprocal cross-links from the `data-entity`/`entidade-de-dados`/`entidade-de-datos` tutorials and from the Master Data usage dashboard tutorial to the new troubleshooting article.

## Related Task

[EDU-19085](https://vtex-dev.atlassian.net/browse/EDU-19085)
