### PR TITLE
EDU-19280, EDU-19281: VTEX Ads campaign and creative approval docs

### DIFF
--- a/docs/en/announcements/2026/august/2026-08-12-creative-approval-available-for-network-campaigns-in-vtex-ads.md
+++ b/docs/en/announcements/2026/august/2026-08-12-creative-approval-available-for-network-campaigns-in-vtex-ads.md
@@ -1,0 +1,15 @@
+---
+title: 'Creative approval available for Network campaigns in VTEX Ads'
+createdAt: 2026-08-12T00:00:00.000Z
+updatedAt: 2026-08-12T00:00:00.000Z
+contentType: updates
+productTeam: Ads
+slugEN: 2026-08-12-creative-approval-available-for-network-campaigns-in-vtex-ads
+locale: en
+announcementSynopsisEN: 'TODO'
+tags:
+  - New feature
+  - VTEX Ads
+---
+
+> ⚠️ Content in translation.

--- a/docs/en/tutorials/retail-media/vtex-ads-campaign-and-creative-approval.md
+++ b/docs/en/tutorials/retail-media/vtex-ads-campaign-and-creative-approval.md
@@ -1,0 +1,11 @@
+---
+title: 'VTEX Ads campaign and creative approval'
+createdAt: 2026-08-13T00:00:00.000Z
+updatedAt: 2026-08-13T00:00:00.000Z
+contentType: tutorial
+productTeam: Others
+slugEN: vtex-ads-campaign-and-creative-approval
+locale: en
+---
+
+> ⚠️ Content in translation.

--- a/docs/en/tutorials/retail-media/vtex-ads-review-and-approve-campaigns-and-creatives.md
+++ b/docs/en/tutorials/retail-media/vtex-ads-review-and-approve-campaigns-and-creatives.md
@@ -1,0 +1,11 @@
+---
+title: 'How to review and approve campaigns and creatives in VTEX Ads'
+createdAt: 2026-08-13T00:00:00.000Z
+updatedAt: 2026-08-13T00:00:00.000Z
+contentType: tutorial
+productTeam: Others
+slugEN: vtex-ads-review-and-approve-campaigns-and-creatives
+locale: en
+---
+
+> ⚠️ Content in translation.

--- a/docs/es/announcements/2026/agosto/2026-08-12-aprobacion-de-creativos-disponible-para-campanas-network-en-vtex-ads.md
+++ b/docs/es/announcements/2026/agosto/2026-08-12-aprobacion-de-creativos-disponible-para-campanas-network-en-vtex-ads.md
@@ -1,0 +1,15 @@
+---
+title: 'Aprobación de creativos disponible para campañas Network en VTEX Ads'
+createdAt: 2026-08-12T00:00:00.000Z
+updatedAt: 2026-08-12T00:00:00.000Z
+contentType: updates
+productTeam: Ads
+slugEN: 2026-08-12-creative-approval-available-for-network-campaigns-in-vtex-ads
+locale: es
+announcementSynopsisES: 'TODO'
+tags:
+  - Nueva funcionalidad
+  - VTEX Ads
+---
+
+> ⚠️ Contenido en traducción.

--- a/docs/es/tutorials/retail-media/aprobacion-de-campanas-y-creativos-en-vtex-ads.md
+++ b/docs/es/tutorials/retail-media/aprobacion-de-campanas-y-creativos-en-vtex-ads.md
@@ -1,0 +1,11 @@
+---
+title: 'Aprobación de campañas y creativos en VTEX Ads'
+createdAt: 2026-08-13T00:00:00.000Z
+updatedAt: 2026-08-13T00:00:00.000Z
+contentType: tutorial
+productTeam: Others
+slugEN: vtex-ads-campaign-and-creative-approval
+locale: es
+---
+
+> ⚠️ Contenido en traducción.

--- a/docs/es/tutorials/retail-media/como-revisar-y-aprobar-campanas-y-creativos-en-vtex-ads.md
+++ b/docs/es/tutorials/retail-media/como-revisar-y-aprobar-campanas-y-creativos-en-vtex-ads.md
@@ -1,0 +1,11 @@
+---
+title: 'Cómo revisar y aprobar campañas y creativos en VTEX Ads'
+createdAt: 2026-08-13T00:00:00.000Z
+updatedAt: 2026-08-13T00:00:00.000Z
+contentType: tutorial
+productTeam: Others
+slugEN: vtex-ads-review-and-approve-campaigns-and-creatives
+locale: es
+---
+
+> ⚠️ Contenido en traducción.

--- a/docs/pt/announcements/2026/agosto/2026-08-12-aprovacao-de-criativos-disponivel-para-campanhas-network-no-vtex-ads.md
+++ b/docs/pt/announcements/2026/agosto/2026-08-12-aprovacao-de-criativos-disponivel-para-campanhas-network-no-vtex-ads.md
@@ -1,0 +1,35 @@
+---
+title: 'Aprovação de criativos disponível para campanhas Network no VTEX Ads'
+createdAt: 2026-08-12T00:00:00.000Z
+updatedAt: 2026-08-12T00:00:00.000Z
+contentType: updates
+productTeam: Ads
+slugEN: 2026-08-12-creative-approval-available-for-network-campaigns-in-vtex-ads
+locale: pt
+announcementSynopsisPT: 'Publicadores de campanhas Network no VTEX Ads já podem aprovar criativos diretamente no próprio dashboard, sem depender da aprovação de toda a rede.'
+tags:
+  - Nova funcionalidade
+  - VTEX Ads
+---
+
+Desde 12 de agosto de 2026, publicadores de campanhas Network no VTEX Ads com a funcionalidade habilitada em sua rede já podem revisar, aprovar ou rejeitar diretamente os criativos enviados pelo anunciante, sem depender de comunicação fora da plataforma.
+
+## O que mudou?
+
+Publicadores de campanhas Network agora usam a mesma [tela de aprovação já disponível para campanhas 1:1](/pt/docs/tutorials/aprovacao-de-campanhas-e-criativos-no-vtex-ads) para revisar banners e criativos de marcas patrocinadas (Sponsored Brands) elegíveis para o próprio inventário. A aprovação de cada publicador é independente: assim que aprova, a campanha passa a ser veiculada no inventário dele, sem depender da aprovação dos demais publicadores da rede.
+
+> ℹ️ A ativação da aprovação de criativos é feita rede a rede pela VTEX Ads. Nem toda rede tem essa funcionalidade habilitada hoje.
+
+## Por que fizemos essa mudança?
+
+A mudança elimina a coleta manual de aprovações fora da plataforma, que antes exigia contato do time de CS e Performance por WhatsApp ou e-mail para cerca de 250 aprovações por mês. Também acaba com a espera pela aprovação de toda a rede, considerando uma mediana de cinco publicadores por campanha entre as campanhas com mais de um publicador.
+
+## O que precisa ser feito?
+
+Publicadores com a funcionalidade habilitada em sua rede devem passar a revisar os criativos pendentes no próprio dashboard. Nenhuma outra ação é necessária.
+
+Anunciantes que enviam campanhas Network devem considerar que a ativação em cada publicador passa a depender da aprovação dele, o que pode atrasar o início da veiculação nesse publicador.
+
+## Saiba mais
+
+- [Aprovação de campanhas e criativos no VTEX Ads](/pt/docs/tutorials/aprovacao-de-campanhas-e-criativos-no-vtex-ads)

--- a/docs/pt/tutorials/retail-media/aprovacao-de-campanhas-e-criativos-no-vtex-ads.md
+++ b/docs/pt/tutorials/retail-media/aprovacao-de-campanhas-e-criativos-no-vtex-ads.md
@@ -1,0 +1,73 @@
+---
+title: 'Aprovação de campanhas e criativos no VTEX Ads'
+createdAt: 2026-08-13T00:00:00.000Z
+updatedAt: 2026-08-13T00:00:00.000Z
+contentType: tutorial
+productTeam: Others
+slugEN: vtex-ads-campaign-and-creative-approval
+locale: pt
+---
+
+Antes de ser veiculada no site de um publicador, toda campanha do VTEX Ads passa por uma etapa de aprovação. O anunciante envia a campanha ou um novo criativo para revisão, e o publicador aprova ou rejeita a partir do seu próprio dashboard antes que o anúncio seja exibido em seu inventário.
+
+Este artigo descreve como funciona esse fluxo nos dois tipos de campanha:
+
+- **Campanhas 1:1:** um anunciante envia campanhas para a revisão de um único publicador.
+- **Campanhas Network:** um anunciante alcança vários publicadores ao mesmo tempo, e cada um deles revisa, de forma independente, os criativos elegíveis para o próprio inventário.
+
+> ℹ️ Para a definição dos papéis de anunciante e publicador citados neste artigo, consulte [Papéis e atribuições em Retail Media](/pt/docs/tracks/papeis-e-atribuicoes-em-retail-media).
+
+## Formatos cobertos
+
+A aprovação se aplica às campanhas de banner e de marcas patrocinadas (Sponsored Brands).
+
+## Como funciona o fluxo
+
+O fluxo tem duas etapas, cada uma conduzida por um papel diferente:
+
+1. O anunciante cria a campanha ou adiciona um novo criativo e confirma o envio para aprovação do publicador.
+2. O publicador acessa o dashboard de Retail Media, revisa o conteúdo enviado e aprova ou rejeita. Veja o passo a passo em [Como revisar e aprovar campanhas e criativos no VTEX Ads](/pt/docs/tutorials/como-revisar-e-aprovar-campanhas-e-criativos-no-vtex-ads).
+
+Nenhum criativo é veiculado no inventário do publicador antes de ser aprovado.
+
+## Níveis de aprovação
+
+A aprovação pode acontecer em dois níveis:
+
+- **Campanha inteira:** aprova ou rejeita de uma vez todos os criativos da campanha.
+- **Criativo individual:** aprova ou rejeita um anúncio específico dentro da campanha, sem afetar os demais.
+
+## Especificidades de campanhas Network
+
+Para o publicador, a aprovação de uma campanha Network acontece na mesma tela do fluxo 1:1, e a mecânica de revisão, aprovação e rejeição não muda. Por isso, não é preciso saber se a campanha é Network ou 1:1 para revisá-la.
+
+O que muda são o alcance da aprovação, o conjunto de criativos exibido a cada publicador e o preenchimento da URL de destino, como descrito a seguir.
+
+> ℹ️ Para saber se a aprovação de criativos em campanhas Network já está ativa na sua rede, ou para solicitar ativação, entre em contato com o [Suporte VTEX](https://help.vtex.com/support).
+
+### URL de destino
+
+No momento da aprovação, o próprio publicador informa a URL de destino dos criativos de banner, ou seja, a página para onde o cliente é levado ao clicar no anúncio veiculado na loja do publicador. O preenchimento é obrigatório e o campo aceita apenas endereços iniciados por `http://` ou `https://`. O botão `Aprovar` permanece indisponível até que todas as URLs exigidas estejam preenchidas corretamente.
+
+A URL informada por um publicador vale somente para os anúncios veiculados no inventário dele e não fica visível para os demais publicadores da rede. Se o anunciante enviar a mesma campanha novamente para aprovação, o publicador pode informar uma URL diferente ao aprová-la.
+
+### Aprovação independente por publicador
+
+A aprovação ou a rejeição feita por um publicador da rede não depende dos demais publicadores nem os bloqueia. Assim que um publicador aprova, a campanha passa a ser veiculada no inventário dele, mesmo que os demais ainda não tenham revisado o conteúdo.
+
+Por isso, uma mesma campanha Network pode estar ativa para parte da rede e pendente de aprovação para o restante.
+
+### Criativos filtrados pelo inventário
+
+Cada publicador vê apenas os tamanhos de banner e as variações de marcas patrocinadas (Sponsored Brands) cadastrados no próprio inventário. Um publicador nunca é solicitado a aprovar um formato que não pode veicular, mesmo que a campanha inclua outros formatos para outros publicadores da rede.
+
+Como o filtro é aplicado individualmente, a mesma campanha pode apresentar conjuntos diferentes de criativos a publicadores diferentes.
+
+### Dados financeiros ocultos para o publicador
+
+O orçamento total da campanha, o custo por clique (CPC) e o custo por mil impressões (CPM) não aparecem para o publicador em nenhuma tela de aprovação. O número de publicadores que participam da mesma campanha Network também não é exibido.
+
+## Saiba mais
+
+- [Como revisar e aprovar campanhas e criativos no VTEX Ads](/pt/docs/tutorials/como-revisar-e-aprovar-campanhas-e-criativos-no-vtex-ads)
+- [Papéis e atribuições em Retail Media](/pt/docs/tracks/papeis-e-atribuicoes-em-retail-media)

--- a/docs/pt/tutorials/retail-media/como-revisar-e-aprovar-campanhas-e-criativos-no-vtex-ads.md
+++ b/docs/pt/tutorials/retail-media/como-revisar-e-aprovar-campanhas-e-criativos-no-vtex-ads.md
@@ -1,0 +1,54 @@
+---
+title: 'Como revisar e aprovar campanhas e criativos no VTEX Ads'
+createdAt: 2026-08-13T00:00:00.000Z
+updatedAt: 2026-08-13T00:00:00.000Z
+contentType: tutorial
+productTeam: Others
+slugEN: vtex-ads-review-and-approve-campaigns-and-creatives
+locale: pt
+---
+
+Este artigo explica como o publicador revisa e aprova ou rejeita campanhas e criativos enviados por um anunciante no VTEX Ads. Para uma visão geral do fluxo de aprovação, consulte [Aprovação de campanhas e criativos no VTEX Ads](/pt/docs/tutorials/aprovacao-de-campanhas-e-criativos-no-vtex-ads).
+
+## Antes de começar
+
+Para revisar campanhas, você precisa ter acesso ao dashboard de Retail Media da sua loja como publicador.
+
+## Passo a passo
+
+1. Acesse o painel admin do VTEX Ads.
+2. Abra a aba **Revisão de campanhas**.
+3. Localize uma campanha com criativos pendentes de revisão.
+4. Clique na campanha para abrir a tela de revisão.
+
+## Revisão em dois níveis
+
+Na tela de revisão, você pode realizar a aprovação em dois níveis:
+
+- **Campanha inteira:** no topo da tela, os botões `Aprovar` e `Rejeitar` afetam de uma vez todos os criativos da campanha.
+- **Criativo individual:** na listagem de anúncios da campanha, cada criativo também pode ser aprovado ou rejeitado separadamente, sem alterar o status dos demais.
+
+## Aprovar um criativo
+
+1. Clique em `Aprovar`, na campanha inteira ou em um criativo individual.
+2. Revise o resumo exibido na janela de confirmação, com o período da campanha, os criativos, os produtos vinculados e o investimento diário.
+3. Confirme a aprovação.
+
+Depois de aprovado, o criativo fica disponível para veiculação imediatamente.
+
+## Rejeitar um criativo
+
+1. Clique em `Rejeitar`, na campanha inteira ou em um criativo individual.
+2. No campo **Motivo da rejeição**, descreva o motivo da rejeição. O campo é de texto livre e seu preenchimento é obrigatório.
+3. Confirme a rejeição.
+
+O anunciante recebe o motivo informado.
+
+## Notificações
+
+O anunciante é notificado por email sobre a aprovação ou a rejeição de cada criativo.
+
+## Saiba mais
+
+- [Aprovação de campanhas e criativos no VTEX Ads](/pt/docs/tutorials/aprovacao-de-campanhas-e-criativos-no-vtex-ads)
+- [Papéis e atribuições em Retail Media](/pt/docs/tracks/papeis-e-atribuicoes-em-retail-media)

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -511,6 +511,21 @@
               "children": [
                 {
                   "name": {
+                    "en": "Creative approval available for Network campaigns in VTEX Ads",
+                    "es": "Aprobación de creativos disponible para campañas Network en VTEX Ads",
+                    "pt": "Aprovação de criativos disponível para campanhas Network no VTEX Ads"
+                  },
+                  "slug": {
+                    "en": "2026-08-12-creative-approval-available-for-network-campaigns-in-vtex-ads",
+                    "es": "2026-08-12-aprobacion-de-creativos-disponible-para-campanas-network-en-vtex-ads",
+                    "pt": "2026-08-12-aprovacao-de-criativos-disponivel-para-campanhas-network-no-vtex-ads"
+                  },
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                },
+                {
+                  "name": {
                     "en": "Orders: New orders listing available in open beta",
                     "es": "Pedidos: nueva lista de pedidos disponible en beta abierta",
                     "pt": "Pedidos: nova lista de pedidos disponível em beta aberto"
@@ -38942,6 +38957,36 @@
           "origin": "",
           "type": "category",
           "children": [
+            {
+              "name": {
+                "en": "How to review and approve campaigns and creatives in VTEX Ads",
+                "es": "Cómo revisar y aprobar campañas y creativos en VTEX Ads",
+                "pt": "Como revisar e aprovar campanhas e criativos no VTEX Ads"
+              },
+              "slug": {
+                "en": "vtex-ads-review-and-approve-campaigns-and-creatives",
+                "es": "como-revisar-y-aprobar-campanas-y-creativos-en-vtex-ads",
+                "pt": "como-revisar-e-aprovar-campanhas-e-criativos-no-vtex-ads"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": {
+                "en": "VTEX Ads campaign and creative approval",
+                "es": "Aprobación de campañas y creativos en VTEX Ads",
+                "pt": "Aprovação de campanhas e criativos no VTEX Ads"
+              },
+              "slug": {
+                "en": "vtex-ads-campaign-and-creative-approval",
+                "es": "aprobacion-de-campanas-y-creativos-en-vtex-ads",
+                "pt": "aprovacao-de-campanhas-e-criativos-no-vtex-ads"
+              },
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
             {
               "name": {
                 "en": "VTEX Ads metrics and attribution",


### PR DESCRIPTION
## Summary

Adds Help Center documentation for VTEX Ads campaign and creative approval (1:1 and Network campaigns), including a GA announcement for the Network creative approval feature.

## Changes

- **EDU-19280:** Overview and how-to tutorials in PT (canonical), EN, and ES covering campaign/creative approval for 1:1 and Network campaigns
- **EDU-19281:** GA announcement in PT (canonical), EN, and ES for independent per-publisher creative approval on Network campaigns

## Related Tasks

- [EDU-19280](https://vtex-dev.atlassian.net/browse/EDU-19280)
- [EDU-19281](https://vtex-dev.atlassian.net/browse/EDU-19281)
